### PR TITLE
Add Hits tracker to readme + Gorkem's Blog to feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Language](https://img.shields.io/badge/Language-go-blue.svg)](https://go.dev/)
 [![Discord](https://img.shields.io/discord/1098133460310294528?logo=Discord)](https://discord.gg/3eDb4yAN)
 [![Twitter](https://img.shields.io/twitter/url/http/shields.io.svg?style=social&label=Twitter)](https://twitter.com/kit_ops)
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fjozu-ai%2Fkitops&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)
 
 [![Official Website](<https://img.shields.io/badge/-Visit%20the%20Official%20Website%20%E2%86%92-rgb(255,175,82)?style=for-the-badge>)](https://kitops.ml/?utm_source=github&utm_medium=kitops-readme)
 [![Use Cases](<https://img.shields.io/badge/-KitOps%20Quick%20Start%20%E2%86%92-rgb(122,140,225)?style=for-the-badge>)](https://kitops.ml/?utm_source=github&utm_medium=kitops-readme)

--- a/docs/.vitepress/theme/posts.json
+++ b/docs/.vitepress/theme/posts.json
@@ -8,5 +8,10 @@
     "url": "https://dev.to/jwilliamsr/the-transitory-nature-of-mlops-advocating-for-devopsmlops-coalescence-1k6j",
     "tags": ["ai", "devops", "open source", "machine learning"],
     "published_time": "2024-03-25"
+  },
+  {
+    "url": "https://thenewstack.io/beyond-git-a-new-collaboration-model-for-ai-ml-development/",
+    "tags": ["git", "devops", "open source", "machine learning"],
+    "published_time": "2024-04-02"
   }
 ]


### PR DESCRIPTION
Hits tracker gives us more detailed visits to the repo that we can track easier than the github traffic dashboard.