### PR TITLE
Implement basic 'jmm models' command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,14 @@ var (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = newRootCmd()
 
+func init() {
+	rootCmd.AddCommand(build.NewCmdBuild())
+	rootCmd.AddCommand(login.NewCmdLogin())
+	rootCmd.AddCommand(pull.NewCmdPull())
+	rootCmd.AddCommand(push.NewCmdPush())
+	rootCmd.AddCommand(models.ModelsCommand())
+}
+
 func newRootCmd() *cobra.Command {
 	flags := &RootFlags{}
 	cmd := &cobra.Command{
@@ -66,6 +74,7 @@ func (f *RootFlags) ToOptions() (*RootOptions, error) {
 		ConfigHome: f.ConfigHome,
 	}, nil
 }
+
 func (o *RootOptions) Complete() error {
 	if o.ConfigHome == "" {
 		currentUser, err := user.Current()
@@ -86,12 +95,4 @@ func Execute() {
 	if err != nil {
 		os.Exit(1)
 	}
-}
-
-func init() {
-	rootCmd.AddCommand(build.NewCmdBuild())
-	rootCmd.AddCommand(login.NewCmdLogin())
-	rootCmd.AddCommand(pull.NewCmdPull())
-	rootCmd.AddCommand(push.NewCmdPush())
-	rootCmd.AddCommand(models.NewCmdModels())
 }

--- a/pkg/cmd/models/cmd.go
+++ b/pkg/cmd/models/cmd.go
@@ -1,0 +1,59 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	shortDesc = `List models`
+	longDesc  = `List models TODO`
+)
+
+var (
+	opts *ModelsOptions
+)
+
+type ModelsOptions struct {
+	configHome string
+}
+
+func (opts *ModelsOptions) complete() {
+	opts.configHome = viper.GetString("config")
+}
+
+func (opts *ModelsOptions) validate() error {
+	return nil
+}
+
+// ModelsCommand represents the models command
+func ModelsCommand() *cobra.Command {
+	opts = &ModelsOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "models",
+		Short: shortDesc,
+		Long:  longDesc,
+		Run:   RunCommand(opts),
+	}
+
+	return cmd
+}
+
+func RunCommand(options *ModelsOptions) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, args []string) {
+		options.complete()
+		err := options.validate()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		err = listModels(options)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+}

--- a/pkg/cmd/models/models.go
+++ b/pkg/cmd/models/models.go
@@ -4,67 +4,124 @@ Copyright © 2024 Jozu.com
 package models
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"jmm/pkg/artifact"
+	"os"
+	"text/tabwriter"
 
-	"github.com/spf13/cobra"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-type ModelsFlags struct {
-}
-type ModelsOptions struct {
-}
+const (
+	ModelsTableHeader = "DIGEST\tMAINTAINER\tMODEL FORMAT\tSIZE"
+	ModelsTableFmt    = "%s\t%s\t%s\t%s\t"
+)
 
-// modelsCmd represents the models command
-func NewCmdModels() *cobra.Command {
-	modelsFlags := NewModelsFlags()
-
-	cmd := &cobra.Command{
-		Use:   "models",
-		Short: "A brief description of your command",
-		Long: `A longer description that spans multiple lines and likely contains examples
-	and usage of using your command. For example:
-	
-	Cobra is a CLI library for Go that empowers applications.
-	This application is a tool to generate the needed files
-	to quickly create a Cobra application.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			options, err := modelsFlags.ToOptions()
-			if err != nil {
-				fmt.Println(err)
-				return
-			}
-			err = options.Validate()
-			if err != nil {
-				fmt.Println(err)
-				return
-			}
-			options.RunModels()
-			if err != nil {
-				fmt.Println(err)
-				return
-			}
-		},
+func listModels(opts *ModelsOptions) error {
+	store := artifact.NewArtifactStore(opts.configHome)
+	index, err := store.ParseIndexJson()
+	if err != nil {
+		return err
 	}
-	modelsFlags.AddFlags(cmd)
-	return cmd
-}
 
-func NewModelsFlags() *ModelsFlags {
-	return &ModelsFlags{}
-}
+	manifests, err := manifestsFromIndex(index, store)
+	if err != nil {
+		return err
+	}
 
-func (f *ModelsFlags) AddFlags(cmd *cobra.Command) {
+	if err := printManifestsSummary(manifests, store); err != nil {
+		return err
+	}
 
-}
-
-func (f *ModelsFlags) ToOptions() (*ModelsOptions, error) {
-	return &ModelsOptions{}, nil
-}
-
-func (o *ModelsOptions) Validate() error {
 	return nil
 }
 
-func (o *ModelsOptions) RunModels() error {
+func manifestsFromIndex(index *ocispec.Index, store *artifact.Store) (map[digest.Digest]ocispec.Manifest, error) {
+	manifests := map[digest.Digest]ocispec.Manifest{}
+	for _, manifestDesc := range index.Manifests {
+		manifestReader, err := store.Storage.Fetch(context.Background(), manifestDesc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get manifest %s: %w", manifestDesc.Digest, err)
+		}
+		manifestBytes, err := io.ReadAll(manifestReader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read manifest %s: %w", manifestDesc.Digest, err)
+		}
+		manifest := ocispec.Manifest{}
+		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+			return nil, fmt.Errorf("failed to parse manifest %s: %w", manifestDesc.Digest, err)
+		}
+		manifests[manifestDesc.Digest] = manifest
+	}
+	return manifests, nil
+}
+
+func readManifestConfig(manifest *ocispec.Manifest, store *artifact.Store) (*artifact.JozuFile, error) {
+	configReader, err := store.Storage.Fetch(context.Background(), manifest.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config: %w", err)
+	}
+	configBytes, err := io.ReadAll(configReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+	config := &artifact.JozuFile{}
+	if err := json.Unmarshal(configBytes, config); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+	return config, nil
+}
+
+func printManifestsSummary(manifests map[digest.Digest]ocispec.Manifest, store *artifact.Store) error {
+	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 3, ' ', 0)
+	fmt.Fprintln(tw, ModelsTableHeader)
+	for digest, manifest := range manifests {
+		// TODO: filter this list for manifests we're interested in (build needs to set a manifest mediaType/artifactType)
+		line, err := getManifestInfoLine(digest, &manifest, store)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(tw, line)
+	}
+	tw.Flush()
 	return nil
+}
+
+func getManifestInfoLine(digest digest.Digest, manifest *ocispec.Manifest, store *artifact.Store) (string, error) {
+	config, err := readManifestConfig(manifest, store)
+	if err != nil {
+		return "", err
+	}
+	var size int64
+	for _, layer := range manifest.Layers {
+		size += layer.Size
+	}
+	sizeStr := formatBytes(size)
+
+	info := fmt.Sprintf(ModelsTableFmt, digest, config.Maintainer, config.ModelFormat, sizeStr)
+	return info, nil
+}
+
+func formatBytes(i int64) string {
+	if i == 0 {
+		return "0 B"
+	}
+
+	suffixes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB"}
+	unit := float64(1024)
+
+	size := float64(i)
+	for _, suffix := range suffixes {
+		if size < unit {
+			return fmt.Sprintf("%.1f %s", size, suffix)
+		}
+		size = size / unit
+	}
+
+	// Fall back to printing 1000's of PiB
+	return fmt.Sprintf("%.1f PiB", size)
 }


### PR DESCRIPTION
Add basic implementation of `jmm models` command that prints artifacts in the local store. Prints digest, maintainer, format, and size for now.

Sample output:
```
❯ jmm models
DIGEST                                                                    MAINTAINER   MODEL FORMAT   SIZE
sha256:65784f6eae42940f917ed44b2f3f236f8a09b4a83064966eb081ef3aa2d47215   gorkem       onnx           28.9 MiB
```

Two concerns here, though:
1. I think we might me misusing `oci.Store` -- it's not entirely clear how `index.json` _should_ work and if it supports multiple images at all. From my understanding, `index.json` is supposed to be the index for a _single_ image (?).
2. Tests are still to come; since this code interacts with disk fairly heavily, I'll need to refactor the `artifact.Store` code to make it so we can sub out implementations in testing.