### PR TITLE
Add initial implementation for pushing and pulling models from remote OCI registries

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,8 +38,8 @@ var rootCmd = newRootCmd()
 func init() {
 	rootCmd.AddCommand(build.NewCmdBuild())
 	rootCmd.AddCommand(login.NewCmdLogin())
-	rootCmd.AddCommand(pull.NewCmdPull())
-	rootCmd.AddCommand(push.NewCmdPush())
+	rootCmd.AddCommand(pull.PullCommand())
+	rootCmd.AddCommand(push.PushCommand())
 	rootCmd.AddCommand(models.ModelsCommand())
 }
 

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -1,0 +1,100 @@
+package pull
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+const (
+	shortDesc = `Pull model from registry`
+	longDesc  = `Pull model from registry TODO`
+)
+
+var (
+	flags *PullFlags
+	opts  *PullOptions
+)
+
+type PullFlags struct {
+	UseHTTP bool
+}
+
+type PullOptions struct {
+	usehttp     bool
+	configHome  string
+	storageHome string
+	modelRef    *registry.Reference
+}
+
+func (opts *PullOptions) complete(args []string) error {
+	opts.configHome = viper.GetString("config")
+	opts.storageHome = path.Join(opts.configHome, "storage")
+	modelRef, err := registry.ParseReference(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to parse reference %s: %w", modelRef, err)
+	}
+	opts.modelRef = &modelRef
+	opts.usehttp = flags.UseHTTP
+	return nil
+}
+
+func (opts *PullOptions) validate() error {
+	return nil
+}
+
+func PullCommand() *cobra.Command {
+	opts = &PullOptions{}
+	flags = &PullFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "pull",
+		Short: shortDesc,
+		Long:  longDesc,
+		Run:   runCommand(opts),
+	}
+
+	cmd.Args = cobra.ExactArgs(1)
+	cmd.Flags().BoolVar(&flags.UseHTTP, "http", false, "Push to http registry")
+	return cmd
+}
+
+func runCommand(opts *PullOptions) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if err := opts.complete(args); err != nil {
+			fmt.Printf("Failed to process arguments: %s", err)
+		}
+		err := opts.validate()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		remoteRegistry, err := remote.NewRegistry(opts.modelRef.Registry)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		if opts.usehttp {
+			remoteRegistry.PlainHTTP = true
+		}
+
+		localStorePath := path.Join(opts.storageHome, opts.modelRef.Registry, opts.modelRef.Repository)
+		localStore, err := oci.New(localStorePath)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		fmt.Printf("Pulling %s\n", opts.modelRef.String())
+		desc, err := doPull(cmd.Context(), remoteRegistry, localStore, opts.modelRef)
+		if err != nil {
+			fmt.Printf("Failed to push: %s\n", err)
+		}
+		fmt.Printf("Pulled %s\n", desc.Digest)
+	}
+}

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -1,0 +1,100 @@
+package push
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+const (
+	shortDesc = `Push model to registry`
+	longDesc  = `Push model to registry TODO`
+)
+
+var (
+	flags *PushFlags
+	opts  *PushOptions
+)
+
+type PushFlags struct {
+	UseHTTP bool
+}
+
+type PushOptions struct {
+	usehttp     bool
+	configHome  string
+	storageHome string
+	modelRef    *registry.Reference
+}
+
+func (opts *PushOptions) complete(args []string) error {
+	opts.configHome = viper.GetString("config")
+	opts.storageHome = path.Join(opts.configHome, "storage")
+	modelRef, err := registry.ParseReference(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to parse reference %s: %w", modelRef, err)
+	}
+	opts.modelRef = &modelRef
+	opts.usehttp = flags.UseHTTP
+	return nil
+}
+
+func (opts *PushOptions) validate() error {
+	return nil
+}
+
+func PushCommand() *cobra.Command {
+	opts = &PushOptions{}
+	flags = &PushFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "push",
+		Short: shortDesc,
+		Long:  longDesc,
+		Run:   runCommand(opts),
+	}
+
+	cmd.Args = cobra.ExactArgs(1)
+	cmd.Flags().BoolVar(&flags.UseHTTP, "http", false, "Push to http registry")
+	return cmd
+}
+
+func runCommand(opts *PushOptions) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if err := opts.complete(args); err != nil {
+			fmt.Printf("Failed to process arguments: %s", err)
+		}
+		err := opts.validate()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		remoteRegistry, err := remote.NewRegistry(opts.modelRef.Registry)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		if opts.usehttp {
+			remoteRegistry.PlainHTTP = true
+		}
+
+		localStorePath := path.Join(opts.storageHome, opts.modelRef.Registry, opts.modelRef.Repository)
+		localStore, err := oci.New(localStorePath)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		fmt.Printf("Pushing %s\n", opts.modelRef.String())
+		desc, err := doPush(cmd.Context(), localStore, remoteRegistry, opts.modelRef)
+		if err != nil {
+			fmt.Printf("Failed to push: %s\n", err)
+		}
+		fmt.Printf("Pushed %s\n", desc.Digest)
+	}
+}

--- a/pkg/cmd/push/push.go
+++ b/pkg/cmd/push/push.go
@@ -4,40 +4,26 @@ Copyright © 2024 Jozu.com
 package push
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/spf13/cobra"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
 )
 
-// pushCmd represents the push command
-
-func NewCmdPush() *cobra.Command {
-
-	cmd := &cobra.Command{
-		Use:   "push",
-		Short: "A brief description of your command",
-		Long: `A longer description that spans multiple lines and likely contains examples
-	and usage of using your command. For example:
-	
-	Cobra is a CLI library for Go that empowers applications.
-	This application is a tool to generate the needed files
-	to quickly create a Cobra application.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("push called")
-		},
+func doPush(ctx context.Context, localStore *oci.Store, remoteRegistry *remote.Registry, ref *registry.Reference) (ocispec.Descriptor, error) {
+	repo, err := remoteRegistry.Repository(ctx, ref.Repository)
+	if err != nil {
+		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to read repository: %w", err)
 	}
-	return cmd
-}
 
-func init() {
+	desc, err := oras.Copy(ctx, localStore, ref.Reference, repo, ref.Reference, oras.DefaultCopyOptions)
+	if err != nil {
+		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to copy to remote: %w", err)
+	}
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// pushCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// pushCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	return desc, err
 }


### PR DESCRIPTION
### Description
Add commands
```
  jmm push <reference>
  jmm pull <reference>
```

Currently, this is very basic; output is just "Pushing" and "Pushed" with no progress indicator. Under the hood, we're basically just doing an `oras.Copy`

To make testing a little easier, both commands take the `--http` option. This is useful for testing against a locally-running OCI registry. 

### Testing
To test:
```bash
# Run OCI registry locally in container
docker run --name registry --rm -d -p 5050:5050 -e REGISTRY_HTTP_ADDR=:5050 registry

# Build model with tag matching registry
jmm build -t localhost:5050/test-repo:test-tag -f examples/onnx/Jozufile examples/onnx
# List models, verify test-repo is there:
jmm models
# Push to OCI registry
jmm push localhost:5050/test-repo:test-tag --http

# Delete local storage
rm -rf ~/.jozu/storage
# Verify model is gone
jmm models

# Pull from registry
jmm pull localhost:5050/test-repo:test-tag --http
# Check model is back
jmm models
```