### PR TITLE
Wrap install buttons in ga4 trackers

### DIFF
--- a/docs/.vitepress/theme/components/Home.vue
+++ b/docs/.vitepress/theme/components/Home.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Vue3Marquee } from 'vue3-marquee'
+import vGaTrack from '../directives/ga'
 </script>
 
 <template>
@@ -8,8 +9,8 @@ import { Vue3Marquee } from 'vue3-marquee'
   <h1 class="mt-4">Bridge the gap between ML and Application teams</h1>
 
   <div class="flex flex-col lg:flex-row justify-center items-center gap-10 lg:gap-4 mt-10 md:mt-14 xl:mt-22">
-    <a href="/docs/cli/installation" class="kit-button">Install</a>
-    <a href="https://github.com/jozu-ai/kitops" class="kit-button bg-none border-transparent hover:text-gold hover:bg-transparent hover:opacity-[80%]">Source Code</a>
+    <a href="/docs/cli/installation" v-ga-track="{ category: 'button', label: 'install', location: 'hero' }" class="kit-button">Install</a>
+    <a href="https://github.com/jozu-ai/kitops" v-ga-track="{ category: 'button', label: 'source code', location: 'hero' }" class="kit-button bg-none border-transparent hover:text-gold hover:bg-transparent hover:opacity-[80%]">Source Code</a>
   </div>
 </div>
 
@@ -88,7 +89,7 @@ import { Vue3Marquee } from 'vue3-marquee'
       <div class="h4 font-bold !text-salmon">1</div>
       <div class="mt-8 flex flex-col flex-1 justify-between">
         <p class="p2">Download and install Kit CLI.</p>
-        <a href="/docs/cli/installation" class="kit-button kit-button-salmon md:w-fit mt-6">Install the CLI</a>
+        <a href="/docs/cli/installation" v-ga-track="{ category: 'button', label: 'install', location: 'get started' }" class="kit-button kit-button-salmon md:w-fit mt-6">Install the CLI</a>
       </div>
     </div>
 
@@ -200,7 +201,7 @@ import { Vue3Marquee } from 'vue3-marquee'
   <h2 class="text-center">How to Get inVolVeD<span class="font-heading font-extralight">?</span></h2>
 
   <div class="space-y-6 w-fit mx-auto mt-22">
-    <a href="https://discord.gg/Tapeh8agYy" class="border border-gray-02 p-8 md:px-14 md:py-10 flex justify-between gap-8 items-center hover:border-gold transition-colors">
+    <a href="https://discord.gg/Tapeh8agYy" v-ga-track="{ category: 'button', label: 'join the kitops discord', location: 'how to get involved' }" class="border border-gray-02 p-8 md:px-14 md:py-10 flex justify-between gap-8 items-center hover:border-gold transition-colors">
       <div class="p1">Join the KitOps Discord</div>
 
       <div class="size-8 md:size-12">
@@ -217,7 +218,7 @@ import { Vue3Marquee } from 'vue3-marquee'
       </div>
     </a>
 
-    <a href="https://github.com/jozu-ai/kitops" class="border border-gray-02 p-8 md:px-14 md:py-10 flex justify-between gap-8 items-center hover:border-gold transition-colors">
+    <a href="https://github.com/jozu-ai/kitops" v-ga-track="{ category: 'button', label: 'contribute to kit', location: 'how to get involved' }" class="border border-gray-02 p-8 md:px-14 md:py-10 flex justify-between gap-8 items-center hover:border-gold transition-colors">
       <div class="p1">Contribute to Kit</div>
 
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none" class="size-8 md:size-12">
@@ -225,7 +226,7 @@ import { Vue3Marquee } from 'vue3-marquee'
       </svg>
     </a>
 
-    <a href="https://github.com/jozu-ai/kitops" class="border border-gray-02 p-8 md:px-14 md:py-10 flex justify-between gap-8 items-center hover:border-gold transition-colors">
+    <a href="https://github.com/jozu-ai/kitops" v-ga-track="{ category: 'button', label: 'star the repo', location: 'how to get involved' }" class="border border-gray-02 p-8 md:px-14 md:py-10 flex justify-between gap-8 items-center hover:border-gold transition-colors">
       <div class="p1">Star the repo on GitHub</div>
 
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none" class="size-8 md:size-12">

--- a/docs/.vitepress/theme/components/PlatformSelect.vue
+++ b/docs/.vitepress/theme/components/PlatformSelect.vue
@@ -2,6 +2,7 @@
 import { type Ref, inject, ref, onMounted } from 'vue'
 import { useLocalStorage } from '@vueuse/core'
 import { getUserOS } from '@theme/utils'
+import vGaTrack from '@theme/directives/ga'
 
 let documentClassList:DOMTokenList
 
