### PR TITLE
Update the cache-dependency-path in the pages workflow

### DIFF
--- a/.github/workflows/build-deploy-docs.yaml
+++ b/.github/workflows/build-deploy-docs.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+          cache-dependency-path: docs
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Install dependencies


### PR DESCRIPTION
This PR updates the path of the cached dependencies for pnpm.