### PR TITLE
Allow attaching tags to models; fix errors when pushing existing content to storage

### DIFF
--- a/pkg/artifact/model.go
+++ b/pkg/artifact/model.go
@@ -2,7 +2,6 @@ package artifact
 
 type Model struct {
 	Repository string
-	Tag        string
-	Layers     []*ModelLayer
+	Layers     []ModelLayer
 	Config     *JozuFile
 }

--- a/pkg/lib/storage/common.go
+++ b/pkg/lib/storage/common.go
@@ -1,0 +1,17 @@
+package storage
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	validTagRegex = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$`)
+)
+
+func validateTag(tag string) error {
+	if !validTagRegex.MatchString(tag) {
+		return fmt.Errorf("invalid tag")
+	}
+	return nil
+}

--- a/pkg/lib/storage/store.go
+++ b/pkg/lib/storage/store.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Store interface {
-	SaveModel(*artifact.Model) (*ocispec.Manifest, error)
+	SaveModel(model *artifact.Model, tag string) (*ocispec.Descriptor, error)
+	TagModel(manifestDesc ocispec.Descriptor, tag string) error
 	ParseIndexJson() (*ocispec.Index, error)
 	Fetch(context.Context, ocispec.Descriptor) ([]byte, error)
 }

--- a/pkg/lib/testing/testing.go
+++ b/pkg/lib/testing/testing.go
@@ -69,7 +69,11 @@ func (s *TestStore) ParseIndexJson() (*ocispec.Index, error) {
 	return nil, TestingNotFoundError
 }
 
+func (*TestStore) TagModel(ocispec.Descriptor, string) error {
+	return fmt.Errorf("tag model is not implemented for testing")
+}
+
 // SaveModel is not yet implemented!
-func (*TestStore) SaveModel(*artifact.Model) (*ocispec.Manifest, error) {
+func (*TestStore) SaveModel(*artifact.Model, string) (*ocispec.Descriptor, error) {
 	return nil, fmt.Errorf("save model is not implemented for testing")
 }


### PR DESCRIPTION
Mainly, the goal of this PR is allow adding tags to builds:
```
jmm build -t <myrepo>:<mytag> .
```
This is required for `jmm push` to make sense

In order to make this work, however, it is necessary to make some changes to how artifacts are stored:

* Folder used for storage is $JOZU_HOME/storage (default: `.jozu/storage`)
  * There are hooks for separating storage and configuration in the future, if e.g. we want to store artifacts in `~/.local/...`
* `index.json` now refers to the elements of one repository (c.f. image repositories; library/registry and library/registry2 are different repositories). This means the storage dir has multiple `index.jsons`. As far as I can tell, this is what is expected by the OCI image spec.
  * We'll probably want to improve this in the future to avoid duplication; e.g. via storing all blobs in one place and more intelligently wiring everything together. For now, this was the easiest way
  * Multiple tags for the same repo still live in the same index.json

If a tag is specified without a registry (e.g. my-repo instead of localhost:5000/my-repo), the default of `localhost` is used. For now, this will break if you use a tag like `my/repo`; `my` will be considered the registry.

I also fixed the bug where running build twice would fail becuase artifacts exist.