### PR TITLE
doc: fix invalid example

### DIFF
--- a/pkg/artifact/kit-file.md
+++ b/pkg/artifact/kit-file.md
@@ -94,8 +94,8 @@ datasets:
     description: Description of the dataset.
     license: CC-BY-4.0
     preprocessing: Preprocessing steps.
-models:
-  - name: ModelName
+model:
+    name: ModelName
     path: models/model.h5
     framework: TensorFlow
     version: 1.0


### PR DESCRIPTION
Fixes a typo on the example at the docs.