### PR TITLE
Ensure target directory exists when unpacking

### DIFF
--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -49,6 +49,11 @@ func unpackModel(ctx context.Context, store oras.Target, ref *registry.Reference
 		return fmt.Errorf("failed to read local model: %s", err)
 	}
 
+	// Make sure target directory exists, in case user is using the -d flag
+	if err := os.MkdirAll(options.unpackDir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", options.unpackDir, err)
+	}
+
 	if options.unpackConf.unpackConfig {
 		if err := unpackConfig(config, options.unpackDir, options.overwrite); err != nil {
 			return err


### PR DESCRIPTION
### Description

Make sure that the target directory for unpack exists before attempting to unpack blobs, in case the user has used `-d` to specify a non-existent directory.

Fixes #204 