### PR TITLE
Add license headers to files, improve in-code documentation slightly

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,6 +33,16 @@ jobs:
             exit 1
           fi
 
+      - name: Check license headers
+        run: |
+          go install github.com/google/addlicense@latest
+          if ! addlicense --check -f license-header.txt $(find . -name '*.go'); then
+            echo "License headers missing from Go files (see above)."
+            echo "Install addlicense via 'go install github.com/google/addlicense@latest'"
+            echo "And run 'addlicense -f license-header.txt \$(find . -name '*.go')'"
+            exit 1
+          fi
+
       - name: Check build
         run: |
           if ! go build -o kit; then

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/docs/src/docs/cli/gen-doc.go
+++ b/docs/src/docs/cli/gen-doc.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,0 +1,15 @@
+Copyright 2024 The KitOps Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/artifact/kit-file.go
+++ b/pkg/artifact/kit-file.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package artifact
 
 import (

--- a/pkg/artifact/model.go
+++ b/pkg/artifact/model.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package artifact
 
 import "kitops/pkg/lib/constants"

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package info
 
 import (

--- a/pkg/cmd/info/info.go
+++ b/pkg/cmd/info/info.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package info
 
 import (

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package inspect
 
 import (

--- a/pkg/cmd/inspect/inspect.go
+++ b/pkg/cmd/inspect/inspect.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package inspect
 
 import (

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package list
 
 import (

--- a/pkg/cmd/list/list_test.go
+++ b/pkg/cmd/list/list_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package list
 
 import (

--- a/pkg/cmd/list/remote.go
+++ b/pkg/cmd/list/remote.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package list
 
 import (

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package login
 
 import (

--- a/pkg/cmd/logout/logout.go
+++ b/pkg/cmd/logout/logout.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package logout
 
 import (

--- a/pkg/cmd/options/common.go
+++ b/pkg/cmd/options/common.go
@@ -4,6 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// NetworkOptions represent common networking-related flags that are used by multiple commands.
+// The flags should be added to the command via AddNetworkFlags before running.
 type NetworkOptions struct {
 	PlainHTTP bool
 	TlsVerify bool

--- a/pkg/cmd/options/common.go
+++ b/pkg/cmd/options/common.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package options
 
 import (

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -71,7 +71,7 @@ func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) {
 			output.Fatalf("Failed to process configuration: %s", err)
 			return
 		}
-		err = RunPack(cmd.Context(), opts)
+		err = runPack(cmd.Context(), opts)
 		if err != nil {
 			output.Fatalf("Failed to pack model kit: %s", err)
 			return

--- a/pkg/cmd/pack/cmd_test.go
+++ b/pkg/cmd/pack/cmd_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package pack
 
 import (

--- a/pkg/cmd/pack/cmd_test.go
+++ b/pkg/cmd/pack/cmd_test.go
@@ -28,7 +28,7 @@ func TestPackOptions_RunPack(t *testing.T) {
 		contextDir: "/path/to/context",
 	}
 
-	err := RunPack(context.Background(), options)
+	err := runPack(context.Background(), options)
 
 	assert.NoError(t, err)
 }

--- a/pkg/cmd/pack/pack.go
+++ b/pkg/cmd/pack/pack.go
@@ -23,7 +23,7 @@ func RunPack(ctx context.Context, options *packOptions) error {
 
 	// 2. package the Code
 	for _, code := range kitfile.Code {
-		codePath, err := filesystem.VerifySubpath(options.contextDir, code.Path)
+		codePath, _, err := filesystem.VerifySubpath(options.contextDir, code.Path)
 		if err != nil {
 			return err
 		}
@@ -36,7 +36,7 @@ func RunPack(ctx context.Context, options *packOptions) error {
 
 	// 3. package the DataSets
 	for _, dataset := range kitfile.DataSets {
-		datasetPath, err := filesystem.VerifySubpath(options.contextDir, dataset.Path)
+		datasetPath, _, err := filesystem.VerifySubpath(options.contextDir, dataset.Path)
 		if err != nil {
 			return err
 		}
@@ -49,7 +49,7 @@ func RunPack(ctx context.Context, options *packOptions) error {
 
 	// 4. package the TrainedModel
 	if kitfile.Model != nil {
-		modelPath, err := filesystem.VerifySubpath(options.contextDir, kitfile.Model.Path)
+		modelPath, _, err := filesystem.VerifySubpath(options.contextDir, kitfile.Model.Path)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pack/pack.go
+++ b/pkg/cmd/pack/pack.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package pack
 
 import (

--- a/pkg/cmd/pack/pack.go
+++ b/pkg/cmd/pack/pack.go
@@ -11,7 +11,14 @@ import (
 	"kitops/pkg/output"
 )
 
-func RunPack(ctx context.Context, options *packOptions) error {
+// runPack compresses and stores a modelkit based on a Kitfile. Returns an error if packing
+// fails for any reason, or if any path in the Kitfile is not a subdirectory of the current
+// context directory.
+//
+// Packed modelkits are saved to the local on-disk cache. As OCI-spec indexes only support one
+// registry/repository reference at a time, individual blobs may be duplicated on disk if stored
+// under different references.
+func runPack(ctx context.Context, options *packOptions) error {
 	// 1. Read the model file
 	kitfile := &artifact.KitFile{}
 	if err := kitfile.LoadModel(options.modelFile); err != nil {

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package pull
 
 import (

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package push
 
 import (

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package remove
 
 import (

--- a/pkg/cmd/remove/remove.go
+++ b/pkg/cmd/remove/remove.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package remove
 
 import (

--- a/pkg/cmd/tag/cmd.go
+++ b/pkg/cmd/tag/cmd.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tag
 
 import (

--- a/pkg/cmd/tag/tag.go
+++ b/pkg/cmd/tag/tag.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tag
 
 import (

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package unpack
 
 import (

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -20,6 +20,9 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
+// unpackModel fetches and unpacks a *registry.Reference from an oras.Target. It returns an error if
+// unpacking fails, or if any path specified in the modelkit is not a subdirectory of the current
+// unpack target directory.
 func unpackModel(ctx context.Context, store oras.Target, ref *registry.Reference, options *unpackOptions) error {
 	manifestDesc, err := store.Resolve(ctx, ref.Reference)
 	if err != nil {

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package unpack
 
 import (

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import (

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -10,11 +10,14 @@ import (
 type ConfigKey struct{}
 
 const (
-	DefaultKitFileName  = "Kitfile"
+	// Default name for Kitfile (otherwise specified via the -f flag in pack)
+	DefaultKitFileName = "Kitfile"
+	// Constants for the directory structure of kit's cached images and credentials
+	// Modelkits are stored in <configpath>/kitops/storage/ and
+	// credentials are stored in <configpath>/kitops/credentials.json
 	DefaultConfigSubdir = "kitops"
-
-	StorageSubpath     = "storage"
-	CredentialsSubpath = "credentials.json"
+	StorageSubpath      = "storage"
+	CredentialsSubpath  = "credentials.json"
 
 	// Media type for the model layer
 	ModelLayerMediaType = "application/vnd.kitops.modelkit.model.v1.tar+gzip"
@@ -26,6 +29,11 @@ const (
 	ModelConfigMediaType = "application/vnd.kitops.modelkit.config.v1+json"
 )
 
+// DefaultConfigPath returns the default configuration and cache directory for the CLI.
+// This is platform-dependent, using
+//   - $XDG_DATA_HOME/kitops on Linux, with fall back to $HOME/.local/share/kitops
+//   - ~/Library/Caches/kitops on MacOS
+//   - %LOCALAPPDATA%\kitops
 func DefaultConfigPath() (string, error) {
 	switch runtime.GOOS {
 	case "linux":
@@ -69,6 +77,8 @@ func CredentialsPath(configBase string) string {
 	return filepath.Join(configBase, CredentialsSubpath)
 }
 
-func IndexJsonPath(configBase string) string {
-	return filepath.Join(configBase, "index.json")
+// IndexJsonPath is a wrapper for getting the index.json path for a local OCI index,
+// based off the base path of the index.
+func IndexJsonPath(storageBase string) string {
+	return filepath.Join(storageBase, "index.json")
 }

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package constants
 
 import (

--- a/pkg/lib/filesystem/paths.go
+++ b/pkg/lib/filesystem/paths.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package filesystem
 
 import (

--- a/pkg/lib/filesystem/paths.go
+++ b/pkg/lib/filesystem/paths.go
@@ -11,39 +11,45 @@ import (
 
 // VerifySubpath checks that filepath.Join(context, subDir) is a subdirectory of context, following
 // symlinks if present.
-func VerifySubpath(context, subDir string) (absPath string, err error) {
+func VerifySubpath(context, subDir string) (absPath, relPath string, err error) {
 	if filepath.IsAbs(subDir) {
-		return "", fmt.Errorf("absolute paths are not supported (%s)", subDir)
+		return "", "", fmt.Errorf("absolute paths are not supported (%s)", subDir)
 	}
 
-	// Get absolute path for context and context + subDir
+	// Get absolute path for context
 	absContext, err := filepath.Abs(context)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve absolute path for %s: %w", context, err)
+		return "", "", fmt.Errorf("failed to resolve absolute path for %s: %w", context, err)
 	}
-	fullPath := filepath.Clean(filepath.Join(absContext, subDir))
+	if _, exists := PathExists(absContext); exists {
+		res, err := filepath.EvalSymlinks(absContext)
+		if err != nil {
+			return "", "", fmt.Errorf("error resolving %s: %w", absContext, err)
+		}
+		absContext = res
+	}
 
-	// Get actual paths, ignoring symlinks along the way
-	resolvedContext, err := filepath.EvalSymlinks(absContext)
-	if err != nil {
-		return "", fmt.Errorf("error resolving %s: %w", absContext, err)
-	}
-	resolvedFullPath, err := filepath.EvalSymlinks(fullPath)
-	if err != nil {
-		return "", fmt.Errorf("error resolving %s: %w", absContext, err)
+	// Get absolute path for context + subpath
+	fullPath := filepath.Clean(filepath.Join(absContext, subDir))
+	if _, exists := PathExists(fullPath); exists {
+		res, err := filepath.EvalSymlinks(fullPath)
+		if err != nil {
+			return "", "", fmt.Errorf("error resolving %s: %w", absContext, err)
+		}
+		fullPath = res
 	}
 
 	// Get relative path between context and the full path to check if the
 	// actual full, absolute path is a subdirectory of context
-	relPath, err := filepath.Rel(resolvedContext, resolvedFullPath)
+	relPath, err = filepath.Rel(absContext, fullPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to get relative path: %w", err)
+		return "", "", fmt.Errorf("failed to get relative path: %w", err)
 	}
 	if strings.Contains(relPath, "..") {
-		return "", fmt.Errorf("paths must be within context directory")
+		return "", "", fmt.Errorf("paths must be within context directory")
 	}
 
-	return resolvedFullPath, nil
+	return fullPath, relPath, nil
 }
 
 func PathExists(path string) (fs.FileInfo, bool) {

--- a/pkg/lib/network/auth.go
+++ b/pkg/lib/network/auth.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/pkg/lib/network/auth.go
+++ b/pkg/lib/network/auth.go
@@ -20,6 +20,8 @@ func NewCredentialStore(storePath string) (credentials.Store, error) {
 	})
 }
 
+// ClientWithAuth returns a default *auth.Client using the provided credentials
+// store
 func ClientWithAuth(store credentials.Store, opts *ClientOpts) *auth.Client {
 	client := DefaultClient(opts)
 	client.Credential = credentials.Credential(store)
@@ -27,6 +29,8 @@ func ClientWithAuth(store credentials.Store, opts *ClientOpts) *auth.Client {
 	return client
 }
 
+// DefaultClient returns an *auth.Client with a default User-Agent header and TLS
+// configured from opts (optionally disabling TLS verification)
 func DefaultClient(opts *ClientOpts) *auth.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if opts.TLSSkipVerify {

--- a/pkg/lib/repo/local.go
+++ b/pkg/lib/repo/local.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package repo
 
 import (

--- a/pkg/lib/repo/registry.go
+++ b/pkg/lib/repo/registry.go
@@ -15,6 +15,8 @@ type RegistryOptions struct {
 	CredentialsPath string
 }
 
+// NewRegistry returns a new *remote.Registry for hostname, with credentials and TLS
+// configured.
 func NewRegistry(hostname string, opts *RegistryOptions) (*remote.Registry, error) {
 	reg, err := remote.NewRegistry(hostname)
 	if err != nil {

--- a/pkg/lib/repo/registry.go
+++ b/pkg/lib/repo/registry.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package repo
 
 import (

--- a/pkg/lib/repo/repo.go
+++ b/pkg/lib/repo/repo.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package repo
 
 import (

--- a/pkg/lib/repo/repo.go
+++ b/pkg/lib/repo/repo.go
@@ -30,7 +30,11 @@ var (
 // references conform to an expected structure, with a defined registry and repository by filling
 // default values for registry and repository where appropriate. Where the first part of a reference
 // doesn't look like a registry URL, the default registry is used, turning e.g. testorg/testrepo into
-// localhost/testorg/testrepo.
+// localhost/testorg/testrepo. If refString does not contain a registry or a repository (i.e. is a
+// base SHA256 hash), the returned reference uses placeholder values for registry and repository.
+//
+// See FormatRepositoryForDisplay for removing default values from a registry for displaying to the
+// user.
 func ParseReference(refString string) (ref *registry.Reference, extraTags []string, err error) {
 	// Check if provided input is a plain digest
 	if _, err := digest.Parse(refString); err == nil {
@@ -84,10 +88,14 @@ func FormatRepositoryForDisplay(repo string) string {
 	return repo
 }
 
+// RepoPath returns the path that should be used for creating a local OCI index given a
+// specific *registry.Reference.
 func RepoPath(storagePath string, ref *registry.Reference) string {
 	return filepath.Join(storagePath, ref.Registry, ref.Repository)
 }
 
+// GetManifestAndConfig returns the manifest and config (Kitfile) for a manifest Descriptor.
+// Calls GetManifest and GetConfig.
 func GetManifestAndConfig(ctx context.Context, store content.Storage, manifestDesc ocispec.Descriptor) (*ocispec.Manifest, *artifact.KitFile, error) {
 	manifest, err := GetManifest(ctx, store, manifestDesc)
 	if err != nil {
@@ -100,6 +108,8 @@ func GetManifestAndConfig(ctx context.Context, store content.Storage, manifestDe
 	return manifest, config, nil
 }
 
+// GetManifest returns the Manifest described by a Descriptor. Returns an error if the manifest blob cannot be
+// resolved or does not represent a modelkit manifest.
 func GetManifest(ctx context.Context, store content.Storage, manifestDesc ocispec.Descriptor) (*ocispec.Manifest, error) {
 	manifestBytes, err := content.FetchAll(ctx, store, manifestDesc)
 	if err != nil {
@@ -116,7 +126,12 @@ func GetManifest(ctx context.Context, store content.Storage, manifestDesc ocispe
 	return manifest, nil
 }
 
+// GetConfig returns the config (Kitfile) described by a descriptor. Returns an error if the config blob cannot
+// be resolved or if the descriptor does not describe a Kitfile.
 func GetConfig(ctx context.Context, store content.Storage, configDesc ocispec.Descriptor) (*artifact.KitFile, error) {
+	if configDesc.MediaType != constants.ModelConfigMediaType {
+		return nil, fmt.Errorf("configuration descriptor does not describe a Kitfile")
+	}
 	configBytes, err := content.FetchAll(ctx, store, configDesc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config: %w", err)
@@ -128,6 +143,7 @@ func GetConfig(ctx context.Context, store content.Storage, configDesc ocispec.De
 	return config, nil
 }
 
+// ResolveManifest returns the manifest for a reference (tag), if present in the target store
 func ResolveManifest(ctx context.Context, store oras.Target, reference string) (*ocispec.Manifest, error) {
 	desc, err := store.Resolve(ctx, reference)
 	if err != nil {
@@ -136,6 +152,8 @@ func ResolveManifest(ctx context.Context, store oras.Target, reference string) (
 	return GetManifest(ctx, store, desc)
 }
 
+// ResolveManifestAndConfig returns the manifest and config (Kitfile) for a given reference (tag), if present
+// in the store. Calls ResolveManifest and GetConfig.
 func ResolveManifestAndConfig(ctx context.Context, store oras.Target, reference string) (*ocispec.Manifest, *artifact.KitFile, error) {
 	manifest, err := ResolveManifest(ctx, store, reference)
 	if err != nil {
@@ -148,6 +166,7 @@ func ResolveManifestAndConfig(ctx context.Context, store oras.Target, reference 
 	return manifest, config, nil
 }
 
+// GetTagsForDescriptor returns the list of tags that reference a particular descriptor (SHA256 hash) in LocalStorage.
 func GetTagsForDescriptor(ctx context.Context, store LocalStorage, desc ocispec.Descriptor) ([]string, error) {
 	index, err := store.GetIndex()
 	if err != nil {

--- a/pkg/lib/repo/repo_test.go
+++ b/pkg/lib/repo/repo_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package repo
 
 import (

--- a/pkg/lib/storage/layer.go
+++ b/pkg/lib/storage/layer.go
@@ -15,7 +15,11 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func compressLayer(layer *artifact.ModelLayer) (string, ocispec.Descriptor, error) {
+// compressLayer compresses an *artifact.ModelLayer to a gzipped tar file. In order to return
+// a descriptor (including hash) for the compressed file, the layer is saved to a temporary file
+// on disk and must be moved to an appropriate location. It is the responsibility of the caller
+// to clean up the temporary file when it is no longer needed.
+func compressLayer(layer *artifact.ModelLayer) (tempFilePath string, desc ocispec.Descriptor, err error) {
 	pathInfo, err := os.Stat(layer.Path)
 	if err != nil {
 		return "", ocispec.DescriptorEmptyJSON, err
@@ -69,7 +73,7 @@ func compressLayer(layer *artifact.ModelLayer) (string, ocispec.Descriptor, erro
 	}
 	callAndPrintError(tempFile.Close, "Failed to close temporary file: %s")
 
-	desc := ocispec.Descriptor{
+	desc = ocispec.Descriptor{
 		MediaType: layer.MediaType,
 		Digest:    digester.Digest(),
 		Size:      tempFileInfo.Size(),
@@ -77,6 +81,8 @@ func compressLayer(layer *artifact.ModelLayer) (string, ocispec.Descriptor, erro
 	return tempFileName, desc, nil
 }
 
+// writeDirToTar walks the filesystem at basePath, compressing contents via the *tar.Writer.
+// Any non-regular files and directories (e.g. symlinks) are skipped.
 func writeDirToTar(basePath string, tw *tar.Writer) error {
 	// We'll want paths in the tarball to be relative to the *parent* of basePath since we want
 	// to compress the directory pointed at by basePath
@@ -133,6 +139,8 @@ func writeFileToTar(file string, fi os.FileInfo, tw *tar.Writer) error {
 	return nil
 }
 
+// callAndPrintError is a wrapper to print an error message for a function that
+// may return an error. The error is printed and then discarded.
 func callAndPrintError(f func() error, msg string) {
 	if err := f(); err != nil {
 		output.Errorf(msg, err)

--- a/pkg/lib/storage/layer.go
+++ b/pkg/lib/storage/layer.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage
 
 import (

--- a/pkg/lib/storage/local.go
+++ b/pkg/lib/storage/local.go
@@ -17,6 +17,9 @@ import (
 	"oras.land/oras-go/v2"
 )
 
+// SaveModel saves an *artifact.Model to the provided oras.Target, compressing layers. It attempts to block
+// modelkits that include paths that leave the base context directory, allowing only subdirectories of the root
+// context to be included in the modelkit.
 func SaveModel(ctx context.Context, store oras.Target, model *artifact.Model, tag string) (*ocispec.Descriptor, error) {
 	configDesc, err := saveConfigFile(ctx, store, model.Config)
 	if err != nil {

--- a/pkg/lib/storage/local.go
+++ b/pkg/lib/storage/local.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage
 
 import (

--- a/pkg/output/logging.go
+++ b/pkg/output/logging.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package output
 
 import (


### PR DESCRIPTION
### Description

* Fix subpaths check when packing/unpacking, restore checking subpaths when unpacking modelkits
* Add license header to all Golang files, add PR check step to verify license header is present before merging
    * I believe the tool can be used on non-Go files as well, if we want to tack headers on js files that were written for this repository
* Add a bit of documentation to functions that was somewhat lacking.