### PR TITLE
Add a new blog post and sort posts by date desc

### DIFF
--- a/docs/.vitepress/theme/posts.json
+++ b/docs/.vitepress/theme/posts.json
@@ -3,5 +3,10 @@
     "url": "https://www.gorkem-ercan.com/p/do-data-scientists-really-like-git",
     "tags": ["thought leadership"],
     "published_time": "2024-02-27"
+  },
+  {
+    "url": "https://dev.to/jwilliamsr/the-transitory-nature-of-mlops-advocating-for-devopsmlops-coalescence-1k6j",
+    "tags": ["ai", "devops", "open source", "machine learning"],
+    "published_time": "2024-03-25"
   }
 ]

--- a/docs/src/blog.md
+++ b/docs/src/blog.md
@@ -3,8 +3,13 @@ layout: page
 sidebar: false
 ---
 <script setup lang="ts">
+import { computed } from 'vue'
 import Blog from '@theme/components/Blog.vue'
 import { data as posts } from '@theme/blog.data.ts'
+
+const sortedPost = computed(() =>
+  posts.toSorted((a, z) => z.published_time.localeCompare(a.published_time))
+)
 </script>
 
-<Blog :posts="posts" />
+<Blog :posts="sortedPost" />


### PR DESCRIPTION
This PR makes blog posts sorted by date DESC instead of relying in the given json order.

It also adds the most recent post published by @Jwilliamsr here: https://dev.to/jwilliamsr/the-transitory-nature-of-mlops-advocating-for-devopsmlops-coalescence-1k6j

## Preview

![image](https://github.com/jozu-ai/kitops/assets/4766570/349caf4c-b56b-4ba0-a00d-fc486b4bec1f)
