### PR TITLE
Remove timestamps from gzip headers to avoid changing hashes

### DIFF
--- a/pkg/lib/storage/layer.go
+++ b/pkg/lib/storage/layer.go
@@ -25,6 +25,7 @@ import (
 	"kitops/pkg/output"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -160,6 +161,9 @@ func writeHeaderToTar(name string, fi os.FileInfo, tw *tar.Writer) error {
 		return fmt.Errorf("failed to generate header for %s: %w", name, err)
 	}
 	header.Name = name
+	header.AccessTime = time.Time{}
+	header.ModTime = time.Time{}
+	header.ChangeTime = time.Time{}
 	if err := tw.WriteHeader(header); err != nil {
 		return fmt.Errorf("failed to write header: %w", err)
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/jozu-ai/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/jozu-ai/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description
By default, file and directory headers include timestamps for creation time, etc. These timestamps mean that kit builds are not reproducible through the sequence

1. kit pack -t <model> .
2. kit unpack <model>
3. kit pack <model-2> # should be same but isn't

since the unpack step results in different timestamps on files.

Instead, we just use the zero value for those timestamps to ensure hash is unchanged.

### Linked issues
N/A