### PR TITLE
Add Dockerfile for installing kit as a KServe ClusterStorageContainer

### DIFF
--- a/build/dockerfiles/KServe/README.md
+++ b/build/dockerfiles/KServe/README.md
@@ -1,0 +1,56 @@
+# Kitops ClusterStorageContainer image for KServe
+
+The Dockerfile in this directory is used to build an image that can run as a ClusterStorageContainer for [KServe](https://kserve.github.io/website/master/).
+
+## Building
+To build the image, `docker` is required. From the root of this repository, set the `$KIT_KSERVE_IMAGE` to the image tag you want to build and run
+```bash
+docker build . \
+  -f build/dockerfiles/KServe/kserve.Dockerfile \
+  -t $KIT_KSERVE_IMAGE \
+  --build-arg version="next" \
+  --build-arg gitCommit=$(git rev-parse HEAD)
+```
+
+## Installing
+The following process will create a new ClusterStorageContainer that uses `kit` to support KServe InferenceServices with storage URIs that have the `kit://` prefix.
+
+Create the following ClusterStorageContainer custom resource in a Kubernetes cluster with KServe installed
+```yaml
+apiVersion: "serving.kserve.io/v1alpha1"
+kind: ClusterStorageContainer
+metadata:
+  name: kitops
+spec:
+  container:
+    name: kit-storage-initializer
+    image: $KIT_KSERVE_IMAGE
+    imagePullPolicy: Always
+    env:
+      - name: KIT_UNPACK_FLAGS
+        value: "" # Add extra flags for the `kit unpack` command
+    resources:
+      requests:
+        memory: 100Mi
+        cpu: 100m
+      limits:
+        memory: 1Gi
+    supportedUriFormats:
+    - prefix: kit://
+```
+
+Once this CR is installed, modelkits can be used in InferenceServices by specifying with the `kit://` URI:
+```yaml
+storageUri: kit://<modelkit-reference>
+```
+
+## Configuration
+The Kit KServe container supports specifying additional flags as supported by the `kit unpack` command. Additional flags are read from the `KIT_UNPACK_FLAGS` environment variable in the ClusterStorageContainer. For example, the following adds `-v` and `--plain-http` for all unpack commands:
+```yaml
+    env:
+      - name: KIT_UNPACK_FLAGS
+        value: "-v --plain-http"
+```
+
+## Additional links
+* [KServe ClusterStorageContainer documentation](https://kserve.github.io/website/master/modelserving/storage/storagecontainers/)

--- a/build/dockerfiles/KServe/entrypoint.sh
+++ b/build/dockerfiles/KServe/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+echo "Binary version info:"
+kit version
+
+read -r -a UNPACK_FLAGS <<< "$KIT_UNPACK_FLAGS"
+
+if [ $# != 2 ]; then
+  echo "Usage: entrypoint.sh <src-uri> <dest-path>"
+  exit 1
+fi
+
+REPO_NAME="${1#kit://}"
+OUTPUT_DIR="$2"
+
+echo "Unpacking $REPO_NAME to $OUTPUT_DIR"
+echo "Unpack options: ${KIT_UNPACK_FLAGS}"
+kit unpack "$REPO_NAME" -d "$OUTPUT_DIR" "${UNPACK_FLAGS[@]}"
+
+echo "Unpacked modelkit:"
+cat "$OUTPUT_DIR/Kitfile"

--- a/build/dockerfiles/KServe/kserve.Dockerfile
+++ b/build/dockerfiles/KServe/kserve.Dockerfile
@@ -1,0 +1,34 @@
+FROM docker.io/library/golang:alpine AS builder
+
+RUN apk --no-cache upgrade && apk add --no-cache git
+ARG version=next
+ARG gitCommit=<unknown>
+
+WORKDIR /build
+
+# Cache dependencies in separate layer
+COPY ["go.mod", "go.sum", "./"]
+RUN go mod download
+
+COPY . .
+RUN \
+    CGO_ENABLED=0 go build \
+    -o kit \
+    -ldflags="-s -w -X kitops/pkg/cmd/version.Version=${version} -X kitops/pkg/cmd/version.GitCommit=$gitCommit -X kitops/pkg/cmd/version.BuildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+FROM docker.io/library/alpine
+ENV USER_ID=1001 \
+    USER_NAME=kit \
+    HOME=/home/user/
+
+RUN apk --no-cache upgrade && \
+    apk add --no-cache bash && \
+    mkdir -p /home/user/ && \
+    adduser -D $USER_NAME -h $HOME -u $USER_ID
+
+USER ${USER_ID}
+
+COPY --from=builder /build/kit /usr/local/bin/kit
+COPY build/dockerfiles/KServe/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
### Description
Add a Dockerfile to enable using kit as a ClusterStorageContainer for KServe via the following CR:
```yaml
apiVersion: "serving.kserve.io/v1alpha1"
kind: ClusterStorageContainer
metadata:
  name: kitops
spec:
  container:
    name: kit-storage-initializer
    image: <kit-kserve-image>
    imagePullPolicy: Always
    env:
      - name: KIT_EXPORT_FLAGS
        value: ""       # Optional: Add extra flags for the `kit export` command
    resources:
      requests:
        memory: 100Mi
        cpu: 100m
      limits:
        memory: 1Gi     # Note: Default value, not measured
    supportedUriFormats:
    - prefix: kit://
```

This will allow downloading modelkits by specifying storageUris with `kit://` -- for example
```yaml
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "torchserve"
spec:
  predictor:
    model:
      modelFormat:
        name: pytorch
      storageUri: kit://<modelkit-reference>
```

Note that KServe inference services generally assume a certain file structure for the model/configuration; as a result building dedicated modelkits for KServe is still likely required. 