### PR TITLE
Add ability to list models in remote repository via `jmm models`

### DIFF
--- a/pkg/cmd/models/remote.go
+++ b/pkg/cmd/models/remote.go
@@ -1,0 +1,96 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"jmm/pkg/artifact"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+func listRemoteModels(ctx context.Context, remoteRef *registry.Reference, useHttp bool) ([]string, error) {
+	remoteRegistry, err := remote.NewRegistry(remoteRef.Registry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read registry: %w", err)
+	}
+	remoteRegistry.PlainHTTP = useHttp
+
+	repo, err := remoteRegistry.Repository(ctx, remoteRef.Repository)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read repository: %w", err)
+	}
+	if remoteRef.Reference != "" {
+		return listImageTag(ctx, repo, remoteRef)
+	}
+	return listTags(ctx, repo, remoteRef)
+}
+
+func listTags(ctx context.Context, repo registry.Repository, ref *registry.Reference) ([]string, error) {
+	var tags []string
+	err := repo.Tags(ctx, "", func(tagsPage []string) error {
+		tags = append(tags, tagsPage...)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tags on repostory: %w", err)
+	}
+
+	var allLines []string
+	for _, tag := range tags {
+		tagRef := &registry.Reference{
+			Registry:   ref.Registry,
+			Repository: ref.Repository,
+			Reference:  tag,
+		}
+		infoLines, err := listImageTag(ctx, repo, tagRef)
+		if err != nil {
+			return nil, err
+		}
+		allLines = append(allLines, infoLines...)
+	}
+
+	return allLines, nil
+}
+
+func listImageTag(ctx context.Context, repo registry.Repository, ref *registry.Reference) ([]string, error) {
+	manifestDesc, manifestReader, err := repo.FetchReference(ctx, ref.Reference)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read reference: %w", err)
+	}
+	manifestBytes, err := io.ReadAll(manifestReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest: %w", err)
+	}
+	manifest := &ocispec.Manifest{}
+	if err := json.Unmarshal(manifestBytes, manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse manifest: %w", err)
+	}
+
+	configReader, err := repo.Fetch(ctx, manifest.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config reference: %w", err)
+	}
+	configBytes, err := io.ReadAll(configReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+	config := &artifact.JozuFile{}
+	if err := json.Unmarshal(configBytes, config); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	// Manifest descriptor may not have annotation for tag, add it here for safety
+	if _, ok := manifestDesc.Annotations[ocispec.AnnotationRefName]; !ok {
+		if manifestDesc.Annotations == nil {
+			manifestDesc.Annotations = map[string]string{}
+		}
+		manifestDesc.Annotations[ocispec.AnnotationRefName] = ref.Reference
+	}
+
+	info := getManifestInfoLine(ref.Repository, manifestDesc, manifest, config)
+	return []string{info}, nil
+}

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -60,7 +60,7 @@ func PullCommand() *cobra.Command {
 	}
 
 	cmd.Args = cobra.ExactArgs(1)
-	cmd.Flags().BoolVar(&flags.UseHTTP, "http", false, "Push to http registry")
+	cmd.Flags().BoolVar(&flags.UseHTTP, "http", false, "Use plain HTTP when connecting to remote registries")
 	return cmd
 }
 

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -60,7 +60,7 @@ func PushCommand() *cobra.Command {
 	}
 
 	cmd.Args = cobra.ExactArgs(1)
-	cmd.Flags().BoolVar(&flags.UseHTTP, "http", false, "Push to http registry")
+	cmd.Flags().BoolVar(&flags.UseHTTP, "http", false, "Use plain HTTP when connecting to remote registries")
 	return cmd
 }
 


### PR DESCRIPTION
### Description
Add optional argument to jmm models:
```
  jmm models [repository]
```
to optionally list models in a remote repository. 

Example output:
```
❯ jmm models localhost:5050/testrepo --http
REPOSITORY   TAG    MAINTAINER   NAME            SIZE       DIGEST
testrepo     tag1   Gorkem       Densenet-ONNX   28.9 MiB   sha256:f86285ad9d0f7a4a621f4c9750a807dfcc481b03cf4503863d0b752ebe0648ea
testrepo     tag2   Gorkem       Densenet-ONNX   28.9 MiB   sha256:f86285ad9d0f7a4a621f4c9750a807dfcc481b03cf4503863d0b752ebe0648ea

❯ jmm models localhost:5050/testrepo:tag2 --http
REPOSITORY   TAG    MAINTAINER   NAME            SIZE       DIGEST
testrepo     tag2   Gorkem       Densenet-ONNX   28.9 MiB   sha256:f86285ad9d0f7a4a621f4c9750a807dfcc481b03cf4503863d0b752ebe0648ea

❯ jmm models localhost:5050/testrepo:tag3 --http
failed to read reference: localhost:5050/testrepo:tag3: not found
```

### Testing instructions
1. Build and push some models to a remote registry (see https://github.com/jozu-ai/jmm/pull/11 for instructions)
2. Run `jmm models <repository>` to list all tags in that repository
3. Run `jmm models <repository>:<tag>` to see description of a single model