### PR TITLE
Add '--all' flag to kit remove

### DIFF
--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -355,15 +355,27 @@ kit remove [flags] registry/repository[:tag|@digest]
 ### Examples
 
 ```
+# Remove modelkit by tag
 kit remove my-registry.com/my-org/my-repo:my-tag
+
+# Remove modelkit by digest
 kit remove my-registry.com/my-org/my-repo@sha256:<digest>
+
+# Remove multiple tags for a modelkit
 kit remove my-registry.com/my-org/my-repo:tag1,tag2,tag3
+
+# Remove all untagged modelkits
+kit remove --all
+
+# Remove all locally stored modelkits
+kit remove --all --force
 ```
 
 ### Options
 
 ```
-  -f, --force   remove manifest even if other tags refer to it
+  -a, --all     remove all untagged modelkits
+  -f, --force   remove modelkit and all other tags that refer to it
   -h, --help    help for remove
 ```
 

--- a/pkg/lib/repo/repo.go
+++ b/pkg/lib/repo/repo.go
@@ -190,7 +190,7 @@ func GetTagsForDescriptor(ctx context.Context, store LocalStorage, desc ocispec.
 	}
 	var tags []string
 	for _, manifest := range index.Manifests {
-		if manifest.Digest == desc.Digest {
+		if manifest.Digest == desc.Digest && manifest.Annotations[ocispec.AnnotationRefName] != "" {
 			tags = append(tags, manifest.Annotations[ocispec.AnnotationRefName])
 		}
 	}


### PR DESCRIPTION
### Description

Add flag `--all` (shorthand `-a`) to kit remove to help with cleaning up local storage:

Remove untagged modelkits:
```
kit remove --all
```

Remove all modelkits, including tagged ones (i.e. untag all modelkits, then remove):
```
kit remove --all --force
```

### Testing
To quickly generate a bunch of tagged and untagged images, you can use the following two-liner:
```bash
for i in {1..5}; do echo -e "manifestVersion: v1.0.0\npackage:\n  name: '$i'" > Kitfile; kit pack -t test:removeall .; rm Kitfile; done
for i in {1..5}; do kit tag test:removeall test:$i; done
```
this will generate five manifests: four untagged and one that has six tags. From here it's easier to test that the `-a` flag works as expected.