### PR TITLE
Include the directive source in the quick-start.md

### DIFF
--- a/docs/src/docs/quick-start.md
+++ b/docs/src/docs/quick-start.md
@@ -1,3 +1,7 @@
+<script setup>
+import vGaTrack from '@theme/directives/ga'
+</script>
+
 # KitOps Quick Start
 
 In this guide, we'll use ModelKits and the kit CLI to easily:


### PR DESCRIPTION
Forgot to actually import the directive in the `quick-start.md` file, which was breaking the docs build.