### PR TITLE
Add commands `kit inspect` and `kit info`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"kitops/pkg/cmd/inspect"
 	"kitops/pkg/cmd/list"
 	"kitops/pkg/cmd/login"
 	"kitops/pkg/cmd/logout"
@@ -81,6 +82,7 @@ func addSubcommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(pull.PullCommand())
 	rootCmd.AddCommand(tag.TagCommand())
 	rootCmd.AddCommand(list.ListCommand())
+	rootCmd.AddCommand(inspect.InspectCommand())
 	rootCmd.AddCommand(remove.RemoveCommand())
 	rootCmd.AddCommand(login.LoginCommand())
 	rootCmd.AddCommand(logout.LogoutCommand())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"kitops/pkg/cmd/info"
 	"kitops/pkg/cmd/inspect"
 	"kitops/pkg/cmd/list"
 	"kitops/pkg/cmd/login"
@@ -83,6 +84,7 @@ func addSubcommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(tag.TagCommand())
 	rootCmd.AddCommand(list.ListCommand())
 	rootCmd.AddCommand(inspect.InspectCommand())
+	rootCmd.AddCommand(info.InfoCommand())
 	rootCmd.AddCommand(remove.RemoveCommand())
 	rootCmd.AddCommand(login.LoginCommand())
 	rootCmd.AddCommand(logout.LogoutCommand())

--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -1,5 +1,94 @@
 # Kit CLI Reference
 
+## kit info
+
+Show the configuration for a modelkit
+
+### Synopsis
+
+Print the contents of a modelkit config to the screen.
+
+By default, kit will check local storage for the specified modelkit. To see
+the configuration for a modelkit stored on a remote registry, use the
+--remote flag.
+
+```
+kit info [flags] MODELKIT
+```
+
+### Examples
+
+```
+# See configuration for a local modelkit:
+kit info mymodel:mytag
+
+# See configuration for a local modelkit by digest:
+kit info mymodel@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+
+# See configuration for a remote modelkit if not present locally:
+kit info registry.example.com/my-model:1.0.0
+```
+
+### Options
+
+```
+  -h, --help         help for info
+      --plain-http   Use plain HTTP when connecting to remote registries
+  -r, --remote       Check remote registry even if modelkit is present locally
+      --tls-verify   Require TLS and verify certificates when connecting to remote registries (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   Config file (default $HOME/.kitops)
+  -v, --verbose         Include additional information in output (default false)
+```
+
+## kit inspect
+
+Inspect a modelkit's manifest
+
+### Synopsis
+
+Print the contents of a modelkit manifest to the screen.
+
+By default, kit will check local storage for the specified modelkit. To
+inspect a modelkit stored on a remote registry, use the --remote flag.
+
+```
+kit inspect [flags] MODELKIT
+```
+
+### Examples
+
+```
+# Inspect a local modelkit:
+kit inspect mymodel:mytag
+
+# Inspect a local modelkit by digest:
+kit inspect mymodel@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+
+# Inspect a remote modelkit if not present locally:
+kit inspect registry.example.com/my-model:1.0.0
+```
+
+### Options
+
+```
+  -h, --help         help for inspect
+      --plain-http   Use plain HTTP when connecting to remote registries
+  -r, --remote       Check remote registry even if modelkit is present locally
+      --tls-verify   Require TLS and verify certificates when connecting to remote registries (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   Config file (default $HOME/.kitops)
+  -v, --verbose         Include additional information in output (default false)
+```
+
 ## kit list
 
 List modelkits in a repository

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/term v0.17.0
+	gopkg.in/yaml.v3 v3.0.1
 	oras.land/oras-go/v2 v2.4.0
-	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -21,5 +21,4 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0q
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -32,5 +30,3 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 oras.land/oras-go/v2 v2.4.0 h1:i+Wt5oCaMHu99guBD0yuBjdLvX7Lz8ukPbwXdR7uBMs=
 oras.land/oras-go/v2 v2.4.0/go.mod h1:osvtg0/ClRq1KkydMAEu/IxFieyjItcsQ4ut4PPF+f8=
-sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
-sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/pkg/artifact/kit-file.go
+++ b/pkg/artifact/kit-file.go
@@ -1,63 +1,64 @@
 package artifact
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"os"
 
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 type (
 	KitFile struct {
-		ManifestVersion string        `json:"manifestVersion"`
-		Kit             ModelKit      `json:"package,omitempty"`
-		Code            []Code        `json:"code,omitempty"`
-		DataSets        []DataSet     `json:"datasets,omitempty"`
-		Model           *TrainedModel `json:"model,omitempty"`
+		ManifestVersion string        `json:"manifestVersion" yaml:"manifestVersion"`
+		Kit             ModelKit      `json:"package,omitempty" yaml:"package,omitempty"`
+		Model           *TrainedModel `json:"model,omitempty" yaml:"model,omitempty"`
+		Code            []Code        `json:"code,omitempty" yaml:"code,omitempty"`
+		DataSets        []DataSet     `json:"datasets,omitempty" yaml:"datasets,omitempty"`
 	}
 
 	ModelKit struct {
-		Name        string   `json:"name,omitempty"`
-		Version     string   `json:"version,omitempty"`
-		Description string   `json:"description,omitempty"`
-		License     string   `json:"license,omitempty"`
-		Authors     []string `json:"authors,omitempty"`
+		Name        string   `json:"name,omitempty" yaml:"name,omitempty"`
+		Version     string   `json:"version,omitempty" yaml:"version,omitempty"`
+		Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+		License     string   `json:"license,omitempty" yaml:"license,omitempty"`
+		Authors     []string `json:"authors,omitempty" yaml:"authors,omitempty,flow"`
 	}
 
 	Code struct {
-		Path        string `json:"path,omitempty"`
-		License     string `json:"license,omitempty"`
-		Description string `json:"description,omitempty"`
+		Path        string `json:"path,omitempty" yaml:"path,omitempty"`
+		License     string `json:"license,omitempty" yaml:"license,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	}
 
 	DataSet struct {
-		Name          string `json:"name,omitempty"`
-		Path          string `json:"path,omitempty"`
-		Description   string `json:"description,omitempty"`
-		License       string `json:"license,omitempty"`
-		Preprocessing string `json:"preprocessing,omitempty"`
+		Name          string `json:"name,omitempty" yaml:"name,omitempty"`
+		Path          string `json:"path,omitempty" yaml:"path,omitempty"`
+		Description   string `json:"description,omitempty" yaml:"description,omitempty"`
+		License       string `json:"license,omitempty" yaml:"license,omitempty"`
+		Preprocessing string `json:"preprocessing,omitempty" yaml:"preprocessing,omitempty"`
 	}
 
 	TrainedModel struct {
-		Name        string      `json:"name,omitempty"`
-		Path        string      `json:"path,omitempty"`
-		Framework   string      `json:"framework,omitempty"`
-		Version     string      `json:"version,omitempty"`
-		Description string      `json:"description,omitempty"`
-		License     string      `json:"license,omitempty"`
-		Training    *Training   `json:"training,omitempty"`
-		Validation  *Validation `json:"validation,omitempty"`
+		Name        string      `json:"name,omitempty" yaml:"name,omitempty"`
+		Path        string      `json:"path,omitempty" yaml:"path,omitempty"`
+		Framework   string      `json:"framework,omitempty" yaml:"framework,omitempty"`
+		Version     string      `json:"version,omitempty" yaml:"version,omitempty"`
+		Description string      `json:"description,omitempty" yaml:"description,omitempty"`
+		License     string      `json:"license,omitempty" yaml:"license,omitempty"`
+		Training    *Training   `json:"training,omitempty" yaml:"training,omitempty"`
+		Validation  *Validation `json:"validation,omitempty" yaml:"validation,omitempty"`
 	}
 
 	Training struct {
-		DataSet    string                 `json:"dataset,omitempty"`
-		Parameters map[string]interface{} `json:"parameters,omitempty"`
+		DataSet    string                 `json:"dataset,omitempty" yaml:"dataset,omitempty"`
+		Parameters map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	}
 
 	Validation struct {
-		DataSet string                 `json:"dataset,omitempty"`
-		Metrics map[string]interface{} `json:"metrics,omitempty"`
+		DataSet string                 `json:"dataset,omitempty" yaml:"dataset,omitempty"`
+		Metrics map[string]interface{} `json:"metrics,omitempty" yaml:"metrics,omitempty"`
 	}
 )
 
@@ -86,4 +87,14 @@ func (kf *KitFile) MarshalToJSON() ([]byte, error) {
 	}
 
 	return jsonData, nil
+}
+
+func (kf *KitFile) MarshalToYAML() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	enc := yaml.NewEncoder(buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(kf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
-	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -69,7 +68,7 @@ func runCommand(opts *infoOptions) func(*cobra.Command, []string) {
 			}
 			output.Fatalf("Error resolving ModelKit: %s", err)
 		}
-		yamlBytes, err := yaml.Marshal(config)
+		yamlBytes, err := config.MarshalToYAML()
 		if err != nil {
 			output.Fatalf("Error formatting manifest: %w", err)
 		}

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -16,19 +16,19 @@ import (
 )
 
 const (
-	shortDesc = `Show the configuration for a ModelKit`
-	longDesc  = `Print the contents of a ModelKit config to the screen.
+	shortDesc = `Show the configuration for a modelkit`
+	longDesc  = `Print the contents of a modelkit config to the screen.
 
-By default, kit will check local storage for the specified ModelKit. To see
-the configuration for a ModelKit stored on a remote registry, use the
+By default, kit will check local storage for the specified modelkit. To see
+the configuration for a modelkit stored on a remote registry, use the
 --remote flag.`
-	example = `# See configuration for a local ModelKit:
+	example = `# See configuration for a local modelkit:
 kit info mymodel:mytag
 
-# See configuration for a local ModelKit by digest:
+# See configuration for a local modelkit by digest:
 kit info mymodel@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
 
-# See configuration for a remote ModelKit if not present locally:
+# See configuration for a remote modelkit if not present locally:
 kit info registry.example.com/my-model:1.0.0`
 )
 
@@ -52,7 +52,7 @@ func InfoCommand() *cobra.Command {
 	}
 
 	opts.AddNetworkFlags(cmd)
-	cmd.Flags().BoolVarP(&opts.checkRemote, "remote", "r", false, "Check remote registry even if ModelKit is present locally")
+	cmd.Flags().BoolVarP(&opts.checkRemote, "remote", "r", false, "Check remote registry even if modelkit is present locally")
 	return cmd
 }
 
@@ -64,9 +64,9 @@ func runCommand(opts *infoOptions) func(*cobra.Command, []string) {
 		config, err := getInfo(cmd.Context(), opts)
 		if err != nil {
 			if errors.Is(err, errdef.ErrNotFound) {
-				output.Fatalf("Could not find ModelKit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
+				output.Fatalf("Could not find modelkit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
 			}
-			output.Fatalf("Error resolving ModelKit: %s", err)
+			output.Fatalf("Error resolving modelkit: %s", err)
 		}
 		yamlBytes, err := config.MarshalToYAML()
 		if err != nil {

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -1,0 +1,101 @@
+package info
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"kitops/pkg/cmd/options"
+	"kitops/pkg/lib/constants"
+	"kitops/pkg/lib/repo"
+	"kitops/pkg/output"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	shortDesc = `Show the configuration for a ModelKit`
+	longDesc  = `Print the contents of a ModelKit config to the screen.
+
+If the ModelKit is present locally, this ModelKit is used by default. If
+it is not present and the ModelKit reference includes a registry, kit will
+download the configuration from the remote registry if possible.`
+	example = `# See configuration for a local ModelKit:
+kit info mymodel:mytag
+
+# See configuration for a local ModelKit by digest:
+kit info mymodel@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+
+# See configuration for a remote ModelKit if not present locally:
+kit info registry.example.com/my-model:1.0.0`
+)
+
+type infoOptions struct {
+	options.NetworkOptions
+	configHome  string
+	checkRemote bool
+	modelRef    *registry.Reference
+}
+
+func InfoCommand() *cobra.Command {
+	opts := &infoOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "info [flags] MODELKIT",
+		Short:   shortDesc,
+		Long:    longDesc,
+		Example: example,
+		Run:     runCommand(opts),
+		Args:    cobra.ExactArgs(1),
+	}
+
+	opts.AddNetworkFlags(cmd)
+	cmd.Flags().BoolVarP(&opts.checkRemote, "remote", "r", false, "Check remote registry even if ModelKit is present locally")
+	return cmd
+}
+
+func runCommand(opts *infoOptions) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if err := opts.complete(cmd.Context(), args); err != nil {
+			output.Fatalf("Failed to parse arguments: %s", err)
+		}
+		config, err := getInfo(cmd.Context(), opts)
+		if err != nil {
+			if errors.Is(err, errdef.ErrNotFound) {
+				output.Fatalf("Could not find ModelKit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
+			}
+			output.Fatalf("Error resolving ModelKit: %s", err)
+		}
+		yamlBytes, err := yaml.Marshal(config)
+		if err != nil {
+			output.Fatalf("Error formatting manifest: %w", err)
+		}
+		fmt.Println(string(yamlBytes))
+	}
+}
+
+func (opts *infoOptions) complete(ctx context.Context, args []string) error {
+	configHome, ok := ctx.Value(constants.ConfigKey{}).(string)
+	if !ok {
+		return fmt.Errorf("default config path not set on command context")
+	}
+	opts.configHome = configHome
+
+	ref, extraTags, err := repo.ParseReference(args[0])
+	if err != nil {
+		return err
+	}
+	if len(extraTags) > 0 {
+		return fmt.Errorf("invalid reference format: extra tags are not supported: %s", strings.Join(extraTags, ", "))
+	}
+	opts.modelRef = ref
+
+	if opts.modelRef.Registry == repo.DefaultRegistry && opts.checkRemote {
+		return fmt.Errorf("can not check remote: %s does not contain registry", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
+	}
+
+	return nil
+}

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -19,9 +19,9 @@ const (
 	shortDesc = `Show the configuration for a ModelKit`
 	longDesc  = `Print the contents of a ModelKit config to the screen.
 
-If the ModelKit is present locally, this ModelKit is used by default. If
-it is not present and the ModelKit reference includes a registry, kit will
-download the configuration from the remote registry if possible.`
+By default, kit will check local storage for the specified ModelKit. To see
+the configuration for a ModelKit stored on a remote registry, use the
+--remote flag.`
 	example = `# See configuration for a local ModelKit:
 kit info mymodel:mytag
 

--- a/pkg/cmd/info/info.go
+++ b/pkg/cmd/info/info.go
@@ -2,35 +2,18 @@ package info
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"kitops/pkg/artifact"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/repo"
-	"kitops/pkg/output"
-
-	"oras.land/oras-go/v2/errdef"
 )
 
 func getInfo(ctx context.Context, opts *infoOptions) (*artifact.KitFile, error) {
-	if opts.modelRef.Registry == repo.DefaultRegistry {
-		// Local only check
+	if opts.checkRemote {
+		return getRemoteConfig(ctx, opts)
+	} else {
 		return getLocalConfig(ctx, opts)
 	}
-	if opts.checkRemote {
-		// Remote only check
-		return getRemoteConfig(ctx, opts)
-	}
-
-	// Check locally first; if not found check remote
-	manifest, err := getLocalConfig(ctx, opts)
-	if err == nil {
-		return manifest, nil
-	} else if !errors.Is(err, errdef.ErrNotFound) {
-		return nil, err
-	}
-	output.Debugf("ModelKit not found locally, checking remote.")
-	return getRemoteConfig(ctx, opts)
 }
 
 func getLocalConfig(ctx context.Context, opts *infoOptions) (*artifact.KitFile, error) {

--- a/pkg/cmd/info/info.go
+++ b/pkg/cmd/info/info.go
@@ -1,0 +1,63 @@
+package info
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"kitops/pkg/artifact"
+	"kitops/pkg/lib/constants"
+	"kitops/pkg/lib/repo"
+	"kitops/pkg/output"
+
+	"oras.land/oras-go/v2/errdef"
+)
+
+func getInfo(ctx context.Context, opts *infoOptions) (*artifact.KitFile, error) {
+	if opts.modelRef.Registry == repo.DefaultRegistry {
+		// Local only check
+		return getLocalConfig(ctx, opts)
+	}
+	if opts.checkRemote {
+		// Remote only check
+		return getRemoteConfig(ctx, opts)
+	}
+
+	// Check locally first; if not found check remote
+	manifest, err := getLocalConfig(ctx, opts)
+	if err == nil {
+		return manifest, nil
+	} else if !errors.Is(err, errdef.ErrNotFound) {
+		return nil, err
+	}
+	output.Debugf("ModelKit not found locally, checking remote.")
+	return getRemoteConfig(ctx, opts)
+}
+
+func getLocalConfig(ctx context.Context, opts *infoOptions) (*artifact.KitFile, error) {
+	storageRoot := constants.StoragePath(opts.configHome)
+	store, err := repo.NewLocalStore(storageRoot, opts.modelRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read local storage: %w", err)
+	}
+	_, config, err := repo.ResolveManifestAndConfig(ctx, store, opts.modelRef.Reference)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func getRemoteConfig(ctx context.Context, opts *infoOptions) (*artifact.KitFile, error) {
+	repository, err := repo.NewRepository(ctx, opts.modelRef.Registry, opts.modelRef.Repository, &repo.RegistryOptions{
+		PlainHTTP:       opts.PlainHTTP,
+		SkipTLSVerify:   !opts.TlsVerify,
+		CredentialsPath: constants.CredentialsPath(opts.configHome),
+	})
+	if err != nil {
+		return nil, err
+	}
+	_, config, err := repo.ResolveManifestAndConfig(ctx, repository, opts.modelRef.Reference)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -1,0 +1,101 @@
+package inspect
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"kitops/pkg/cmd/options"
+	"kitops/pkg/lib/constants"
+	"kitops/pkg/lib/repo"
+	"kitops/pkg/output"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry"
+)
+
+const (
+	shortDesc = `Inspect a ModelKit's manifest`
+	longDesc  = `Print the contents of a ModelKit manifest to the screen.
+
+If the ModelKit is present locally, this ModelKit is inspected by default. If
+it is not present and the ModelKit reference includes a registry, kit will
+download the manifest from the remote registry if possible.`
+	example = `# Inspect a local ModelKit:
+kit inspect mymodel:mytag
+
+# Inspect a local ModelKit by digest:
+kit inspect mymodel@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+
+# Inspect a remote ModelKit if not present locally:
+kit inspect registry.example.com/my-model:1.0.0`
+)
+
+type inspectOptions struct {
+	options.NetworkOptions
+	configHome  string
+	checkRemote bool
+	modelRef    *registry.Reference
+}
+
+func InspectCommand() *cobra.Command {
+	opts := &inspectOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "inspect [flags] MODELKIT",
+		Short:   shortDesc,
+		Long:    longDesc,
+		Example: example,
+		Run:     runCommand(opts),
+		Args:    cobra.ExactArgs(1),
+	}
+
+	opts.AddNetworkFlags(cmd)
+	cmd.Flags().BoolVarP(&opts.checkRemote, "remote", "r", false, "Check remote registry even if ModelKit is present locally")
+	return cmd
+}
+
+func runCommand(opts *inspectOptions) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if err := opts.complete(cmd.Context(), args); err != nil {
+			output.Fatalf("Failed to parse arguments: %s", err)
+		}
+		manifest, err := inspectReference(cmd.Context(), opts)
+		if err != nil {
+			if errors.Is(err, errdef.ErrNotFound) {
+				output.Fatalf("Could not find ModelKit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
+			}
+			output.Fatalf("Error resolving ModelKit: %s", err)
+		}
+		jsonBytes, err := json.MarshalIndent(manifest, "", "  ")
+		if err != nil {
+			output.Fatalf("Error formatting manifest: %w", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}
+
+func (opts *inspectOptions) complete(ctx context.Context, args []string) error {
+	configHome, ok := ctx.Value(constants.ConfigKey{}).(string)
+	if !ok {
+		return fmt.Errorf("default config path not set on command context")
+	}
+	opts.configHome = configHome
+
+	ref, extraTags, err := repo.ParseReference(args[0])
+	if err != nil {
+		return err
+	}
+	if len(extraTags) > 0 {
+		return fmt.Errorf("invalid reference format: extra tags are not supported: %s", strings.Join(extraTags, ", "))
+	}
+	opts.modelRef = ref
+
+	if opts.modelRef.Registry == repo.DefaultRegistry && opts.checkRemote {
+		return fmt.Errorf("can not check remote: %s does not contain registry", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
+	}
+
+	return nil
+}

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -17,18 +17,18 @@ import (
 )
 
 const (
-	shortDesc = `Inspect a ModelKit's manifest`
-	longDesc  = `Print the contents of a ModelKit manifest to the screen.
+	shortDesc = `Inspect a modelkit's manifest`
+	longDesc  = `Print the contents of a modelkit manifest to the screen.
 
-By default, kit will check local storage for the specified ModelKit. To
-inspect a ModelKit stored on a remote registry, use the --remote flag.`
-	example = `# Inspect a local ModelKit:
+By default, kit will check local storage for the specified modelkit. To
+inspect a modelkit stored on a remote registry, use the --remote flag.`
+	example = `# Inspect a local modelkit:
 kit inspect mymodel:mytag
 
-# Inspect a local ModelKit by digest:
+# Inspect a local modelkit by digest:
 kit inspect mymodel@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
 
-# Inspect a remote ModelKit if not present locally:
+# Inspect a remote modelkit if not present locally:
 kit inspect registry.example.com/my-model:1.0.0`
 )
 
@@ -52,7 +52,7 @@ func InspectCommand() *cobra.Command {
 	}
 
 	opts.AddNetworkFlags(cmd)
-	cmd.Flags().BoolVarP(&opts.checkRemote, "remote", "r", false, "Check remote registry even if ModelKit is present locally")
+	cmd.Flags().BoolVarP(&opts.checkRemote, "remote", "r", false, "Check remote registry even if modelkit is present locally")
 	return cmd
 }
 
@@ -64,9 +64,9 @@ func runCommand(opts *inspectOptions) func(*cobra.Command, []string) {
 		manifest, err := inspectReference(cmd.Context(), opts)
 		if err != nil {
 			if errors.Is(err, errdef.ErrNotFound) {
-				output.Fatalf("Could not find ModelKit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
+				output.Fatalf("Could not find modelkit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
 			}
-			output.Fatalf("Error resolving ModelKit: %s", err)
+			output.Fatalf("Error resolving modelkit: %s", err)
 		}
 		jsonBytes, err := json.MarshalIndent(manifest, "", "  ")
 		if err != nil {

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -20,9 +20,8 @@ const (
 	shortDesc = `Inspect a ModelKit's manifest`
 	longDesc  = `Print the contents of a ModelKit manifest to the screen.
 
-If the ModelKit is present locally, this ModelKit is inspected by default. If
-it is not present and the ModelKit reference includes a registry, kit will
-download the manifest from the remote registry if possible.`
+By default, kit will check local storage for the specified ModelKit. To
+inspect a ModelKit stored on a remote registry, use the --remote flag.`
 	example = `# Inspect a local ModelKit:
 kit inspect mymodel:mytag
 

--- a/pkg/cmd/inspect/inspect.go
+++ b/pkg/cmd/inspect/inspect.go
@@ -1,0 +1,55 @@
+package inspect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"kitops/pkg/lib/constants"
+	"kitops/pkg/lib/repo"
+	"kitops/pkg/output"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
+)
+
+func inspectReference(ctx context.Context, opts *inspectOptions) (*ocispec.Manifest, error) {
+	if opts.modelRef.Registry == repo.DefaultRegistry {
+		// Local only check
+		return getLocalManifest(ctx, opts)
+	}
+	if opts.checkRemote {
+		// Remote only check
+		return getRemoteManifest(ctx, opts)
+	}
+
+	// Check locally first; if not found check remote
+	manifest, err := getLocalManifest(ctx, opts)
+	if err == nil {
+		return manifest, nil
+	} else if !errors.Is(err, errdef.ErrNotFound) {
+		return nil, err
+	}
+	output.Debugf("ModelKit not found locally, checking remote.")
+	return getRemoteManifest(ctx, opts)
+}
+
+func getLocalManifest(ctx context.Context, opts *inspectOptions) (*ocispec.Manifest, error) {
+	storageRoot := constants.StoragePath(opts.configHome)
+	store, err := repo.NewLocalStore(storageRoot, opts.modelRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read local storage: %w", err)
+	}
+	return repo.ResolveManifest(ctx, store, opts.modelRef.Reference)
+}
+
+func getRemoteManifest(ctx context.Context, opts *inspectOptions) (*ocispec.Manifest, error) {
+	repository, err := repo.NewRepository(ctx, opts.modelRef.Registry, opts.modelRef.Repository, &repo.RegistryOptions{
+		PlainHTTP:       opts.PlainHTTP,
+		SkipTLSVerify:   !opts.TlsVerify,
+		CredentialsPath: constants.CredentialsPath(opts.configHome),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return repo.ResolveManifest(ctx, repository, opts.modelRef.Reference)
+}

--- a/pkg/cmd/inspect/inspect.go
+++ b/pkg/cmd/inspect/inspect.go
@@ -2,35 +2,19 @@ package inspect
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/repo"
-	"kitops/pkg/output"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2/errdef"
 )
 
 func inspectReference(ctx context.Context, opts *inspectOptions) (*ocispec.Manifest, error) {
-	if opts.modelRef.Registry == repo.DefaultRegistry {
-		// Local only check
+	if opts.checkRemote {
+		return getRemoteManifest(ctx, opts)
+	} else {
 		return getLocalManifest(ctx, opts)
 	}
-	if opts.checkRemote {
-		// Remote only check
-		return getRemoteManifest(ctx, opts)
-	}
-
-	// Check locally first; if not found check remote
-	manifest, err := getLocalManifest(ctx, opts)
-	if err == nil {
-		return manifest, nil
-	} else if !errors.Is(err, errdef.ErrNotFound) {
-		return nil, err
-	}
-	output.Debugf("ModelKit not found locally, checking remote.")
-	return getRemoteManifest(ctx, opts)
 }
 
 func getLocalManifest(ctx context.Context, opts *inspectOptions) (*ocispec.Manifest, error) {

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -18,7 +18,6 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/registry"
-	"sigs.k8s.io/yaml"
 )
 
 func unpackModel(ctx context.Context, store oras.Target, ref *registry.Reference, options *unpackOptions) error {
@@ -88,7 +87,7 @@ func unpackConfig(config *artifact.KitFile, unpackDir string, overwrite bool) er
 		}
 	}
 
-	configBytes, err := yaml.Marshal(config)
+	configBytes, err := config.MarshalToYAML()
 	if err != nil {
 		return fmt.Errorf("failed to unpack config: %w", err)
 	}

--- a/pkg/lib/repo/registry.go
+++ b/pkg/lib/repo/registry.go
@@ -1,8 +1,11 @@
 package repo
 
 import (
+	"context"
+	"fmt"
 	"kitops/pkg/lib/network"
 
+	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
 )
 
@@ -27,4 +30,16 @@ func NewRegistry(hostname string, opts *RegistryOptions) (*remote.Registry, erro
 	reg.Client = client
 
 	return reg, nil
+}
+
+func NewRepository(ctx context.Context, hostname, repository string, opts *RegistryOptions) (registry.Repository, error) {
+	registry, err := NewRegistry(hostname, opts)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := registry.Repository(ctx, repository)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repository: %w", err)
+	}
+	return repo, nil
 }


### PR DESCRIPTION
### Description
Add commands to the CLI:

* `kit inspect [flags] MODELKIT` - Print the manifest for a ModelKit
* `kit info [flags] MODELKIT` - Print the config (Kitfile) for a ModelKit

Both commands will, by default, show a local ModelKit if it exists before checking remote repositories; each command supports the flag `-r|--remote` to force checking a remote in case it exists both locally and in the registry (e.g. in the case of a `latest` ModelKit that maybe out of date).

In testing `kit info`, I realized that the yaml library we're using (`sigs.k8s.io/yaml`) prints struct fields in alphabetic order, with no way to control this behavior. This meant that Kitfiles would be rendered as
```yaml
code: []
datasets: []
manifestVersion: v1.0.0
model: {}
package:
  license: <license>
  name: <name>
```

As a result, I've switched the repo back to using `gopkg.in/yaml.v3` (which preserves the expected order like JSON does) and reordered struct fields for better legibility.