### PR TITLE
Add discord link tracking

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,8 +3,8 @@
 Welcome to our project! We use GitHub for tracking bugs and feature requests.
 
 If you need other types of help try:
-* [User Documentation - TODO](TODO)
-* [Discord - TODO](TODO)
+* View our [product documentation](https://kitops.ml/docs/overview.html)
+* Join the [KitOps Discord](https://discord.gg/Tapeh8agYy)
 * Join our [public office hours meeting](./GOVERNANCE.md)
 
 ## Enterprise Support

--- a/docs/discord-tracking.md
+++ b/docs/discord-tracking.md
@@ -1,0 +1,13 @@
+# Locations where discord links are
+
+Because our allegedly permanent discord links have needed to be refreshed a couple of times already...
+
+* ./README.md
+* ./CONTRIBUTING.md
+* ./GOVERNANCE.md
+* ./SUPPORT.mf
+* ./docs/.vitepress/config.mts
+* ./docs/.vitepress/theme/components/Footer.vue
+* ./docs/.vitepress/theme/components/Home.vue
+* ./docs/src/docs/next-steps.md
+* ./docs/src/docs/quick-start.md


### PR DESCRIPTION
In case we have to update our Discord server link (again) this file lists all the places where we have that link in the repo.

* New discord-tracking.md with list of where discord links live
* Added correct links to SUPPORT.md