### PR TITLE
Check for absolute paths in a Kitfile and print clear message

### DIFF
--- a/pkg/lib/filesystem/paths.go
+++ b/pkg/lib/filesystem/paths.go
@@ -12,6 +12,10 @@ import (
 // VerifySubpath checks that filepath.Join(context, subDir) is a subdirectory of context, following
 // symlinks if present.
 func VerifySubpath(context, subDir string) (absPath string, err error) {
+	if filepath.IsAbs(subDir) {
+		return "", fmt.Errorf("absolute paths are not supported (%s)", subDir)
+	}
+
 	// Get absolute path for context and context + subDir
 	absContext, err := filepath.Abs(context)
 	if err != nil {


### PR DESCRIPTION
### Description

Print a clear error message if a Kitfile contains an absolute path (instead of a relative one). Otherwise, we try to concatenate the absolute path to the pack context, which leads to a very confusing error message.