### PR TITLE
Fix capitalization of custom tags

### DIFF
--- a/docs/.vitepress/theme/blog.data.ts
+++ b/docs/.vitepress/theme/blog.data.ts
@@ -39,7 +39,7 @@ export default {
         const image = getMetaTag('image') || $('meta[property="og:image:url"]').attr('content')
         const icon = $('link[rel="icon"]').attr('href') || $('link[rel="shortcut icon"]').attr('href') || $('link[rel="alternate icon"]').attr('href')
         const author = getMetaTag('author')
-        const published_time = $('meta[property="article:published_time"]').attr('content') || post.published_time
+        const published_time = post.published_time || $('meta[property="article:published_time"]').attr('content')
         const tags = post.tags || []
 
         return {

--- a/docs/.vitepress/theme/components/Blog.vue
+++ b/docs/.vitepress/theme/components/Blog.vue
@@ -22,6 +22,14 @@ const tagsColorsMap = [
   { normal: '!border-tea hocus:!bg-tea hocus:!text-night !text-tea', selected: '!border-tea !bg-tea !text-night', post: 'hocus:!border-tea' },
 ]
 
+// There are custom acronyms that must go with custom capitalization or fully uppercase.
+// eg. AWS, AI, DevOps, etc.
+// Those are listed here and replaced as specified.
+const customCapitalTags = {
+  'ai': 'AI',
+  'devops': 'DevOps'
+}
+
 const formatDate = (raw: string) => {
   const date = new Date(raw)
   date.setUTCHours(12)
@@ -90,7 +98,7 @@ watchEffect(() => {
             [getColorForTag(tag).selected]: selectedTag === tag
           }"
           @click="filterByTag(tag)">
-          {{ tag }}
+          {{ customCapitalTags[tag] || tag }}
         </button>
       </li>
     </ul>
@@ -107,7 +115,7 @@ watchEffect(() => {
           v-for="tag in post.tags" :key="tag"
           class="tag"
           :class="getColorForTag(tag).selected">
-          {{ tag }}
+          {{ customCapitalTags[tag] || tag }}
         </span>
         <time v-if="post.published_time"
           :datetime="post.published_time"

--- a/docs/.vitepress/theme/posts.json
+++ b/docs/.vitepress/theme/posts.json
@@ -7,6 +7,7 @@
   {
     "url": "https://dev.to/jwilliamsr/the-transitory-nature-of-mlops-advocating-for-devopsmlops-coalescence-1k6j",
     "tags": ["ai", "devops", "open source", "machine learning"],
+    "author": "Jesse Williams",
     "published_time": "2024-03-25"
   },
   {


### PR DESCRIPTION
This PR:
- adds a missing author in one of the blog posts
- adds custom capitalization for some tags (DevOps instead of Devops, AI instead of Ai)
- Fixes a tiny bug in the published_time property for blog posts

## Preview

<img width="1376" alt="image" src="https://github.com/jozu-ai/kitops/assets/4766570/383ee4f4-4f56-4d73-b1bd-736d70b00fc5">
