### PR TITLE
Update how default config directory is handled

### DIFF
--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -48,7 +48,7 @@ kit list registry.example.com/my-namespace/my-model
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default $HOME/.kitops)
+      --config string   Alternate path to root storage directory for CLI
   -v, --verbose         Include additional information in output (default false)
 ```
 
@@ -86,7 +86,7 @@ kit login ghcr.io -u github_user -p personal_token
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default $HOME/.kitops)
+      --config string   Alternate path to root storage directory for CLI
   -v, --verbose         Include additional information in output (default false)
 ```
 
@@ -119,7 +119,7 @@ kit logout ghcr.io
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default $HOME/.kitops)
+      --config string   Alternate path to root storage directory for CLI
   -v, --verbose         Include additional information in output (default false)
 ```
 
@@ -166,7 +166,7 @@ kit pack . -f /path/to/your/Kitfile -t registry/repository:modelv1
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default $HOME/.kitops)
+      --config string   Alternate path to root storage directory for CLI
   -v, --verbose         Include additional information in output (default false)
 ```
 
@@ -201,7 +201,7 @@ kit pull registry.example.com/my-model:latest
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default $HOME/.kitops)
+      --config string   Alternate path to root storage directory for CLI
   -v, --verbose         Include additional information in output (default false)
 ```
 
@@ -241,7 +241,7 @@ kit push registry.example.com/my-model:1.0.0
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default $HOME/.kitops)
+      --config string   Alternate path to root storage directory for CLI
   -v, --verbose         Include additional information in output (default false)
 ```
 
@@ -281,7 +281,7 @@ kit remove my-registry.com/my-org/my-repo:tag1,tag2,tag3
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default $HOME/.kitops)
+      --config string   Alternate path to root storage directory for CLI
   -v, --verbose         Include additional information in output (default false)
 ```
 
@@ -345,7 +345,7 @@ kit tag myregistry.com/myrepo/mykit:latest myregistry.com/myrepo/mykit:v1.0.0
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default $HOME/.kitops)
+      --config string   Alternate path to root storage directory for CLI
   -v, --verbose         Include additional information in output (default false)
 ```
 
@@ -427,7 +427,7 @@ kit version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default $HOME/.kitops)
+      --config string   Alternate path to root storage directory for CLI
   -v, --verbose         Include additional information in output (default false)
 ```
 

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -120,7 +120,6 @@ func printSummary(lines []string) {
 }
 
 func printConfig(opts *listOptions) {
-	output.Debugf("Using config path: %s", opts.configHome)
 	if opts.remoteRef != nil {
 		output.Debugf("Listing remote model kits in %s", opts.remoteRef.String())
 	}

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -47,7 +47,6 @@ func (opts *pullOptions) complete(ctx context.Context, args []string) error {
 	}
 	opts.modelRef = modelRef
 
-	printConfig(opts)
 	return nil
 }
 
@@ -96,8 +95,4 @@ func runCommand(opts *pullOptions) func(*cobra.Command, []string) {
 		}
 		output.Infof("Pulled %s", desc.Digest)
 	}
-}
-
-func printConfig(opts *pullOptions) {
-	output.Debugf("Using config path: %s", opts.configHome)
 }

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -52,7 +52,6 @@ func (opts *pushOptions) complete(ctx context.Context, args []string) error {
 	}
 	opts.modelRef = modelRef
 
-	printConfig(opts)
 	return nil
 }
 
@@ -102,8 +101,4 @@ func runCommand(opts *pushOptions) func(*cobra.Command, []string) {
 		}
 		output.Infof("Pushed %s", desc.Digest)
 	}
-}
-
-func printConfig(opts *pushOptions) {
-	output.Debugf("Using config path: %s", opts.configHome)
 }

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -96,6 +96,5 @@ func runCommand(opts *removeOptions) func(*cobra.Command, []string) {
 }
 
 func printConfig(opts *removeOptions) {
-	output.Debugf("Using config path: %s", opts.configHome)
 	output.Debugf("Removing %s and additional tags: [%s]", opts.modelRef.String(), strings.Join(opts.extraTags, ", "))
 }

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -171,7 +171,6 @@ func getStoreForRef(ctx context.Context, opts *unpackOptions) (oras.Target, erro
 }
 
 func printConfig(opts *unpackOptions) {
-	output.Debugf("Using config path: %s", opts.configHome)
 	output.Debugf("Overwrite: %t", opts.overwrite)
 	output.Debugf("Unpacking %s", opts.modelRef.String())
 }

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -1,12 +1,17 @@
 package constants
 
-import "path/filepath"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
 
 type ConfigKey struct{}
 
 const (
 	DefaultKitFileName  = "Kitfile"
-	DefaultConfigSubdir = ".kitops"
+	DefaultConfigSubdir = "kitops"
 
 	StorageSubpath     = "storage"
 	CredentialsSubpath = "credentials.json"
@@ -20,6 +25,41 @@ const (
 	// Media type for the model config (Kitfile)
 	ModelConfigMediaType = "application/vnd.kitops.modelkit.config.v1+json"
 )
+
+func DefaultConfigPath() (string, error) {
+	switch runtime.GOOS {
+	case "linux":
+		datahome := os.Getenv("XDG_DATA_HOME")
+		if datahome == "" {
+			// Use default ~/.local/share/
+			userhome := os.Getenv("HOME")
+			if userhome == "" {
+				return "", fmt.Errorf("could not get $HOME directory")
+			}
+			datahome = filepath.Join(userhome, ".local", "share")
+		}
+		return filepath.Join(datahome, DefaultConfigSubdir), nil
+
+	case "darwin":
+		// Use ~/Library/Caches/kitops
+		cacheDir, err := os.UserCacheDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cacheDir, DefaultConfigSubdir), nil
+
+	case "windows":
+		// Use %LOCALAPPDATA%\kitops
+		appdata, err := os.UserCacheDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(appdata, DefaultConfigSubdir), nil
+
+	default:
+		return "", fmt.Errorf("Unrecognized operating system")
+	}
+}
 
 func StoragePath(configBase string) string {
 	return filepath.Join(configBase, StorageSubpath)


### PR DESCRIPTION
### Description

Update how we resolve a default configuration directory for the CLI, in order of precedence:

* The value of the `--config` flag, if specified
* The value of the `$KITOPS_HOME` environment variable, if set
* A default OS-dependent value:
  * linux: `$XDG_DATA_HOME/kitops`, falling back to `~/.local/share/kitops`
  * windows: `%LOCALAPPDATA\kitops`
  * darwin: `~/Library/Caches/kitops`

If a suitable directory cannot be found (e.g. `$HOME` is not set), print an error message telling the user to either use the `--config` flag or set the `$KITOPS_HOME` environment variable.