### PR TITLE
Package MacOS binaries to a zip and notarize them

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
       - windows
     binary: kit
     ldflags:
-      - -s -w -X kitops/pkg/cmd/version.Version={{.Version}} -X kitops/pkg/cmd/version.GitCommit={{.Commit}} -X kitops/pkg/cmd/version.BuildTime={{.Date}}
+      - -s -w -X kitops/pkg/cmd/version.Version={{.Version}} -X kitops/pkg/cmd/version.GitCommit={{.Commit}} -X kitops/pkg/cmd/version.BuildTime={{.CommitDate}}
 
   - id: "kit-macos"
     env:
@@ -28,16 +28,21 @@ builds:
       - arm64
     binary: kit
     ldflags:
-      - -s -w -X kitops/pkg/cmd/version.Version={{.Version}} -X kitops/pkg/cmd/version.GitCommit={{.Commit}} -X kitops/pkg/cmd/version.BuildTime={{.Date}}
+      - -s -w -X kitops/pkg/cmd/version.Version={{.Version}} -X kitops/pkg/cmd/version.GitCommit={{.Commit}} -X kitops/pkg/cmd/version.BuildTime={{.CommitDate}}
     hooks:
       post: |-
         sh -c '
         cat <<EOF > /tmp/kit-gon.hcl
         source = ["./dist/kit-macos_darwin_{{ .Arch }}{{- if .Amd64 }}_{{ .Amd64 }}{{ end }}/kit"]
         bundle_id = "com.jozu-ai.kitops"
-        apple_id {}
+        apple_id {
+          provider = "PMHBCVV9C2"
+        }
         sign {
           application_identity = "Developer ID Application: AKARA TECHNOLOGIES, INC. (PMHBCVV9C2)"
+        }
+        zip {
+          output_path = "./dist/kitops-darwin-{{ .Arch }}.zip"
         }
         EOF
         gon /tmp/kit-gon.hcl
@@ -45,6 +50,8 @@ builds:
 
 archives:
   - format: tar.gz
+    builds:
+      - kit
     name_template: >-
       {{ .ProjectName }}-
       {{- tolower .Os }}-
@@ -56,6 +63,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+
 
 changelog:
   sort: asc


### PR DESCRIPTION
### Description

Try to get notarizing working as well. This change skips packaging darwin builds as `.tar.gz` and instead packages them into zips.