@@ -41,6 +42,7 @@ const changePlatform = () => {
     <select
       @change="changePlatform"
       v-model="selectedPlatform"
+      v-ga-track="{ category: 'select', action: 'change', label: 'platform selector switch', location: 'sidebar' }"
       aria-label="select your preferred platform">
       <option value="mac">Mac</option>
       <option value="windows">Windows</option>
@@ -70,6 +72,7 @@ const changePlatform = () => {
                 changePlatform();
                 closeModal();
               }"
+              v-ga-track="{ category: 'select', action: 'change', label: 'platform selector switch', location: 'platform switch modal' }"
               v-model="selectedPlatform"
               aria-label="select your preferred platform">
               <option value="mac">Mac</option>

--- a/docs/.vitepress/theme/directives/ga.ts
+++ b/docs/.vitepress/theme/directives/ga.ts
@@ -1,0 +1,40 @@
+import type { DirectiveBinding } from 'vue'
+
+// Common tracking function to keep it DRY
+function trackEvent(action, binding: DirectiveBinding) {
+  // Category, action and label are needed, the rest is custom, per implementation
+  const { category, label, ...values } = binding
+
+  return (event: InputEvent | Event) => {
+
+    const parameters = {
+      event_category: category,
+      event_label: label,
+      value: event?.target?.value || values?.value,
+      ...values,
+    }
+
+    // Call the gtag function to track the event
+    window.gtag('event', action, parameters);
+  }
+}
+
+export default {
+  // When mounted, add the bindings...
+  mounted(el: HTMLElement, binding: DirectiveBinding) {
+    if (typeof binding.value !== 'object') {
+      console.error('Directive value must be an object')
+      return;
+    }
+
+    // Attach the given event/action
+    const action = binding.value.action || 'click'
+    el.addEventListener(action, trackEvent(action, binding.value));
+  },
+
+  beforeUnmount(el: HTMLElement, binding: DirectiveBinding) {
+    // Remove the listener when destroying the directive instance
+    const action = binding.value.action || 'click'
+    el.removeEventListener(action, trackEvent(action, binding.value));
+  }
+};

--- a/docs/src/docs/cli/installation.md
+++ b/docs/src/docs/cli/installation.md
@@ -1,3 +1,7 @@
+<script setup>
+import vGaTrack from '@theme/directives/ga'
+</script>
+
 # Installation Guide for `kit` CLI
 
 ## Installation from GitHub Releases
@@ -7,9 +11,21 @@ Welcome to the installation guide for the `kit`! This guide is designed to help 
 
 To begin, you will need to download the latest version of `kit`. You can find the most recent release on the official GitHub releases page:
 
-[Download the latest `kit` release](https://github.com/jozu-ai/kitops/releases/latest)
+<a href="https://github.com/jozu-ai/kitops/releases/latest"
+  v-ga-track="{
+    category: 'link',
+    label: 'download the latest kit',
+    location: 'docs/installation'
+  }">
+  Download the latest `kit`
+</a>
 
-Or, if you're feeling frisky try the cutting edge [`next` release](https://github.com/jozu-ai/kitops/releases/latest). Just remember that's not fully tested so YMMV.
+Or, if you're feeling frisky try the cutting edge <a href="https://github.com/jozu-ai/kitops/releases/latest"
+  v-ga-track="{
+    category: 'link',
+    label: 'download next release',
+    location: 'docs/installation'
+  }">`next` release</a>. Just remember that's not fully tested so YMMV.
 
 #### Selecting the Correct Version for Your Platform
 

--- a/docs/src/docs/cli/installation.md
+++ b/docs/src/docs/cli/installation.md
@@ -17,7 +17,7 @@ To begin, you will need to download the latest version of `kit`. You can find th
     label: 'download the latest kit',
     location: 'docs/installation'
   }">
-  Download the latest `kit`
+  Download the latest `kit` release
 </a>
 
 Or, if you're feeling frisky try the cutting edge <a href="https://github.com/jozu-ai/kitops/releases/latest"

--- a/docs/src/docs/quick-start.md
+++ b/docs/src/docs/quick-start.md
@@ -47,7 +47,12 @@ You'll see `Log in successful`.
 
 Let's unpack a sample ModelKit to our machine that we can play with. In this case we'll unpack the whole thing, but one of the great things about Kit is that you can also selectively unpack only the thigs you need: just the model, the model and dataset, the code, the configuration...whatever you want. Check out the `unpack` [command reference](./cli/cli-reference.md) for details.
 
-You can grab [any of the ModelKits](https://github.com/orgs/jozu-ai/packages) from our site, but we've chosen a small language model example below.
+You can grab <a href="https://github.com/orgs/jozu-ai/packages"
+  v-ga-track="{
+    category: 'link',
+    label: 'grab any of the ModelKits',
+    location: 'docs/quick-start'
+  }">any of the ModelKits</a>from our site, but we've chosen a small language model example below.
 
 ```sh
 kit unpack ghcr.io/jozu-ai/modelkit-examples/finetuning_slm:latest

--- a/docs/src/docs/why-kitops.md
+++ b/docs/src/docs/why-kitops.md
@@ -8,7 +8,7 @@ Jupyter notebooks are great, but extracting the model, datasets, and metadata fr
 
 Worse yet, none of these AI/ML tools are compatible with the toolchains organizations have successfully used for years with their applications.
 
-With leaders demanding teams "add AI/ML" to their protfolios, many have fallen into a "throw it over the wall and hope it works" process that adds risk, delay, and frustration to self-hosting models.
+With leaders demanding teams "add AI/ML" to their portfolios, many have fallen into a "throw it over the wall and hope it works" process that adds risk, delay, and frustration to self-hosting models.
 
 > **The goal of KitOps is to simplify the sharing of AI/ML models, datasets, code, and configuration so that they can be run anywhere.**
 


### PR DESCRIPTION
This PR fixes #141 .

It adds a new Vue Directive to track GA events and implements it in:
- the sidebar `select platorm` dropdown
- the `change platform modal` select
- all the buttons in the home / landing page
- relevant links in the docs (install, downloads, discord, etc).