### PR TITLE
Pass Apple env vars to notarization

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -50,6 +50,12 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD}}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID}}
       - name: Notarize the macOS binary
+        env:
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLICATION_IDENTITY}}
+          APPLE_ID: ${{ vars.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD}}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID}}
+        shell: bash
         run: |
           ./build/scripts/sign ./dist/kitops-darwin-amd64.zip
           ./build/scripts/sign ./dist/kitops-darwin-x86_64.zip

--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -44,3 +44,7 @@ archives:
 git:
   ignore_tags:
     - "next"
+
+snapshot:
+  name_template: "{{ .Version }}-{{ .ShortCommit }}"
+

--- a/.goreleaser.linux.yaml
+++ b/.goreleaser.linux.yaml
@@ -36,3 +36,6 @@ archives:
 git:
   ignore_tags:
     - "next"
+
+snapshot:
+  name_template: "{{ .Version }}-{{ .ShortCommit }}"

--- a/.goreleaser.windows.yaml
+++ b/.goreleaser.windows.yaml
@@ -32,3 +32,6 @@ archives:
     files:
       - LICENSE
       - README.md
+
+snapshot:
+  name_template: "{{ .Version }}-{{ .ShortCommit }}"


### PR DESCRIPTION
### Description
Passes environment variables needed for notarization to the workflow step. Updates the goreleaser configuration to remove snapshot designation from version
