### PR TITLE
Set gon.hcl per-arch to ensure the right file is signed on darwin

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,21 +8,21 @@ before:
     - go mod tidy
 
 builds:
-  - id: "kit-linux-windows"
+  - id: "kit"
     env:
       - CGO_ENABLED=0
     goos:
       - linux
       - windows
     binary: kit
-
     ldflags:
       - -s -w -X kitops/pkg/cmd/version.Version={{.Version}} -X kitops/pkg/cmd/version.GitCommit={{.Commit}} -X kitops/pkg/cmd/version.BuildTime={{.Date}}
+
   - id: "kit-macos"
     env:
       - CGO_ENABLED=0
     goos:
-        - darwin
+      - darwin
     goarch:
       - amd64
       - arm64
@@ -30,7 +30,18 @@ builds:
     ldflags:
       - -s -w -X kitops/pkg/cmd/version.Version={{.Version}} -X kitops/pkg/cmd/version.GitCommit={{.Commit}} -X kitops/pkg/cmd/version.BuildTime={{.Date}}
     hooks:
-      post: gon gon.hcl
+      post: |-
+        sh -c '
+        cat <<EOF > /tmp/kit-gon.hcl
+        source = ["./dist/kit-macos_darwin_{{ .Arch }}{{- if .Amd64 }}_{{ .Amd64 }}{{ end }}/kit"]
+        bundle_id = "com.jozu-ai.kitops"
+        apple_id {}
+        sign {
+          application_identity = "Developer ID Application: AKARA TECHNOLOGIES, INC. (PMHBCVV9C2)"
+        }
+        EOF
+        gon /tmp/kit-gon.hcl
+        '
 
 archives:
   - format: tar.gz

--- a/gon.hcl
+++ b/gon.hcl
@@ -1,9 +1,0 @@
-source = ["./dist/kit-macos_darwin_amd64_v1/kit"]
-bundle_id = "com.jozu-ai.kitops"
-
-apple_id {
-}
-
-sign {
- application_identity = "Developer ID Application: AKARA TECHNOLOGIES, INC. (PMHBCVV9C2)"
-}


### PR DESCRIPTION
### Description

Goreleaser outputs the built binary to an OS and architecture-dependent directory, meaning the `gon.hcl` configuration file has to use a different source for arm64 vs amd64 builds.

To work around this issue, write a new `gon.hcl` before running `gon` to ensure `source` points at the right directory. This idea is taken [from `fzf`](https://github.com/junegunn/fzf/blob/8977c9257a8093a82a2cffa4f7e6974e43206ef4/.goreleaser.yml)

Note that the amd64 directory has `_v1` appended to it (see: [doc](https://goreleaser.com/customization/builds/#why-is-there-a-_v1-suffix-on-amd64-builds), hence the ugly Golang templating workaround.