### PR TITLE
Fail packing process if layer path does not exist locally.

### DIFF
--- a/pkg/lib/storage/layer.go
+++ b/pkg/lib/storage/layer.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"kitops/pkg/lib/filesystem"
@@ -47,6 +48,9 @@ func compressLayer(path, mediaType string, ignore filesystem.IgnorePaths) (tempF
 
 	pathInfo, err := os.Stat(path)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", ocispec.DescriptorEmptyJSON, fmt.Errorf("%s path %s does not exist", layerTypeForMediaType(mediaType), path)
+		}
 		return "", ocispec.DescriptorEmptyJSON, err
 	}
 	tempFile, err := os.CreateTemp("", "kitops_layer_*")

--- a/pkg/lib/storage/local.go
+++ b/pkg/lib/storage/local.go
@@ -42,6 +42,9 @@ func SaveModel(ctx context.Context, store oras.Target, kitfile *artifact.KitFile
 		return nil, err
 	}
 	layerDescs, err := saveKitfileLayers(ctx, store, kitfile, ignore)
+	if err != nil {
+		return nil, err
+	}
 
 	manifest := CreateManifest(configDesc, layerDescs)
 	manifestDesc, err := saveModelManifest(ctx, store, manifest)


### PR DESCRIPTION
### Description
* Fix an ignored error bug
* Return more legible message when a layer path being packed does not exist:
    > `Failed to pack model kit: model path not-exist.txt does not exist`

### Linked issues
Closes #255 
