### PR TITLE
Add functional testing for CLI operations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,8 @@ func RunCommand() *cobra.Command {
 		Short: shortDesc,
 		Long:  longDesc,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			output.SetOut(cmd.OutOrStdout())
+			output.SetErr(cmd.ErrOrStderr())
 			output.SetDebug(opts.verbose)
 			output.SetProgressBars(opts.enableProgressBars)
 

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -19,11 +19,11 @@ package list
 import (
 	"context"
 	"fmt"
+	"io"
 	"kitops/pkg/cmd/options"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/repo"
 	"kitops/pkg/output"
-	"os"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -121,13 +121,12 @@ func runCommand(opts *listOptions) func(*cobra.Command, []string) {
 			}
 			allInfoLines = lines
 		}
-
-		printSummary(allInfoLines)
+		printSummary(cmd.OutOrStdout(), allInfoLines)
 	}
 }
 
-func printSummary(lines []string) {
-	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 3, ' ', 0)
+func printSummary(w io.Writer, lines []string) {
+	tw := tabwriter.NewWriter(w, 0, 2, 3, ' ', 0)
 	fmt.Fprintln(tw, listTableHeader)
 	for _, line := range lines {
 		fmt.Fprintln(tw, line)

--- a/pkg/cmd/list/list.go
+++ b/pkg/cmd/list/list.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	listTableHeader = "REPOSITORY\tTAG\tMAINTAINER\tNAME\tSIZE\tDIGEST"
-	listTableFmt    = "%s\t%s\t%s\t%s\t%s\t%s\t"
+	listTableFmt    = "%s\t%s\t%s\t%s\t%s\t%s"
 )
 
 func listLocalKits(ctx context.Context, opts *listOptions) ([]string, error) {

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -138,7 +138,8 @@ func runCommand(opts *removeOptions) func(*cobra.Command, []string) {
 
 func printConfig(opts *removeOptions) {
 	if opts.modelRef != nil {
-		output.Debugf("Removing %s and additional tags: [%s]", opts.modelRef, strings.Join(opts.extraTags, ", "))
+		displayRef := repo.FormatRepositoryForDisplay(opts.modelRef.String())
+		output.Debugf("Removing %s and additional tags: [%s]", displayRef, strings.Join(opts.extraTags, ", "))
 	}
 	if opts.removeAll {
 		if opts.forceDelete {

--- a/pkg/cmd/remove/remove.go
+++ b/pkg/cmd/remove/remove.go
@@ -115,16 +115,18 @@ func removeModel(ctx context.Context, opts *removeOptions) error {
 	if err != nil {
 		return fmt.Errorf("Failed to remove: %s", err)
 	}
-	output.Infof("Removed %s (digest %s)", opts.modelRef.String(), desc.Digest)
+	displayRef := repo.FormatRepositoryForDisplay(opts.modelRef.String())
+	output.Infof("Removed %s (digest %s)", displayRef, desc.Digest)
 
 	for _, tag := range opts.extraTags {
 		ref := *opts.modelRef
 		ref.Reference = tag
+		displayRef := repo.FormatRepositoryForDisplay(ref.String())
 		desc, err := removeModelRef(ctx, localStore, &ref, opts.forceDelete)
 		if err != nil {
 			output.Errorf("Failed to remove tag %s: %s", tag, err)
 		} else {
-			output.Infof("Removed %s (digest %s)", ref.String(), desc.Digest)
+			output.Infof("Removed %s (digest %s)", displayRef, desc.Digest)
 		}
 	}
 	return nil
@@ -134,7 +136,7 @@ func removeModelRef(ctx context.Context, store repo.LocalStorage, ref *registry.
 	desc, err := oras.Resolve(ctx, store, ref.Reference, oras.ResolveOptions{})
 	if err != nil {
 		if err == errdef.ErrNotFound {
-			return ocispec.DescriptorEmptyJSON, fmt.Errorf("model %s not found", ref.String())
+			return ocispec.DescriptorEmptyJSON, fmt.Errorf("model %s not found", repo.FormatRepositoryForDisplay(ref.String()))
 		}
 		return ocispec.DescriptorEmptyJSON, fmt.Errorf("error resolving model: %s", err)
 	}

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -66,7 +66,7 @@ type unpackOptions struct {
 }
 
 type unpackConf struct {
-	unpackConfig   bool
+	unpackKitfile  bool
 	unpackModels   bool
 	unpackCode     bool
 	unpackDatasets bool
@@ -88,8 +88,8 @@ func (opts *unpackOptions) complete(ctx context.Context, args []string) error {
 	opts.modelRef = modelRef
 
 	conf := opts.unpackConf
-	if !conf.unpackConfig && !conf.unpackModels && !conf.unpackCode && !conf.unpackDatasets {
-		opts.unpackConf.unpackConfig = true
+	if !conf.unpackKitfile && !conf.unpackModels && !conf.unpackCode && !conf.unpackDatasets {
+		opts.unpackConf.unpackKitfile = true
 		opts.unpackConf.unpackModels = true
 		opts.unpackConf.unpackCode = true
 		opts.unpackConf.unpackDatasets = true
@@ -119,7 +119,7 @@ func UnpackCommand() *cobra.Command {
 	cmd.Args = cobra.ExactArgs(1)
 	cmd.Flags().StringVarP(&opts.unpackDir, "dir", "d", "", "The target directory to unpack components into. This directory will be created if it does not exist")
 	cmd.Flags().BoolVarP(&opts.overwrite, "overwrite", "o", false, "Overwrites existing files and directories in the target unpack directory without prompting")
-	cmd.Flags().BoolVar(&opts.unpackConf.unpackConfig, "config", false, "Unpack only config file")
+	cmd.Flags().BoolVar(&opts.unpackConf.unpackKitfile, "kitfile", false, "Unpack only Kitfile")
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackModels, "model", false, "Unpack only model")
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackCode, "code", false, "Unpack only code")
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackDatasets, "datasets", false, "Unpack only datasets")

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -49,7 +49,7 @@ func unpackModel(ctx context.Context, store oras.Target, ref *registry.Reference
 		return fmt.Errorf("Failed to read local model: %s", err)
 	}
 
-	if options.unpackConf.unpackConfig {
+	if options.unpackConf.unpackKitfile {
 		if err := unpackConfig(config, options.unpackDir, options.overwrite); err != nil {
 			return err
 		}

--- a/pkg/lib/repo/repo.go
+++ b/pkg/lib/repo/repo.go
@@ -152,8 +152,12 @@ func DefaultReference() *registry.Reference {
 // FormatRepositoryForDisplay removes default values from a repository string to avoid surfacing defaulted fields
 // when displaying references, which may be confusing.
 func FormatRepositoryForDisplay(repo string) string {
+	// Trim default registry, if present
 	repo = strings.TrimPrefix(repo, DefaultRegistry+"/")
+	// Trim default repository, if present
 	repo = strings.TrimPrefix(repo, DefaultRepository)
+	// Trim @ in case what's left is a bare digest
+	repo = strings.TrimPrefix(repo, "@")
 	return repo
 }
 

--- a/pkg/output/config.go
+++ b/pkg/output/config.go
@@ -16,9 +16,16 @@
 
 package output
 
+import (
+	"io"
+	"os"
+)
+
 var (
-	printDebug        = false
-	printProgressBars = true
+	printDebug                  = false
+	printProgressBars           = true
+	stdout            io.Writer = os.Stdout
+	stderr            io.Writer = os.Stderr
 )
 
 func SetDebug(debug bool) {
@@ -27,4 +34,12 @@ func SetDebug(debug bool) {
 
 func SetProgressBars(print bool) {
 	printProgressBars = print
+}
+
+func SetOut(w io.Writer) {
+	stdout = w
+}
+
+func SetErr(w io.Writer) {
+	stderr = w
 }

--- a/pkg/output/logging.go
+++ b/pkg/output/logging.go
@@ -26,40 +26,40 @@ import (
 )
 
 func Infoln(s any) {
-	fmt.Println(s)
+	fmt.Fprintln(stdout, s)
 }
 
 func Infof(s string, args ...any) {
-	printFmt(os.Stdout, s, args...)
+	printFmt(stdout, s, args...)
 }
 
 func Errorln(s any) {
-	fmt.Fprintln(os.Stderr, s)
+	fmt.Fprintln(stderr, s)
 }
 
 func Errorf(s string, args ...any) {
-	printFmt(os.Stderr, s, args...)
+	printFmt(stderr, s, args...)
 }
 
 func Fatalln(s any) {
-	fmt.Fprintln(os.Stderr, s)
+	fmt.Fprintln(stderr, s)
 	os.Exit(1)
 }
 
 func Fatalf(s string, args ...any) {
-	printFmt(os.Stderr, s, args...)
+	printFmt(stderr, s, args...)
 	os.Exit(1)
 }
 
 func Debugln(s any) {
 	if printDebug {
-		fmt.Println(s)
+		fmt.Fprintln(stdout, s)
 	}
 }
 
 func Debugf(s string, args ...any) {
 	if printDebug {
-		printFmt(os.Stdout, s, args...)
+		printFmt(stdout, s, args...)
 	}
 }
 

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -64,7 +64,7 @@ func (w *wrappedRepo) Push(ctx context.Context, expected ocispec.Descriptor, con
 // If output is configured to not print progress bars, this is a no-op.
 func WrapTarget(wrap oras.Target) (oras.Target, *ProgressLogger) {
 	if !shouldPrintProgress() {
-		return wrap, &ProgressLogger{os.Stdout}
+		return wrap, &ProgressLogger{stdout}
 	}
 	p := mpb.New(
 		mpb.WithWidth(60),
@@ -78,7 +78,7 @@ func WrapTarget(wrap oras.Target) (oras.Target, *ProgressLogger) {
 
 func WrapReadCloser(size int64, rc io.ReadCloser) (io.ReadCloser, *ProgressLogger) {
 	if !shouldPrintProgress() {
-		return rc, &ProgressLogger{os.Stdout}
+		return rc, &ProgressLogger{stdout}
 	}
 
 	p := mpb.New(

--- a/testing/pack-unpack_test.go
+++ b/testing/pack-unpack_test.go
@@ -1,0 +1,206 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"kitops/cmd"
+	"kitops/pkg/lib/constants"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+const modelKitTag = "test:test"
+
+type PackUnpackTestcase struct {
+	Name         string
+	Description  string   `yaml:"description"`
+	Kitfile      string   `yaml:"kitfile"`
+	Kitignore    string   `yaml:"kitignore"`
+	Files        []string `yaml:"files"`
+	IgnoredFiles []string `yaml:"ignored"`
+}
+
+// TestPackUnpack tests kit functionality by generating a file tree, packing it,
+// unpacking it, and verifying that the unpacked contents match expectations.
+// We work in a new temporary directory for each test to avoid interaction between
+// tests.
+func TestPackUnpack(t *testing.T) {
+	tests := loadAllTestCasesOrPanic(t, "testdata/pack-unpack")
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.Description), func(t *testing.T) {
+			// Set up temporary directory for work
+			tmpDir, err := os.MkdirTemp("", "kitops-testing-*")
+			if !assert.NoError(t, err) {
+				return
+			}
+			defer func() {
+				if err := os.RemoveAll(tmpDir); err != nil {
+					t.Logf("Error removing temp dir: %s", err)
+				}
+			}()
+			t.Logf("Using temp directory: %s", tmpDir)
+
+			// Set up paths to use for test
+			modelKitPath, unpackPath, contextPath := setupTestDirs(t, tmpDir)
+			t.Setenv("KITOPS_HOME", contextPath)
+
+			// Create Kitfile
+			kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
+			if err := os.WriteFile(kitfilePath, []byte(tt.Kitfile), 0644); err != nil {
+				t.Fatal(err)
+			}
+			// Create .kitignore, if it exists
+			if tt.Kitignore != "" {
+				ignorePath := filepath.Join(modelKitPath, constants.IgnoreFileName)
+				if err := os.WriteFile(ignorePath, []byte(tt.Kitignore), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// Create files for test case
+			setupFiles(t, modelKitPath, append(tt.Files, tt.IgnoredFiles...))
+
+			runCommand(t, "pack", modelKitPath, "-t", modelKitTag, "-v")
+			runCommand(t, "list")
+			runCommand(t, "unpack", modelKitTag, "-d", unpackPath, "-v")
+
+			checkFilesExist(t, unpackPath, tt.Files)
+			checkFilesDoNotExist(t, unpackPath, append(tt.IgnoredFiles, ".kitignore"))
+		})
+	}
+}
+
+// runCommand executes kit <args>, saving stdout/stderr output to a buffer
+// that is then printed through the test interface. If the kit command
+// calls `os.Exit`, this command will terminate without generating any logs.
+func runCommand(t *testing.T, args ...string) {
+	t.Logf("Running command: kit %s", strings.Join(args, " "))
+	runCmd := cmd.RunCommand()
+	runCmd.SetArgs(args)
+
+	// Set up buffer to capture command output
+	outbuf := &bytes.Buffer{}
+	runCmd.SetOut(outbuf)
+	runCmd.SetErr(outbuf)
+
+	err := runCmd.Execute()
+	if !assert.NoError(t, err, "Command returned error") {
+		return
+	}
+
+	outlog, err := io.ReadAll(outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Command output: \n%s", string(outlog))
+}
+
+// setupTestDirs generates the test directories used for storing $KIT_HOME, the original modelkit
+// and the unpacked modelkit as subdirectories of tmpDir.
+func setupTestDirs(t *testing.T, tmpDir string) (modelKitPath, unpackPath, contextPath string) {
+	// Set up paths to use for test
+	modelKitPath = filepath.Join(tmpDir, "test-modelkit-in")
+	unpackPath = filepath.Join(tmpDir, "test-modelkit-out")
+	contextPath = filepath.Join(tmpDir, ".kitops")
+	for _, path := range []string{modelKitPath, unpackPath, contextPath} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return
+}
+
+// setupFiles ensures that all paths in files exist within tmpDir. Directories along the
+// path are created if necessary, and files contain the text "testing: <filename>".
+func setupFiles(t *testing.T, tmpDir string, files []string) {
+	for _, file := range files {
+		path := filepath.Join(tmpDir, file)
+		dirName := filepath.Dir(path)
+		if err := os.MkdirAll(dirName, 0755); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("creating path %s", path)
+		if err := os.WriteFile(path, []byte("testing: "+file), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// checkFilesExist tests that every path listed in files exists within tmpDir, failing the
+// current test if not.
+func checkFilesExist(t *testing.T, tmpDir string, files []string) {
+	for _, file := range files {
+		path := filepath.Join(tmpDir, file)
+		stat, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				t.Errorf("File %s should exist", file)
+			} else {
+				t.Errorf("Unexpected error: %s", err)
+			}
+		} else {
+			assert.True(t, stat.Mode().IsRegular(), "Path %s should be regular file", path)
+		}
+	}
+}
+
+// checkFilesDoNotExist checks that none of the paths listed in files exist within tmpDir.
+func checkFilesDoNotExist(t *testing.T, tmpDir string, files []string) {
+	for _, file := range files {
+		path := filepath.Join(tmpDir, file)
+		_, err := os.Stat(path)
+		if err == nil {
+			t.Errorf("File %s should not exist", file)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("Unexpected error: %s", err)
+		}
+	}
+}
+
+func loadAllTestCasesOrPanic(t *testing.T, testsPath string) []PackUnpackTestcase {
+	files, err := os.ReadDir(testsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tests []PackUnpackTestcase
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		bytes, err := os.ReadFile(filepath.Join(testsPath, file.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		testcase := PackUnpackTestcase{}
+		if err := yaml.Unmarshal(bytes, &testcase); err != nil {
+			t.Fatal(err)
+		}
+		testcase.Name = file.Name()
+		tests = append(tests, testcase)
+	}
+	return tests
+}

--- a/testing/pack-unpack_test.go
+++ b/testing/pack-unpack_test.go
@@ -17,33 +17,13 @@
 package testing
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
-	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"kitops/cmd"
 	"kitops/pkg/lib/constants"
-
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
-
-const modelKitTag = "test:test"
-
-type PackUnpackTestcase struct {
-	Name         string
-	Description  string   `yaml:"description"`
-	Kitfile      string   `yaml:"kitfile"`
-	Kitignore    string   `yaml:"kitignore"`
-	Files        []string `yaml:"files"`
-	IgnoredFiles []string `yaml:"ignored"`
-}
 
 // TestPackUnpack tests kit functionality by generating a file tree, packing it,
 // unpacking it, and verifying that the unpacked contents match expectations.
@@ -54,16 +34,8 @@ func TestPackUnpack(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.Description), func(t *testing.T) {
 			// Set up temporary directory for work
-			tmpDir, err := os.MkdirTemp("", "kitops-testing-*")
-			if !assert.NoError(t, err) {
-				return
-			}
-			defer func() {
-				if err := os.RemoveAll(tmpDir); err != nil {
-					t.Logf("Error removing temp dir: %s", err)
-				}
-			}()
-			t.Logf("Using temp directory: %s", tmpDir)
+			tmpDir, removeTmp := setupTempDir(t)
+			defer removeTmp()
 
 			// Set up paths to use for test
 			modelKitPath, unpackPath, contextPath := setupTestDirs(t, tmpDir)
@@ -92,115 +64,4 @@ func TestPackUnpack(t *testing.T) {
 			checkFilesDoNotExist(t, unpackPath, append(tt.IgnoredFiles, ".kitignore"))
 		})
 	}
-}
-
-// runCommand executes kit <args>, saving stdout/stderr output to a buffer
-// that is then printed through the test interface. If the kit command
-// calls `os.Exit`, this command will terminate without generating any logs.
-func runCommand(t *testing.T, args ...string) {
-	t.Logf("Running command: kit %s", strings.Join(args, " "))
-	runCmd := cmd.RunCommand()
-	runCmd.SetArgs(args)
-
-	// Set up buffer to capture command output
-	outbuf := &bytes.Buffer{}
-	runCmd.SetOut(outbuf)
-	runCmd.SetErr(outbuf)
-
-	err := runCmd.Execute()
-	if !assert.NoError(t, err, "Command returned error") {
-		return
-	}
-
-	outlog, err := io.ReadAll(outbuf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("Command output: \n%s", string(outlog))
-}
-
-// setupTestDirs generates the test directories used for storing $KIT_HOME, the original modelkit
-// and the unpacked modelkit as subdirectories of tmpDir.
-func setupTestDirs(t *testing.T, tmpDir string) (modelKitPath, unpackPath, contextPath string) {
-	// Set up paths to use for test
-	modelKitPath = filepath.Join(tmpDir, "test-modelkit-in")
-	unpackPath = filepath.Join(tmpDir, "test-modelkit-out")
-	contextPath = filepath.Join(tmpDir, ".kitops")
-	for _, path := range []string{modelKitPath, unpackPath, contextPath} {
-		if err := os.MkdirAll(path, 0755); err != nil {
-			t.Fatal(err)
-		}
-	}
-	return
-}
-
-// setupFiles ensures that all paths in files exist within tmpDir. Directories along the
-// path are created if necessary, and files contain the text "testing: <filename>".
-func setupFiles(t *testing.T, tmpDir string, files []string) {
-	for _, file := range files {
-		path := filepath.Join(tmpDir, file)
-		dirName := filepath.Dir(path)
-		if err := os.MkdirAll(dirName, 0755); err != nil {
-			t.Fatal(err)
-		}
-		t.Logf("creating path %s", path)
-		if err := os.WriteFile(path, []byte("testing: "+file), 0644); err != nil {
-			t.Fatal(err)
-		}
-	}
-}
-
-// checkFilesExist tests that every path listed in files exists within tmpDir, failing the
-// current test if not.
-func checkFilesExist(t *testing.T, tmpDir string, files []string) {
-	for _, file := range files {
-		path := filepath.Join(tmpDir, file)
-		stat, err := os.Stat(path)
-		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				t.Errorf("File %s should exist", file)
-			} else {
-				t.Errorf("Unexpected error: %s", err)
-			}
-		} else {
-			assert.True(t, stat.Mode().IsRegular(), "Path %s should be regular file", path)
-		}
-	}
-}
-
-// checkFilesDoNotExist checks that none of the paths listed in files exist within tmpDir.
-func checkFilesDoNotExist(t *testing.T, tmpDir string, files []string) {
-	for _, file := range files {
-		path := filepath.Join(tmpDir, file)
-		_, err := os.Stat(path)
-		if err == nil {
-			t.Errorf("File %s should not exist", file)
-		} else if !errors.Is(err, fs.ErrNotExist) {
-			t.Errorf("Unexpected error: %s", err)
-		}
-	}
-}
-
-func loadAllTestCasesOrPanic(t *testing.T, testsPath string) []PackUnpackTestcase {
-	files, err := os.ReadDir(testsPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var tests []PackUnpackTestcase
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-		bytes, err := os.ReadFile(filepath.Join(testsPath, file.Name()))
-		if err != nil {
-			t.Fatal(err)
-		}
-		testcase := PackUnpackTestcase{}
-		if err := yaml.Unmarshal(bytes, &testcase); err != nil {
-			t.Fatal(err)
-		}
-		testcase.Name = file.Name()
-		tests = append(tests, testcase)
-	}
-	return tests
 }

--- a/testing/remove_test.go
+++ b/testing/remove_test.go
@@ -1,0 +1,302 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+import (
+	"fmt"
+	"kitops/pkg/lib/constants"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	testKitfile = `
+manifestVersion: 1.0.0
+package:
+  name: test-delete-modelkit
+model:
+  path: .
+`
+)
+
+func TestRemoveSingleModelkitTag(t *testing.T) {
+	// Set up temporary directory for work
+	tmpDir, removeTmp := setupTempDir(t)
+	defer removeTmp()
+
+	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv("KITOPS_HOME", contextPath)
+
+	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
+	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pack model kit and tag it
+	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:delete_testing", "-v")
+	digest := digestFromPack(t, packOut)
+	modelRegexp := fmt.Sprintf(`^test\s+delete_testing.*%s$`, digest)
+
+	// Ensure modelkit exists in output of 'kit list'
+	listOut := runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, modelRegexp, true)
+
+	// Remove modelkit and verify it's no longer in 'kit list'
+	runCommand(t, "remove", "test:delete_testing", "-v")
+	listOut = runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, modelRegexp, false)
+}
+
+func TestRemoveSingleModelkitDigest(t *testing.T) {
+	// Set up temporary directory for work
+	tmpDir, removeTmp := setupTempDir(t)
+	defer removeTmp()
+
+	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv("KITOPS_HOME", contextPath)
+
+	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
+	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pack model kit and tag it
+	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:delete_testing", "-v")
+	digest := digestFromPack(t, packOut)
+	modelRegexp := fmt.Sprintf(`^test\s+delete_testing.*%s$`, digest)
+
+	// Ensure modelkit exists in output of 'kit list'
+	listOut := runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, modelRegexp, true)
+
+	// Remove modelkit and verify it's no longer in 'kit list'
+	ref := fmt.Sprintf("test@%s", digest)
+	runCommand(t, "remove", ref, "-v")
+	listOut = runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, modelRegexp, false)
+}
+
+func TestRemoveSingleModelkitNoTag(t *testing.T) {
+	// Set up temporary directory for work
+	tmpDir, removeTmp := setupTempDir(t)
+	defer removeTmp()
+
+	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv("KITOPS_HOME", contextPath)
+
+	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
+	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pack model kit and tag it
+	packOut := runCommand(t, "pack", modelKitPath, "-v")
+	digest := digestFromPack(t, packOut)
+	modelRegexp := fmt.Sprintf(`^.*%s$`, digest)
+
+	// Ensure modelkit exists in output of 'kit list'
+	listOut := runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, modelRegexp, true)
+
+	// Remove modelkit and verify it's no longer in 'kit list'
+	runCommand(t, "remove", digest, "-v")
+	listOut = runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, modelRegexp, false)
+}
+
+func TestRemoveModelkitUntagsWhenMultiple(t *testing.T) {
+	// Set up temporary directory for work
+	tmpDir, removeTmp := setupTempDir(t)
+	defer removeTmp()
+
+	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv("KITOPS_HOME", contextPath)
+
+	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
+	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pack model kit and tag it
+	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:test_tag_1", "-v")
+	digest := digestFromPack(t, packOut)
+	firstModelRegexp := fmt.Sprintf(`^test\s+test_tag_1.*%s$`, digest)
+
+	runCommand(t, "tag", "test:test_tag_1", "test:test_tag_2", "-v")
+	secondModelRegexp := fmt.Sprintf(`^test\s+test_tag_2.*%s$`, digest)
+
+	// Ensure modelkit exists in output of 'kit list'
+	listOut := runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, firstModelRegexp, true)
+	assertContainsLineRegexp(t, listOut, secondModelRegexp, true)
+
+	// Remove modelkit and verify it's no longer in 'kit list'
+	runCommand(t, "remove", "test:test_tag_1", "-v")
+	listOut = runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, firstModelRegexp, false)
+	assertContainsLineRegexp(t, listOut, secondModelRegexp, true)
+}
+
+func TestRemoveModelkitUntagsAllWhenDigest(t *testing.T) {
+	// Set up temporary directory for work
+	tmpDir, removeTmp := setupTempDir(t)
+	defer removeTmp()
+
+	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv("KITOPS_HOME", contextPath)
+
+	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
+	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pack model kit and tag it
+	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:test_tag_1", "-v")
+	digest := digestFromPack(t, packOut)
+	firstModelRegexp := fmt.Sprintf(`^test\s+test_tag_1.*%s$`, digest)
+
+	runCommand(t, "tag", "test:test_tag_1", "test:test_tag_2", "-v")
+	secondModelRegexp := fmt.Sprintf(`^test\s+test_tag_2.*%s$`, digest)
+
+	// Ensure modelkit exists in output of 'kit list'
+	listOut := runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, firstModelRegexp, true)
+	assertContainsLineRegexp(t, listOut, secondModelRegexp, true)
+
+	// Remove modelkit and verify it's no longer in 'kit list'
+	ref := fmt.Sprintf("test@%s", digest)
+	runCommand(t, "remove", ref, "-v")
+	listOut = runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, firstModelRegexp, false)
+	assertContainsLineRegexp(t, listOut, secondModelRegexp, false)
+}
+
+func TestRemoveModelkitUntagged(t *testing.T) {
+	// Set up temporary directory for work
+	tmpDir, removeTmp := setupTempDir(t)
+	defer removeTmp()
+
+	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv("KITOPS_HOME", contextPath)
+
+	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
+	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pack model kit and tag it
+	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	digestOne := digestFromPack(t, packOut)
+	regexpOne := fmt.Sprintf("^test.*%s$", digestOne)
+
+	// Create files to pack with a different digests
+	setupFiles(t, modelKitPath, []string{"testfile-1"})
+	packOut = runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	digestTwo := digestFromPack(t, packOut)
+	regexpTwo := fmt.Sprintf("^test.*%s$", digestTwo)
+
+	setupFiles(t, modelKitPath, []string{"testfile-2"})
+	packOut = runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	digestThree := digestFromPack(t, packOut)
+	regexpThree := fmt.Sprintf(`^test\s+testing-tag.*%s$`, digestThree)
+
+	// Ensure modelkit exists in output of 'kit list'
+	listOut := runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, regexpOne, true)
+	assertContainsLineRegexp(t, listOut, regexpTwo, true)
+	assertContainsLineRegexp(t, listOut, regexpThree, true)
+
+	// Remove modelkit and verify it's no longer in 'kit list'
+	runCommand(t, "remove", "--all", "-v")
+	listOut = runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, regexpOne, false)
+	assertContainsLineRegexp(t, listOut, regexpTwo, false)
+	assertContainsLineRegexp(t, listOut, regexpThree, true)
+}
+
+func TestRemoveModelkitAll(t *testing.T) {
+	// Set up temporary directory for work
+	tmpDir, removeTmp := setupTempDir(t)
+	defer removeTmp()
+
+	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv("KITOPS_HOME", contextPath)
+
+	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
+	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pack model kit and tag it
+	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	digestOne := digestFromPack(t, packOut)
+	regexpOne := fmt.Sprintf("^test.*%s$", digestOne)
+
+	// Create files to pack with a different digests
+	setupFiles(t, modelKitPath, []string{"testfile-1"})
+	packOut = runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	digestTwo := digestFromPack(t, packOut)
+	regexpTwo := fmt.Sprintf("^test.*%s$", digestTwo)
+
+	setupFiles(t, modelKitPath, []string{"testfile-2"})
+	packOut = runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	digestThree := digestFromPack(t, packOut)
+	regexpThree := fmt.Sprintf(`^test\s+testing-tag.*%s$`, digestThree)
+
+	// Ensure modelkit exists in output of 'kit list'
+	listOut := runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, regexpOne, true)
+	assertContainsLineRegexp(t, listOut, regexpTwo, true)
+	assertContainsLineRegexp(t, listOut, regexpThree, true)
+
+	// Remove modelkit and verify it's no longer in 'kit list'
+	runCommand(t, "remove", "--all", "--force", "-v")
+	listOut = runCommand(t, "list")
+	assertContainsLineRegexp(t, listOut, regexpOne, false)
+	assertContainsLineRegexp(t, listOut, regexpTwo, false)
+	assertContainsLineRegexp(t, listOut, regexpThree, false)
+}
+
+func digestFromPack(t *testing.T, packOutput string) string {
+	digestRegexp := regexp.MustCompile(`Model saved: (sha256:\w+)`)
+	matches := digestRegexp.FindStringSubmatch(packOutput)
+	if len(matches) != 2 {
+		t.Fatal("Failed to find digest from 'kit pack' output")
+	}
+	t.Logf("Found digest from packing: %s", matches[1])
+	return matches[1]
+}
+
+func assertContainsLineRegexp(t *testing.T, output, lineRegexp string, shouldContain bool) {
+	re := regexp.MustCompile(lineRegexp)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	matches := false
+	for _, line := range lines {
+		if re.MatchString(line) {
+			matches = true
+		}
+	}
+	if shouldContain && !matches {
+		t.Fatalf("Output should include regexp %s", lineRegexp)
+	}
+	if !shouldContain && matches {
+		t.Fatalf("Output should not include regexp %s", lineRegexp)
+	}
+}

--- a/testing/testdata/README.md
+++ b/testing/testdata/README.md
@@ -1,0 +1,32 @@
+# Functional testing structure
+
+This directory contains subdirectories for various test cases for the Kit CLI. Each subdirectory is named based on what flow is being tested, and contains files describing a test case via the struct
+
+```yaml
+description: "Description of what the test is testing"
+kitfile: |
+  The Kitfile to use for the test
+kitignore: |
+  The .kitignore to use for the test
+files:
+  - A list of files that should be included in the modelkit
+  - E.g. "dir1/dir2/myfile.txt"
+  - Directories will be created as necessary
+ignored:
+  - A list of files that should exist in the context but should _not_ be included in the modelkit
+```
+
+Fields are optional and their usage depends on the test -- e.g. testing packing and unpacking will require `files:` and `ignored:`, whereas testing tagging does not require files necessarily.
+
+To generate a test case from an existing modelkit directory, you can use the following snippet:
+```bash
+cat <<EOF > new-test-case.yaml
+description: "enter your description"
+kitfile: |
+$(sed 's|^|  |g' Kitfile)
+kitignore: |
+$(sed 's|^|  |g' .kitignore)
+files: # Sort these into files vs ignored as necessary
+$(find . -type f | sed 's|^|  - |g')
+EOF
+```

--- a/testing/testdata/pack-unpack/test_empty-kitfile.yaml
+++ b/testing/testdata/pack-unpack/test_empty-kitfile.yaml
@@ -1,0 +1,10 @@
+description: Pack and unpack a basic modelkit
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-empty
+ignored:
+  - ./model/my-model.bin
+  - ./datasets/my-dataset.bin
+  - ./code/my-code.py
+  - some-file.txt

--- a/testing/testdata/pack-unpack/test_pack-basic-model.yaml
+++ b/testing/testdata/pack-unpack/test_pack-basic-model.yaml
@@ -1,0 +1,17 @@
+description: Pack and unpack a basic modelkit
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-basic
+  model:
+    name: test-model
+    path: ./model
+  datasets:
+    - name: test-dataset
+      path: ./datasets
+  code:
+    - path: ./code
+files:
+  - ./model/my-model.bin
+  - ./datasets/my-dataset.bin
+  - ./code/my-code.py

--- a/testing/testdata/pack-unpack/test_pack-ignores-basic.yaml
+++ b/testing/testdata/pack-unpack/test_pack-ignores-basic.yaml
@@ -1,0 +1,57 @@
+description: Pack and unpack with basic ignorefile
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-ignores
+  model:
+    name: test-ignores
+    path: .
+
+kitignore: |
+  # Ignore an entire directory
+  dir1
+  # Ignore a subdirectory
+  dir2/dirA
+  # Ignore a file in root
+  root-ignored.txt
+  # Ignore a file in a subdirectory
+  dir3/dir3-ignored.txt
+  # Ignore with wildcard
+  dir4/*/ignored-file.txt
+  # Ignore all with md extension
+  **/*.md
+  # Ignore all dirs with name
+  **/ignored
+  # Single character wildcard
+  ignored-?.txt
+  # Exclusions
+  !dir5/not-ignored.md
+
+files:
+  - dir2/file2.txt
+  - dir2/dirB/fileB.txt
+  - root-included.txt
+  - dir3/dir3-included.txt
+  - dir3/dirA/fileA.txt
+  - dir4/dirA/not-ignored
+  - dir4/dirB/not-ignored
+  - dir4/ignored-file.txt
+  - dir5/not-ignored.md
+
+ignored:
+  - dir1/dirA/fileA.txt
+  - dir1/file1.txt
+  - dir2/dirA/fileA.txt
+  - root-ignored.txt
+  - dir3/dir3-ignored.txt
+  - dir4/dirA/ignored-file.txt
+  - dir4/dirB/ignored-file.txt
+  - dir4/dirC/ignored-file.txt
+  - ignored-root.md
+  - dir2/ignored-dir2.md
+  - dir3/dirA/ignored-dirA.md
+  - dir2/ignored/ignored-file1.txt
+  - dir3/dirB/ignored/ignored-file2.txt
+  - ignored-a.txt
+  - ignored-b.txt
+  - ignored-1.txt

--- a/testing/testdata/pack-unpack/test_pack-ignores-intersecting.yaml
+++ b/testing/testdata/pack-unpack/test_pack-ignores-intersecting.yaml
@@ -1,0 +1,41 @@
+description: Pack and unpack when paths intersect
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-ignore-intersecting-dir
+  model:
+    name: test-model
+    path: main-dir
+  dataset:
+    - name: test-dataset
+      path: main-dir/subdir
+  code:
+    - path: .   # everything else
+kitignore: |
+  main-dir/ignored-subdir
+  main-dir/main-subdir/ignored-file1.txt
+  main-dir/subdir/ignored-dataset1.txt
+  main-dir/subdir/ignored-subdir
+  ignored-dir
+files:
+  # Files belonging to model
+  - main-dir/model-file1.txt
+  - main-dir/model-file2.txt
+  - main-dir/model-file3.txt
+  - main-dir/main-subdir/model-subdir1.txt
+  - main-dir/main-subdir/model-subdir2.txt
+  # Files belonging to dataset
+  - main-dir/subdir/dataset-file1.txt
+  - main-dir/subdir/dataset-file2.txt
+  - main-dir/subdir/subdir2/dataset-subdir1.txt
+  # Files belonging to code
+  - other-dir/code-file1.txt
+  - other-dir/code-file2.txt
+  - root-file1.txt
+  - root-file2
+ignored:
+  - main-dir/ignored-subdir/file1
+  - main-dir/main-subdir/ignored-file1.txt
+  - main-dir/subdir/ignored-dataset1.txt
+  - main-dir/subdir/ignored-subdir/file1
+  - ignored-dir/file1

--- a/testing/testdata/pack-unpack/test_pack-intersecting-paths.yaml
+++ b/testing/testdata/pack-unpack/test_pack-intersecting-paths.yaml
@@ -1,0 +1,29 @@
+description: Pack and unpack when paths intersect
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-intersecting-dir
+  model:
+    name: test-model
+    path: main-dir
+  dataset:
+    - name: test-dataset
+      path: main-dir/subdir
+  code:
+    - path: .   # everything else
+files:
+  # Files belonging to model
+  - main-dir/model-file1.txt
+  - main-dir/model-file2.txt
+  - main-dir/model-file3.txt
+  - main-dir/main-subdir/model-subdir1.txt
+  - main-dir/main-subdir/model-subdir2.txt
+  # Files belonging to dataset
+  - main-dir/subdir/dataset-file1.txt
+  - main-dir/subdir/dataset-file2.txt
+  - main-dir/subdir/subdir2/dataset-subdir1.txt
+  # Files belonging to code
+  - other-dir/code-file1.txt
+  - other-dir/code-file2.txt
+  - root-file1.txt
+  - root-file2

--- a/testing/testdata/pack-unpack/test_pack-path-formats.yaml
+++ b/testing/testdata/pack-unpack/test_pack-path-formats.yaml
@@ -1,0 +1,40 @@
+description: Pack and unpack with different path formats
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-paths
+  datasets:
+    - name: test-with-dot
+      path: ./test1
+    - name: test-path-without-dot
+      path: test2
+    - name: test-path-is-directory
+      path: test3/
+    - name: test-path-is-file
+      path: test4/test-single-file.txt
+    - name: test-path-is-subdirectory
+      path: test5/subdir/subdir2/
+    - name: test-path-has-subdirs
+      path: test6/
+    - name: test-path-has-repeated-elements
+      path: test7/test7
+files:
+  - test1/test1-file1.txt
+  - test1/test1-file2.txt
+  - test2/test2-file1
+  - test2/test2-file2
+  - test3/test3-file1.txt
+  - test3/test3-file2.txt
+  - test4/test-single-file.txt
+  - test5/subdir/subdir2/test5-file1.txt
+  - test6/subdir1/test6-file1.txt
+  - test6/subdir2/test6-file2.txt
+  - test6/subdir2/test6-file3.txt
+  - test6/test6-file4.txt
+  - test7/test7/test7/test7/test7-file1.txt
+ignored:
+  - test4/ignored-file.txt
+  - test5/ignored-file.txt
+  - test5/ignored-subdir/ignored-file.txt
+  - test5/subdir/ignored-subdir/ignored-file.txt
+  - test-ignored/ignored-file.txt

--- a/testing/testdata/pack-unpack/test_pack-path-is-context-dir.yaml
+++ b/testing/testdata/pack-unpack/test_pack-path-is-context-dir.yaml
@@ -1,0 +1,14 @@
+description: Pack and unpack path that is context dir itself
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-context-dir
+  model:
+    name: test-model
+    path: .
+files:
+  - file-in-root1.txt
+  - file-in-root2.txt
+  - main-dir/file-main1.txt
+  - main-dir/subdir/file-subdir1.txt
+  - dir2/test-file1.txt

--- a/testing/util_test.go
+++ b/testing/util_test.go
@@ -1,0 +1,171 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"kitops/cmd"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+const modelKitTag = "test:test"
+
+type testcase struct {
+	Name         string
+	Description  string   `yaml:"description"`
+	Kitfile      string   `yaml:"kitfile"`
+	Kitignore    string   `yaml:"kitignore"`
+	Files        []string `yaml:"files"`
+	IgnoredFiles []string `yaml:"ignored"`
+}
+
+// runCommand executes kit <args>, saving stdout/stderr output to a buffer
+// that is then printed through the test interface. If the kit command
+// calls `os.Exit`, this command will terminate without generating any logs.
+// Returns the stdout and stderr output of the command.
+func runCommand(t *testing.T, args ...string) string {
+	t.Logf("Running command: kit %s", strings.Join(args, " "))
+	runCmd := cmd.RunCommand()
+	runCmd.SetArgs(args)
+
+	// Set up buffer to capture command output
+	outbuf := &bytes.Buffer{}
+	runCmd.SetOut(outbuf)
+	runCmd.SetErr(outbuf)
+
+	err := runCmd.Execute()
+	if !assert.NoError(t, err, "Command returned error") {
+		return ""
+	}
+
+	outlog, err := io.ReadAll(outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Command output: \n%s", string(outlog))
+	return string(outlog)
+}
+
+func setupTempDir(t *testing.T) (tmpDir string, removeTmpDir func()) {
+	// Set up temporary directory for work
+	tmpDir, err := os.MkdirTemp("", "kitops-testing-*")
+	if !assert.NoError(t, err) {
+		t.Fatalf("Could not create temporary directory: %s", err)
+	}
+	removeTmpDir = func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("Error removing temp dir: %s", err)
+		}
+	}
+	t.Logf("Using temp directory: %s", tmpDir)
+	return tmpDir, removeTmpDir
+}
+
+// setupTestDirs generates the test directories used for storing $KIT_HOME, the original modelkit
+// and the unpacked modelkit as subdirectories of tmpDir.
+func setupTestDirs(t *testing.T, tmpDir string) (modelKitPath, unpackPath, contextPath string) {
+	// Set up paths to use for test
+	modelKitPath = filepath.Join(tmpDir, "test-modelkit-in")
+	unpackPath = filepath.Join(tmpDir, "test-modelkit-out")
+	contextPath = filepath.Join(tmpDir, ".kitops")
+	for _, path := range []string{modelKitPath, unpackPath, contextPath} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return
+}
+
+// setupFiles ensures that all paths in files exist within tmpDir. Directories along the
+// path are created if necessary, and files contain the text "testing: <filename>".
+func setupFiles(t *testing.T, tmpDir string, files []string) {
+	for _, file := range files {
+		path := filepath.Join(tmpDir, file)
+		dirName := filepath.Dir(path)
+		if err := os.MkdirAll(dirName, 0755); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("creating path %s", path)
+		if err := os.WriteFile(path, []byte("testing: "+file), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// checkFilesExist tests that every path listed in files exists within tmpDir, failing the
+// current test if not.
+func checkFilesExist(t *testing.T, tmpDir string, files []string) {
+	for _, file := range files {
+		path := filepath.Join(tmpDir, file)
+		stat, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				t.Errorf("File %s should exist", file)
+			} else {
+				t.Errorf("Unexpected error: %s", err)
+			}
+		} else {
+			assert.True(t, stat.Mode().IsRegular(), "Path %s should be regular file", path)
+		}
+	}
+}
+
+// checkFilesDoNotExist checks that none of the paths listed in files exist within tmpDir.
+func checkFilesDoNotExist(t *testing.T, tmpDir string, files []string) {
+	for _, file := range files {
+		path := filepath.Join(tmpDir, file)
+		_, err := os.Stat(path)
+		if err == nil {
+			t.Errorf("File %s should not exist", file)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("Unexpected error: %s", err)
+		}
+	}
+}
+
+func loadAllTestCasesOrPanic(t *testing.T, testsPath string) []testcase {
+	files, err := os.ReadDir(testsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tests []testcase
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		bytes, err := os.ReadFile(filepath.Join(testsPath, file.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		testcase := testcase{}
+		if err := yaml.Unmarshal(bytes, &testcase); err != nil {
+			t.Fatal(err)
+		}
+		testcase.Name = file.Name()
+		tests = append(tests, testcase)
+	}
+	return tests
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please review
* Our contibuting guide: https://github.com/jozu-ai/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/jozu-ai/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description
Add functional tests for the CLI and fix minor bugs writing the tests revealed:
* When running `kit remove`, we were logging placeholder registry/repo values (i.e. `localhost/test:test` instead of `test:test`)
* The `unpack` subcommand had a flag `--config` (to unpack only the Kitfile) which conflicted with the global `--config` flag. This flag was renamed to `--kitfile`
* Unpacking would break if a Kitfile path had a trailing slash, unpacking files one directory higher in the tree
* Updated the output package to use the command's output/error channels instead of hardcoding stdout/stderr.

The way the tests work is by 
1. Setting up a temporary directory
2. Configuring Kit to do everything within that directory (i.e. storage is within the directory, etc.)
3. Running Kit commands directly within that directory and verifying behaviour

For testing pack/unpack and ignoring, each test generates a Kitfile, a `.kitignore` and files representing a model kit. It then packs those files, unpacks them to a separate directory, and verifies that all expected files are present (and no unexpected ones are)

For testing `kit remove`, each test packs one or more modelkits and verifies that `kit remove` cleans them up as expected

Each test also incidentally tests other commands, e.g. `kit tag` or `kit list` as required. Test logging is fairly verbose, so in test failures are relatively easy to diagnose (add the `-test.v` flag to see all output).

### Linked issues
Related: #119, #85
