### PR TITLE
Update release action to use gh for creating a docs update PR

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 jobs:
   build-macos:
     runs-on: macos-latest
@@ -169,14 +170,22 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate CLI documentation
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./docs/src/docs/cli/generate.sh > /dev/null
+          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          PR_BRANCH="${{ github.ref_name }}-docs-update"
+          git branch "$PR_BRANCH"
+          git checkout "$PR_BRANCH"
+          git pull origin --ff-only "${PR_BRANCH}" || true
 
-      - name: PR for CLI documentation
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: peter-evans/create-pull-request@v6
-        with:
-          add-paths: |
-            docs/*.md
-          commit-message: "docs: update CLI documentation for ${{ github.ref_name }}"
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+
+          ./docs/src/docs/cli/generate.sh > /dev/null
+          git add --all
+          git commit -m "docs: update CLI documentation for ${{ github.ref_name }}"
+          git push origin "${PR_BRANCH}"
+          gh pr create --fill --base main --head "${PR_BRANCH}"
+          git checkout "${CURRENT_BRANCH}"


### PR DESCRIPTION
### Description
Open docs update PRs using the `gh` CLI rather than a marketplace action. The new step is

1. Create a branch `<ref>-docs-update`, sync it with origin (in case it already exists)
2. Set up git user name/email as required
3. Generate docs
4. Create a commit with updated docs
5. Open a PR via `gh create pr`

### Testing
I tested a simplified version of this step on my fork (I'll delete this commit once this PR is merged):
* [test-workflow.yaml](https://github.com/amisevsk/kitops/blob/22690c09d6661b184cea4cf3d0828af752eda5d2/.github/workflows/test-workflow.yaml)
* [Successful CI run](https://github.com/amisevsk/kitops/actions/runs/8755632975)
* [Generated PR](https://github.com/amisevsk/kitops/pull/1)

### Linked issues
N/A