### PR TITLE
Fetch origin when preparing docs update PR

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -182,6 +182,7 @@ jobs:
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           PR_BRANCH="${{ github.ref_name }}-docs-update"
+          git fetch origin main
           git branch "$PR_BRANCH"
           git checkout "$PR_BRANCH"
           git pull origin --ff-only "${PR_BRANCH}" || true


### PR DESCRIPTION


### Description
It looks like origin/main isn't available locally when running in our action, resulting in the comparison `main..<branch>` failing.

### Linked issues
<!-- link any issues in this repository that are related to the PR; use "closes <issue>" or "fixes <issue>" to automatically link issues to this PR -->
