### PR TITLE
Discard zip used for MacOS notarizing; package as .tar.gz instead

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,7 +42,7 @@ builds:
           application_identity = "Developer ID Application: AKARA TECHNOLOGIES, INC. (PMHBCVV9C2)"
         }
         zip {
-          output_path = "./dist/kitops-darwin-{{ .Arch }}.zip"
+          output_path = "/tmp/signing/kitops-darwin-{{ .Arch }}.zip"
         }
         EOF
         gon /tmp/kit-gon.hcl
@@ -52,6 +52,7 @@ archives:
   - format: tar.gz
     builds:
       - kit
+      - kit-macos
     name_template: >-
       {{ .ProjectName }}-
       {{- tolower .Os }}-


### PR DESCRIPTION
### Description

Build the zip file that is used for notarizing in a temporary directory and discard it during the build, as it does not include the license and readme. Instead, bundle the signed (and sent for notarization) binary in the normal .tar.gz to include license, readme, etc.

As zip files (and bare executables) cannot be stapled, it should make no difference how they are bundled for download.