### PR TITLE
Return clearer error messages when failing to parse a reference

### DIFF
--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -75,7 +75,7 @@ func InfoCommand() *cobra.Command {
 func runCommand(opts *infoOptions) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to parse arguments: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 		config, err := getInfo(cmd.Context(), opts)
 		if err != nil {

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -75,7 +75,7 @@ func InspectCommand() *cobra.Command {
 func runCommand(opts *inspectOptions) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to parse arguments: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 		manifest, err := inspectReference(cmd.Context(), opts)
 		if err != nil {

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -104,7 +104,7 @@ func ListCommand() *cobra.Command {
 func runCommand(opts *listOptions) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to parse argument: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		var allInfoLines []string

--- a/pkg/cmd/login/cmd.go
+++ b/pkg/cmd/login/cmd.go
@@ -62,7 +62,7 @@ func LoginCommand() *cobra.Command {
 func runLogin(opts *loginOptions) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to process flags: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		err := login(cmd.Context(), opts)

--- a/pkg/cmd/logout/cmd.go
+++ b/pkg/cmd/logout/cmd.go
@@ -43,7 +43,7 @@ func LogoutCommand() *cobra.Command {
 func runLogout(opts *logoutOptions) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to process flags: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 		err := logout(cmd.Context(), opts.registry, opts.credentialStoreHome)
 		if err != nil {

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -68,7 +68,7 @@ func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		err := opts.complete(cmd.Context(), args)
 		if err != nil {
-			output.Fatalf("Failed to process configuration: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 			return
 		}
 		err = runPack(cmd.Context(), opts)
@@ -96,7 +96,7 @@ func (opts *packOptions) complete(ctx context.Context, args []string) error {
 	if opts.fullTagRef != "" {
 		modelRef, extraRefs, err := repo.ParseReference(opts.fullTagRef)
 		if err != nil {
-			return fmt.Errorf("failed to parse reference '%s': %w", opts.fullTagRef, err)
+			return fmt.Errorf("failed to parse reference: %w", err)
 		}
 		opts.modelRef = modelRef
 		opts.extraRefs = extraRefs

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -96,7 +96,7 @@ func (opts *packOptions) complete(ctx context.Context, args []string) error {
 	if opts.fullTagRef != "" {
 		modelRef, extraRefs, err := repo.ParseReference(opts.fullTagRef)
 		if err != nil {
-			return fmt.Errorf("failed to parse reference %s: %w", opts.fullTagRef, err)
+			return fmt.Errorf("failed to parse reference '%s': %w", opts.fullTagRef, err)
 		}
 		opts.modelRef = modelRef
 		opts.extraRefs = extraRefs

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -53,7 +53,7 @@ func (opts *pullOptions) complete(ctx context.Context, args []string) error {
 
 	modelRef, extraTags, err := repo.ParseReference(args[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference %s: %w", modelRef, err)
+		return fmt.Errorf("failed to parse reference '%s': %w", modelRef, err)
 	}
 	if modelRef.Registry == "localhost" {
 		return fmt.Errorf("registry is required when pulling")

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -53,7 +53,7 @@ func (opts *pullOptions) complete(ctx context.Context, args []string) error {
 
 	modelRef, extraTags, err := repo.ParseReference(args[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference '%s': %w", modelRef, err)
+		return fmt.Errorf("failed to parse reference: %w", err)
 	}
 	if modelRef.Registry == "localhost" {
 		return fmt.Errorf("registry is required when pulling")
@@ -85,7 +85,7 @@ func PullCommand() *cobra.Command {
 func runCommand(opts *pullOptions) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to process arguments: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 		remoteRegistry, err := repo.NewRegistry(opts.modelRef.Registry, &repo.RegistryOptions{
 			PlainHTTP:       opts.PlainHTTP,

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -58,7 +58,7 @@ func (opts *pushOptions) complete(ctx context.Context, args []string) error {
 
 	modelRef, extraTags, err := repo.ParseReference(args[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference %s: %w", modelRef, err)
+		return fmt.Errorf("failed to parse reference '%s': %w", modelRef, err)
 	}
 	if modelRef.Registry == "localhost" {
 		return fmt.Errorf("registry is required when pushing")

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -58,7 +58,7 @@ func (opts *pushOptions) complete(ctx context.Context, args []string) error {
 
 	modelRef, extraTags, err := repo.ParseReference(args[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference '%s': %w", modelRef, err)
+		return fmt.Errorf("failed to parse reference: %w", err)
 	}
 	if modelRef.Registry == "localhost" {
 		return fmt.Errorf("registry is required when pushing")
@@ -90,7 +90,7 @@ func PushCommand() *cobra.Command {
 func runCommand(opts *pushOptions) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to process arguments: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		remoteRegistry, err := repo.NewRegistry(opts.modelRef.Registry, &repo.RegistryOptions{

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -72,7 +72,7 @@ func (opts *removeOptions) complete(ctx context.Context, args []string) error {
 	if len(args) > 0 {
 		modelRef, extraTags, err := repo.ParseReference(args[0])
 		if err != nil {
-			return fmt.Errorf("failed to parse reference '%s': %w", modelRef, err)
+			return fmt.Errorf("failed to parse reference: %w", err)
 		}
 		opts.modelRef = modelRef
 		opts.extraTags = extraTags
@@ -118,7 +118,7 @@ func RemoveCommand() *cobra.Command {
 func runCommand(opts *removeOptions) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to process arguments: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		var err error

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -72,7 +72,7 @@ func (opts *removeOptions) complete(ctx context.Context, args []string) error {
 	if len(args) > 0 {
 		modelRef, extraTags, err := repo.ParseReference(args[0])
 		if err != nil {
-			return fmt.Errorf("failed to parse reference %s: %w", modelRef, err)
+			return fmt.Errorf("failed to parse reference '%s': %w", modelRef, err)
 		}
 		opts.modelRef = modelRef
 		opts.extraTags = extraTags

--- a/pkg/cmd/tag/cmd.go
+++ b/pkg/cmd/tag/cmd.go
@@ -82,13 +82,13 @@ func (opts *tagOptions) complete(ctx context.Context, args []string) error {
 	opts.configHome = configHome
 	modelRef, _, err := repo.ParseReference(args[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference '%s': %w", args[0], err)
+		return fmt.Errorf("failed to parse reference: %w", err)
 	}
 	opts.sourceRef = modelRef
 
 	modelRef, _, err = repo.ParseReference(args[1])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference '%s': %w", args[1], err)
+		return fmt.Errorf("failed to parse reference: %w", err)
 	}
 	opts.targetRef = modelRef
 	return nil
@@ -111,7 +111,7 @@ func TagCommand() *cobra.Command {
 func runCommand(opts *tagOptions) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to parse argument: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		err := RunTag(cmd.Context(), opts)

--- a/pkg/cmd/tag/cmd.go
+++ b/pkg/cmd/tag/cmd.go
@@ -82,12 +82,13 @@ func (opts *tagOptions) complete(ctx context.Context, args []string) error {
 	opts.configHome = configHome
 	modelRef, _, err := repo.ParseReference(args[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference %s: %w", opts.sourceRef, err)
+		return fmt.Errorf("failed to parse reference '%s': %w", args[0], err)
 	}
 	opts.sourceRef = modelRef
+
 	modelRef, _, err = repo.ParseReference(args[1])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference %s: %w", opts.targetRef, err)
+		return fmt.Errorf("failed to parse reference '%s': %w", args[1], err)
 	}
 	opts.targetRef = modelRef
 	return nil

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -78,7 +78,7 @@ func (opts *unpackOptions) complete(ctx context.Context, args []string) error {
 	opts.configHome = configHome
 	modelRef, extraTags, err := repo.ParseReference(args[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference '%s': %w", args[0], err)
+		return fmt.Errorf("failed to parse reference: %w", err)
 	}
 	if len(extraTags) > 0 {
 		return fmt.Errorf("can not unpack multiple tags")
@@ -123,7 +123,7 @@ func UnpackCommand() *cobra.Command {
 func runCommand(opts *unpackOptions) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Failed to process arguments: %s", err)
+			output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		if opts.modelRef.Reference == "" {

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -78,7 +78,7 @@ func (opts *unpackOptions) complete(ctx context.Context, args []string) error {
 	opts.configHome = configHome
 	modelRef, extraTags, err := repo.ParseReference(args[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse reference %s: %w", args[0], err)
+		return fmt.Errorf("failed to parse reference '%s': %w", args[0], err)
 	}
 	if len(extraTags) > 0 {
 		return fmt.Errorf("can not unpack multiple tags")

--- a/pkg/lib/repo/repo.go
+++ b/pkg/lib/repo/repo.go
@@ -39,7 +39,8 @@ const (
 )
 
 var (
-	validTagRegex = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$`)
+	validTagRegex        = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$`)
+	startEndAlphanumeric = regexp.MustCompile(`[a-z0-9].*[a-z0-9]`)
 )
 
 // ParseReference parses a reference string into a Reference struct. It attempts to make
@@ -51,7 +52,7 @@ var (
 //
 // See FormatRepositoryForDisplay for removing default values from a registry for displaying to the
 // user.
-func ParseReference(refString string) (ref *registry.Reference, extraTags []string, err error) {
+func ParseReference(refString string) (reference *registry.Reference, extraTags []string, err error) {
 	// Check if provided input is a plain digest
 	if _, err := digest.Parse(refString); err == nil {
 		ref := &registry.Reference{
@@ -62,29 +63,81 @@ func ParseReference(refString string) (ref *registry.Reference, extraTags []stri
 		return ref, []string{}, nil
 	}
 
-	// Handle registry, which may or may not be specified; if unspecified, use a default value for registry
-	refParts := strings.Split(refString, "/")
-	if len(refParts) == 1 {
-		// Just a repo, need to add default registry
-		refString = fmt.Sprintf("%s/%s", DefaultRegistry, refString)
+	var reg, repo, ref, unprocessed string
+	hasDigest := false
+	hasTag := false
+
+	// Trim extra tags, if present
+	parts := strings.Split(refString, ",")
+	unprocessed = parts[0]
+	extraTags = parts[1:]
+
+	// Split off registry
+	parts = strings.SplitN(unprocessed, "/", 2)
+	if len(parts) == 1 {
+		// Just a repo, use default registry
+		reg = DefaultRegistry
 	} else {
 		// Check if registry part "looks" like a URL; we're trying to distinguish between cases:
 		// a) testorg/testrepo --> should be localhost/testorg/testrepo
 		// b) registry.io/testrepo --> should be registry.io/testrepo
 		// c) localhost:5000/testrepo --> should be localhost:5000/testrepo
-		registry := refParts[0]
-		if !strings.Contains(registry, ":") && !strings.Contains(registry, ".") {
-			refString = fmt.Sprintf("%s/%s", DefaultRegistry, refString)
+		reg = parts[0]
+		if !strings.Contains(reg, ":") && !strings.Contains(reg, ".") {
+			reg = DefaultRegistry
+		} else {
+			unprocessed = parts[1]
 		}
 	}
 
-	// Split off extra tags (e.g. repo:tag1,tag2,tag3)
-	refAndTags := strings.Split(refString, ",")
-	baseRef, err := registry.ParseReference(refAndTags[0])
-	if err != nil {
+	// Split tags/digest from repository
+	if index := strings.Index(unprocessed, "@"); index != -1 {
+		hasDigest = true
+		repo = unprocessed[:index]
+		ref = unprocessed[index+1:]
+		if index := strings.Index(repo, ":"); index != -1 {
+			repo = repo[:index]
+		}
+	} else if index := strings.Index(unprocessed, ":"); index != -1 {
+		hasTag = true
+		repo = unprocessed[:index]
+		ref = unprocessed[index+1:]
+	} else {
+		// No tag or digest
+		repo = unprocessed
+	}
+
+	// Check for common errors
+	if strings.ToLower(repo) != repo {
+		return nil, nil, fmt.Errorf("repository (%s) name must be lowercase", repo)
+	}
+	if !startEndAlphanumeric.MatchString(repo) {
+		return nil, nil, fmt.Errorf("repository (%s) must start and end with a letter or number", repo)
+	}
+
+	reference = &registry.Reference{
+		Registry:   reg,
+		Repository: repo,
+		Reference:  ref,
+	}
+	// Do full checks in case we missed something
+	if err := reference.ValidateRegistry(); err != nil {
 		return nil, nil, err
 	}
-	return &baseRef, refAndTags[1:], nil
+	if err := reference.ValidateRepository(); err != nil {
+		return nil, nil, err
+	}
+	if hasTag {
+		if err := reference.ValidateReferenceAsTag(); err != nil {
+			return nil, nil, err
+		}
+	} else if hasDigest {
+		if err := reference.ValidateReferenceAsDigest(); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return reference, extraTags, nil
 }
 
 // DefaultReference returns a reference that can be used when no reference is supplied. It uses


### PR DESCRIPTION
### Description

Re-implement ParseReference to avoid unclear error messages. Instead, return a user-friendly error if e.g. the repository has an uppercase letter:

```
❯ kit tag mymodel:latest MyModel:latest
Failed to parse argument: failed to parse reference 'MyModel:latest': repository (MyModel) name must be lowercase
```