### PR TITLE
FAQ: Update the cursor and fix the marker in Safari

### DIFF
--- a/docs/.vitepress/theme/components/Accordion.vue
+++ b/docs/.vitepress/theme/components/Accordion.vue
@@ -29,10 +29,11 @@ const props = withDefaults(defineProps<{
 
 <style scoped>
 details summary {
-  @apply flex justify-between text-off-white;
+  @apply flex justify-between text-off-white cursor-pointer;
 }
 
-details summary::marker {
+details summary::marker,
+details summary::-webkit-details-marker {
   content: '';
   display: none;
 }


### PR DESCRIPTION
This PR fixes a small css issue in Safari. Firefox and Chrome are OK.

## Before

![image](https://github.com/jozu-ai/kitops/assets/4766570/e09f4f3d-e90f-441d-b440-958a2533c826)


## After

![image](https://github.com/jozu-ai/kitops/assets/4766570/caa065c2-7783-4143-b87e-07fdb55f213c)
