### PR TITLE
Add ability to reference other ModelKits in a Kitfile

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,10 @@ func RunCommand() *cobra.Command {
 		Use:   `kit`,
 		Short: shortDesc,
 		Long:  longDesc,
+		// Commands do all their printing directly and return an error only to signal that we should exit with
+		// nonzero status. We don't want to print usage or the error message in this case.
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			output.SetOut(cmd.OutOrStdout())
 			output.SetErr(cmd.ErrOrStderr())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,10 +45,6 @@ func RunCommand() *cobra.Command {
 		Use:   `kit`,
 		Short: shortDesc,
 		Long:  longDesc,
-		// Commands do all their printing directly and return an error only to signal that we should exit with
-		// nonzero status. We don't want to print usage or the error message in this case.
-		SilenceUsage:  true,
-		SilenceErrors: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			output.SetOut(cmd.OutOrStdout())
 			output.SetErr(cmd.ErrOrStderr())

--- a/pkg/artifact/kit-file.go
+++ b/pkg/artifact/kit-file.go
@@ -65,6 +65,13 @@ type (
 		License     string      `json:"license,omitempty" yaml:"license,omitempty"`
 		Training    *Training   `json:"training,omitempty" yaml:"training,omitempty"`
 		Validation  *Validation `json:"validation,omitempty" yaml:"validation,omitempty"`
+		Parts       []ModelPart `json:"parts,omitempty" yaml:"parts,omitempty"`
+	}
+
+	ModelPart struct {
+		Name        string `json:"name,omitempty" yaml:"name,omitempty"`
+		Path        string `json:"path,omitempty" yaml:"path,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	}
 
 	Training struct {

--- a/pkg/artifact/kit-file.go
+++ b/pkg/artifact/kit-file.go
@@ -69,9 +69,9 @@ type (
 	}
 
 	ModelPart struct {
-		Name        string `json:"name,omitempty" yaml:"name,omitempty"`
-		Path        string `json:"path,omitempty" yaml:"path,omitempty"`
-		Description string `json:"description,omitempty" yaml:"description,omitempty"`
+		Name string `json:"name,omitempty" yaml:"name,omitempty"`
+		Path string `json:"path,omitempty" yaml:"path,omitempty"`
+		Type string `json:"type,omitempty" yaml:"type,omitempty"`
 	}
 
 	Training struct {

--- a/pkg/artifact/kit-file.md
+++ b/pkg/artifact/kit-file.md
@@ -12,7 +12,7 @@ The manifest is structured into several key sections: `version`, `package`,`code
 - **Type**: String
 - **Example**: `1.0`
 
-### `modelkit`
+### `package`
 
 This section provides general information about the AI/ML project.
 
@@ -66,6 +66,10 @@ This section provides general information about the AI/ML project.
   - `version`: Version of the model
   - `description`: Overview of the model
   - `license`: SPDX license identifier for the dataset.
+  - `parts`: List of related files for the model (e.g. LoRA weights)
+    - `name`: Identifier for the part
+    - `path`: Location of the file or a directory relative to the context
+    - `description`: Description of the part
   - `training`:
     - `dataset`: Name of the dataset
     - `parameters`: name value pairs

--- a/pkg/artifact/kit-file.md
+++ b/pkg/artifact/kit-file.md
@@ -69,7 +69,7 @@ This section provides general information about the AI/ML project.
   - `parts`: List of related files for the model (e.g. LoRA weights)
     - `name`: Identifier for the part
     - `path`: Location of the file or a directory relative to the context
-    - `description`: Description of the part
+    - `type`: The type of the part (e.g. LoRA weights)
   - `training`:
     - `dataset`: Name of the dataset
     - `parameters`: name value pairs

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -63,7 +63,7 @@ func InfoCommand() *cobra.Command {
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: example,
-		Run:     runCommand(opts),
+		RunE:    runCommand(opts),
 		Args:    cobra.ExactArgs(1),
 	}
 
@@ -72,23 +72,24 @@ func InfoCommand() *cobra.Command {
 	return cmd
 }
 
-func runCommand(opts *infoOptions) func(*cobra.Command, []string) {
-	return func(cmd *cobra.Command, args []string) {
+func runCommand(opts *infoOptions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
+			return output.Fatalf("Invalid arguments: %s", err)
 		}
 		config, err := getInfo(cmd.Context(), opts)
 		if err != nil {
 			if errors.Is(err, errdef.ErrNotFound) {
-				output.Fatalf("Could not find modelkit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
+				return output.Fatalf("Could not find modelkit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
 			}
-			output.Fatalf("Error resolving modelkit: %s", err)
+			return output.Fatalf("Error resolving modelkit: %s", err)
 		}
 		yamlBytes, err := config.MarshalToYAML()
 		if err != nil {
-			output.Fatalf("Error formatting manifest: %w", err)
+			return output.Fatalf("Error formatting manifest: %w", err)
 		}
 		fmt.Println(string(yamlBytes))
+		return nil
 	}
 }
 

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -74,6 +74,10 @@ func InfoCommand() *cobra.Command {
 
 func runCommand(opts *infoOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/info/util.go
+++ b/pkg/cmd/info/util.go
@@ -22,17 +22,22 @@ import (
 	"kitops/pkg/artifact"
 	"kitops/pkg/cmd/options"
 	"kitops/pkg/lib/repo"
+
+	"oras.land/oras-go/v2/registry"
 )
 
-func GetKitfileForRef(ctx context.Context, configHome, ref string) (*artifact.KitFile, error) {
+func GetKitfileForRefString(ctx context.Context, configHome, ref string) (*artifact.KitFile, error) {
 	modelRef, _, err := repo.ParseReference(ref)
 	if err != nil {
 		return nil, err
 	}
+	return GetKitfileForRef(ctx, configHome, modelRef)
+}
 
+func GetKitfileForRef(ctx context.Context, configHome string, ref *registry.Reference) (*artifact.KitFile, error) {
 	opts := &infoOptions{
 		configHome: configHome,
-		modelRef:   modelRef,
+		modelRef:   ref,
 		NetworkOptions: options.NetworkOptions{
 			PlainHTTP: false,
 			TlsVerify: true,
@@ -47,5 +52,5 @@ func GetKitfileForRef(ctx context.Context, configHome, ref string) (*artifact.Ki
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch Kitfile for %s: %w", ref, err)
 	}
-	return kitfile, err
+	return kitfile, nil
 }

--- a/pkg/cmd/info/util.go
+++ b/pkg/cmd/info/util.go
@@ -1,0 +1,51 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package info
+
+import (
+	"context"
+	"fmt"
+	"kitops/pkg/artifact"
+	"kitops/pkg/cmd/options"
+	"kitops/pkg/lib/repo"
+)
+
+func GetKitfileForRef(ctx context.Context, configHome, ref string) (*artifact.KitFile, error) {
+	modelRef, _, err := repo.ParseReference(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &infoOptions{
+		configHome: configHome,
+		modelRef:   modelRef,
+		NetworkOptions: options.NetworkOptions{
+			PlainHTTP: false,
+			TlsVerify: true,
+		},
+	}
+
+	kitfile, err := getLocalConfig(ctx, opts)
+	if err == nil {
+		return kitfile, nil
+	}
+	kitfile, err = getRemoteConfig(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch Kitfile for %s: %w", ref, err)
+	}
+	return kitfile, err
+}

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -63,7 +63,7 @@ func InspectCommand() *cobra.Command {
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: example,
-		Run:     runCommand(opts),
+		RunE:    runCommand(opts),
 		Args:    cobra.ExactArgs(1),
 	}
 
@@ -72,23 +72,24 @@ func InspectCommand() *cobra.Command {
 	return cmd
 }
 
-func runCommand(opts *inspectOptions) func(*cobra.Command, []string) {
-	return func(cmd *cobra.Command, args []string) {
+func runCommand(opts *inspectOptions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
+			return output.Fatalf("Invalid arguments: %s", err)
 		}
 		manifest, err := inspectReference(cmd.Context(), opts)
 		if err != nil {
 			if errors.Is(err, errdef.ErrNotFound) {
-				output.Fatalf("Could not find modelkit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
+				return output.Fatalf("Could not find modelkit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
 			}
-			output.Fatalf("Error resolving modelkit: %s", err)
+			return output.Fatalf("Error resolving modelkit: %s", err)
 		}
 		jsonBytes, err := json.MarshalIndent(manifest, "", "  ")
 		if err != nil {
-			output.Fatalf("Error formatting manifest: %w", err)
+			return output.Fatalf("Error formatting manifest: %w", err)
 		}
 		fmt.Println(string(jsonBytes))
+		return nil
 	}
 }
 

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -74,6 +74,10 @@ func InspectCommand() *cobra.Command {
 
 func runCommand(opts *inspectOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -92,7 +92,7 @@ func ListCommand() *cobra.Command {
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: example,
-		Run:     runCommand(opts),
+		RunE:    runCommand(opts),
 	}
 
 	cmd.Args = cobra.MaximumNArgs(1)
@@ -101,27 +101,28 @@ func ListCommand() *cobra.Command {
 	return cmd
 }
 
-func runCommand(opts *listOptions) func(*cobra.Command, []string) {
-	return func(cmd *cobra.Command, args []string) {
+func runCommand(opts *listOptions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
+			return output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		var allInfoLines []string
 		if opts.remoteRef == nil {
 			lines, err := listLocalKits(cmd.Context(), opts)
 			if err != nil {
-				output.Fatalln(err)
+				return output.Fatalln(err)
 			}
 			allInfoLines = lines
 		} else {
 			lines, err := listRemoteKits(cmd.Context(), opts)
 			if err != nil {
-				output.Fatalln(err)
+				return output.Fatalln(err)
 			}
 			allInfoLines = lines
 		}
 		printSummary(cmd.OutOrStdout(), allInfoLines)
+		return nil
 	}
 }
 

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -103,6 +103,10 @@ func ListCommand() *cobra.Command {
 
 func runCommand(opts *listOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/login/cmd.go
+++ b/pkg/cmd/login/cmd.go
@@ -47,7 +47,7 @@ func LoginCommand() *cobra.Command {
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: example,
-		Run:     runLogin(opts),
+		RunE:    runCommand(opts),
 	}
 
 	cmd.Args = cobra.ExactArgs(1)
@@ -59,16 +59,17 @@ func LoginCommand() *cobra.Command {
 	return cmd
 }
 
-func runLogin(opts *loginOptions) func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
+func runCommand(opts *loginOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
+			return output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		err := login(cmd.Context(), opts)
 		if err != nil {
-			output.Fatalln(err)
+			return output.Fatalln(err)
 		}
+		return nil
 	}
 }
 

--- a/pkg/cmd/login/cmd.go
+++ b/pkg/cmd/login/cmd.go
@@ -61,6 +61,10 @@ func LoginCommand() *cobra.Command {
 
 func runCommand(opts *loginOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/logout/cmd.go
+++ b/pkg/cmd/logout/cmd.go
@@ -34,21 +34,22 @@ func LogoutCommand() *cobra.Command {
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: example,
-		Run:     runLogout(opts),
+		RunE:    runCommand(opts),
 	}
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd
 }
 
-func runLogout(opts *logoutOptions) func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
+func runCommand(opts *logoutOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
+			return output.Fatalf("Invalid arguments: %s", err)
 		}
 		err := logout(cmd.Context(), opts.registry, opts.credentialStoreHome)
 		if err != nil {
-			output.Fatalln(err)
+			return output.Fatalln(err)
 		}
+		return nil
 	}
 }
 

--- a/pkg/cmd/logout/cmd.go
+++ b/pkg/cmd/logout/cmd.go
@@ -42,6 +42,10 @@ func LogoutCommand() *cobra.Command {
 
 func runCommand(opts *logoutOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -58,7 +58,7 @@ func PackCommand() *cobra.Command {
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: examples,
-		Run:     runCommand(opts),
+		RunE:    runCommand(opts),
 	}
 	cmd.Flags().StringVarP(&opts.modelFile, "file", "f", "", "Specifies the path to the Kitfile explictly (use \"-\" to read from standard input)")
 	cmd.Flags().StringVarP(&opts.fullTagRef, "tag", "t", "", "Assigns one or more tags to the built modelkit. Example: -t registry/repository:tag1,tag2")
@@ -66,24 +66,24 @@ func PackCommand() *cobra.Command {
 	return cmd
 }
 
-func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
+func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
 		err := opts.complete(cmd.Context(), args)
 		if err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
+			return output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		// Change working directory to context path to make sure relative paths within
 		// tarballs are correct. This is the equivalent of using the -C parameter for tar
 		if err := os.Chdir(opts.contextDir); err != nil {
-			output.Fatalf("Failed to use context path %s: %w", opts.contextDir, err)
+			return output.Fatalf("Failed to use context path %s: %w", opts.contextDir, err)
 		}
 
 		err = runPack(cmd.Context(), opts)
 		if err != nil {
-			output.Fatalf("Failed to pack model kit: %s", err)
-			return
+			return output.Fatalf("Failed to pack model kit: %s", err)
 		}
+		return nil
 	}
 }
 

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -68,6 +68,10 @@ func PackCommand() *cobra.Command {
 
 func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		err := opts.complete(cmd.Context(), args)
 		if err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)

--- a/pkg/cmd/pack/pack.go
+++ b/pkg/cmd/pack/pack.go
@@ -78,7 +78,8 @@ func runPack(ctx context.Context, options *packOptions) error {
 func pack(ctx context.Context, opts *packOptions, kitfile *artifact.KitFile, store repo.LocalStorage) (*ocispec.Descriptor, error) {
 	var extraLayerPaths []string
 	if kitfile.Model != nil && kfutils.IsModelKitReference(kitfile.Model.Path) {
-		parentKitfile, err := kfutils.ResolveKitfile(ctx, opts.configHome, kitfile.Model.Path)
+		baseRef := repo.FormatRepositoryForDisplay(opts.modelRef.String())
+		parentKitfile, err := kfutils.ResolveKitfile(ctx, opts.configHome, kitfile.Model.Path, baseRef)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -25,7 +25,6 @@ import (
 	"kitops/pkg/output"
 
 	"github.com/spf13/cobra"
-	"oras.land/oras-go/v2/content/oci"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -87,24 +86,9 @@ func runCommand(opts *pullOptions) func(*cobra.Command, []string) {
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			output.Fatalf("Invalid arguments: %s", err)
 		}
-		remoteRegistry, err := repo.NewRegistry(opts.modelRef.Registry, &repo.RegistryOptions{
-			PlainHTTP:       opts.PlainHTTP,
-			SkipTLSVerify:   !opts.TlsVerify,
-			CredentialsPath: constants.CredentialsPath(opts.configHome),
-		})
-		if err != nil {
-			output.Fatalln(err)
-		}
-
-		storageHome := constants.StoragePath(opts.configHome)
-		localStorePath := repo.RepoPath(storageHome, opts.modelRef)
-		localStore, err := oci.New(localStorePath)
-		if err != nil {
-			output.Fatalln(err)
-		}
 
 		output.Infof("Pulling %s", opts.modelRef.String())
-		desc, err := pullModel(cmd.Context(), remoteRegistry, localStore, opts.modelRef)
+		desc, err := runPull(cmd.Context(), opts)
 		if err != nil {
 			output.Fatalf("Failed to pull: %s", err)
 			return

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -72,7 +72,7 @@ func PullCommand() *cobra.Command {
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: example,
-		Run:     runCommand(opts),
+		RunE:    runCommand(opts),
 	}
 
 	cmd.Args = cobra.ExactArgs(1)
@@ -81,18 +81,18 @@ func PullCommand() *cobra.Command {
 	return cmd
 }
 
-func runCommand(opts *pullOptions) func(*cobra.Command, []string) {
-	return func(cmd *cobra.Command, args []string) {
+func runCommand(opts *pullOptions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
+			return output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		output.Infof("Pulling %s", opts.modelRef.String())
 		desc, err := runPull(cmd.Context(), opts)
 		if err != nil {
-			output.Fatalf("Failed to pull: %s", err)
-			return
+			return output.Fatalf("Failed to pull: %s", err)
 		}
 		output.Infof("Pulled %s", desc.Digest)
+		return nil
 	}
 }

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -83,6 +83,10 @@ func PullCommand() *cobra.Command {
 
 func runCommand(opts *pullOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -89,6 +89,10 @@ func PushCommand() *cobra.Command {
 
 func runCommand(opts *pushOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -89,7 +89,7 @@ func RemoveCommand() *cobra.Command {
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: examples,
-		Run:     runCommand(opts),
+		RunE:    runCommand(opts),
 	}
 	// cmd.Args = cobra.ExactArgs(1)
 	cmd.Flags().BoolVarP(&opts.forceDelete, "force", "f", false, "remove modelkit and all other tags that refer to it")
@@ -115,10 +115,10 @@ func RemoveCommand() *cobra.Command {
 	return cmd
 }
 
-func runCommand(opts *removeOptions) func(*cobra.Command, []string) {
-	return func(cmd *cobra.Command, args []string) {
+func runCommand(opts *removeOptions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
+			return output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		var err error
@@ -131,8 +131,9 @@ func runCommand(opts *removeOptions) func(*cobra.Command, []string) {
 			err = removeAllModels(cmd.Context(), opts)
 		}
 		if err != nil {
-			output.Fatalf(err.Error())
+			return output.Fatalf(err.Error())
 		}
+		return nil
 	}
 }
 

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -117,6 +117,10 @@ func RemoveCommand() *cobra.Command {
 
 func runCommand(opts *removeOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/tag/cmd.go
+++ b/pkg/cmd/tag/cmd.go
@@ -101,23 +101,24 @@ func TagCommand() *cobra.Command {
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: example,
-		Run:     runCommand(&tagOptions{}),
+		RunE:    runCommand(&tagOptions{}),
 	}
 
 	cmd.Args = cobra.ExactArgs(2)
 	return cmd
 }
 
-func runCommand(opts *tagOptions) func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
+func runCommand(opts *tagOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
 		if err := opts.complete(cmd.Context(), args); err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
+			return output.Fatalf("Invalid arguments: %s", err)
 		}
 
 		err := RunTag(cmd.Context(), opts)
 		if err != nil {
-			output.Fatalf("Failed to tag modelkit: %s", err)
+			return output.Fatalf("Failed to tag modelkit: %s", err)
 		}
 		output.Infof("Modelkit %s tagged as %s", opts.sourceRef, opts.targetRef)
+		return nil
 	}
 }

--- a/pkg/cmd/tag/cmd.go
+++ b/pkg/cmd/tag/cmd.go
@@ -110,6 +110,10 @@ func TagCommand() *cobra.Command {
 
 func runCommand(opts *tagOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -18,7 +18,6 @@ package unpack
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"kitops/pkg/cmd/options"
 	"kitops/pkg/lib/constants"
@@ -28,9 +27,6 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content/oci"
-	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -137,11 +133,6 @@ func runCommand(opts *unpackOptions) func(*cobra.Command, []string) {
 		if opts.modelRef.Reference == "" {
 			output.Fatalf("Invalid reference: unpacking requires a tag or digest")
 		}
-		store, err := getStoreForRef(cmd.Context(), opts)
-		if err != nil {
-			ref := repo.FormatRepositoryForDisplay(opts.modelRef.String())
-			output.Fatalf("Failed to find reference %s: %s", ref, err)
-		}
 
 		unpackTo := opts.unpackDir
 		if unpackTo == "" {
@@ -158,50 +149,11 @@ func runCommand(opts *unpackOptions) func(*cobra.Command, []string) {
 		}
 
 		output.Infof("Unpacking to %s", unpackTo)
-		err = unpackModel(cmd.Context(), store, opts.modelRef, opts)
+		err := runUnpack(cmd.Context(), opts)
 		if err != nil {
 			output.Fatalln(err)
 		}
 	}
-}
-
-func getStoreForRef(ctx context.Context, opts *unpackOptions) (oras.Target, error) {
-	storageHome := constants.StoragePath(opts.configHome)
-	localStore, err := oci.New(repo.RepoPath(storageHome, opts.modelRef))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read local storage: %s\n", err)
-	}
-
-	if _, err := localStore.Resolve(ctx, opts.modelRef.Reference); err == nil {
-		// Reference is present in local storage
-		return localStore, nil
-	}
-
-	if opts.modelRef.Registry == repo.DefaultRegistry {
-		return nil, fmt.Errorf("not found")
-	}
-	// Not in local storage, check remote
-	remoteRegistry, err := repo.NewRegistry(opts.modelRef.Registry, &repo.RegistryOptions{
-		PlainHTTP:       opts.PlainHTTP,
-		SkipTLSVerify:   !opts.TlsVerify,
-		CredentialsPath: constants.CredentialsPath(opts.configHome),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("could not resolve registry %s: %w", opts.modelRef.Registry, err)
-	}
-
-	repo, err := remoteRegistry.Repository(ctx, opts.modelRef.Repository)
-	if err != nil {
-		return nil, fmt.Errorf("could not resolve repository %s in registry %s", opts.modelRef.Repository, opts.modelRef.Registry)
-	}
-	if _, err := repo.Resolve(ctx, opts.modelRef.Reference); err != nil {
-		if errors.Is(err, errdef.ErrNotFound) {
-			return nil, fmt.Errorf("reference %s is not present in local storage and could not be found in remote", opts.modelRef.String())
-		}
-		return nil, fmt.Errorf("unexpected error retrieving reference from remote: %w", err)
-	}
-
-	return repo, nil
 }
 
 func printConfig(opts *unpackOptions) {

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -126,6 +126,10 @@ func UnpackCommand() *cobra.Command {
 
 func runCommand(opts *unpackOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
+		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -22,35 +22,56 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"kitops/pkg/artifact"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/filesystem"
+	kfutils "kitops/pkg/lib/kitfile"
 	"kitops/pkg/lib/repo"
 	"kitops/pkg/output"
-	"os"
-	"path/filepath"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
-	"oras.land/oras-go/v2/registry"
 )
 
-// unpackModel fetches and unpacks a *registry.Reference from an oras.Target. It returns an error if
+// runUnpack fetches and unpacks a *registry.Reference from an oras.Target. It returns an error if
 // unpacking fails, or if any path specified in the modelkit is not a subdirectory of the current
 // unpack target directory.
-func unpackModel(ctx context.Context, store oras.Target, ref *registry.Reference, options *unpackOptions) error {
+func runUnpack(ctx context.Context, opts *unpackOptions) error {
+	return runUnpackRecursive(ctx, opts, []string{})
+}
+
+func runUnpackRecursive(ctx context.Context, opts *unpackOptions, visitedRefs []string) error {
+	if len(visitedRefs) > constants.MaxModelRefChain {
+		return fmt.Errorf("Reached maximum number of model references: [%s]", strings.Join(visitedRefs, "=>"))
+	}
+
+	ref := opts.modelRef
+	store, err := getStoreForRef(ctx, opts)
+	if err != nil {
+		ref := repo.FormatRepositoryForDisplay(opts.modelRef.String())
+		output.Fatalf("Failed to find reference %s: %s", ref, err)
+	}
 	manifestDesc, err := store.Resolve(ctx, ref.Reference)
 	if err != nil {
-		return fmt.Errorf("Failed to resolve local reference: %w", err)
+		return fmt.Errorf("Failed to resolve reference: %w", err)
 	}
 	manifest, config, err := repo.GetManifestAndConfig(ctx, store, manifestDesc)
 	if err != nil {
-		return fmt.Errorf("Failed to read local model: %s", err)
+		return fmt.Errorf("Failed to read model: %s", err)
+	}
+	if config.Model != nil && kfutils.IsModelKitReference(config.Model.Path) {
+		output.Infof("Unpacking referenced modelkit %s", config.Model.Path)
+		if err := unpackParent(ctx, config.Model.Path, opts, visitedRefs); err != nil {
+			return err
+		}
 	}
 
-	if options.unpackConf.unpackKitfile {
-		if err := unpackConfig(config, options.unpackDir, options.overwrite); err != nil {
+	if opts.unpackConf.unpackKitfile {
+		if err := unpackConfig(config, opts.unpackDir, opts.overwrite); err != nil {
 			return err
 		}
 	}
@@ -62,21 +83,21 @@ func unpackModel(ctx context.Context, store oras.Target, ref *registry.Reference
 		var relPath string
 		switch layerDesc.MediaType {
 		case constants.ModelLayerMediaType:
-			if !options.unpackConf.unpackModels {
+			if !opts.unpackConf.unpackModels {
 				continue
 			}
-			_, relPath, err = filesystem.VerifySubpath(options.unpackDir, config.Model.Path)
+			_, relPath, err = filesystem.VerifySubpath(opts.unpackDir, config.Model.Path)
 			if err != nil {
 				return fmt.Errorf("Error resolving model path: %w", err)
 			}
 			output.Infof("Unpacking model %s to %s", config.Model.Name, relPath)
 
 		case constants.ModelPartLayerMediaType:
-			if !options.unpackConf.unpackModels {
+			if !opts.unpackConf.unpackModels {
 				continue
 			}
 			part := config.Model.Parts[modelPartIdx]
-			_, relPath, err = filesystem.VerifySubpath(options.unpackDir, part.Path)
+			_, relPath, err = filesystem.VerifySubpath(opts.unpackDir, part.Path)
 			if err != nil {
 				return fmt.Errorf("Error resolving code path: %w", err)
 			}
@@ -84,11 +105,11 @@ func unpackModel(ctx context.Context, store oras.Target, ref *registry.Reference
 			modelPartIdx += 1
 
 		case constants.CodeLayerMediaType:
-			if !options.unpackConf.unpackCode {
+			if !opts.unpackConf.unpackCode {
 				continue
 			}
 			codeEntry := config.Code[codeIdx]
-			_, relPath, err = filesystem.VerifySubpath(options.unpackDir, codeEntry.Path)
+			_, relPath, err = filesystem.VerifySubpath(opts.unpackDir, codeEntry.Path)
 			if err != nil {
 				return fmt.Errorf("Error resolving code path: %w", err)
 			}
@@ -96,18 +117,18 @@ func unpackModel(ctx context.Context, store oras.Target, ref *registry.Reference
 			codeIdx += 1
 
 		case constants.DataSetLayerMediaType:
-			if !options.unpackConf.unpackDatasets {
+			if !opts.unpackConf.unpackDatasets {
 				continue
 			}
 			datasetEntry := config.DataSets[datasetIdx]
-			_, relPath, err = filesystem.VerifySubpath(options.unpackDir, datasetEntry.Path)
+			_, relPath, err = filesystem.VerifySubpath(opts.unpackDir, datasetEntry.Path)
 			if err != nil {
 				return fmt.Errorf("Error resolving dataset path for dataset %s: %w", datasetEntry.Name, err)
 			}
 			output.Infof("Unpacking dataset %s to %s", datasetEntry.Name, relPath)
 			datasetIdx += 1
 		}
-		if err := unpackLayer(ctx, store, layerDesc, relPath, options.overwrite); err != nil {
+		if err := unpackLayer(ctx, store, layerDesc, relPath, opts.overwrite); err != nil {
 			return fmt.Errorf("Failed to unpack: %w", err)
 		}
 	}
@@ -116,6 +137,26 @@ func unpackModel(ctx context.Context, store oras.Target, ref *registry.Reference
 	output.Debugf("Unpacked %d dataset layers", datasetIdx)
 
 	return nil
+}
+
+func unpackParent(ctx context.Context, ref string, optsIn *unpackOptions, visitedRefs []string) error {
+	if idx := getIndex(visitedRefs, ref); idx != -1 {
+		cycleStr := fmt.Sprintf("[%s=>%s]", strings.Join(visitedRefs[idx:], "=>"), ref)
+		return fmt.Errorf("Found cycle in modelkit references: %s", cycleStr)
+	}
+
+	parentRef, _, err := repo.ParseReference(ref)
+	if err != nil {
+		return err
+	}
+	opts := *optsIn
+	opts.modelRef = parentRef
+	// Unpack only model, ignore code/datasets
+	opts.unpackConf.unpackKitfile = false
+	opts.unpackConf.unpackCode = false
+	opts.unpackConf.unpackDatasets = false
+
+	return runUnpackRecursive(ctx, &opts, append(visitedRefs, ref))
 }
 
 func unpackConfig(config *artifact.KitFile, unpackDir string, overwrite bool) error {
@@ -219,4 +260,13 @@ func extractTar(tr *tar.Reader, dir string, overwrite bool, logger *output.Progr
 		}
 	}
 	return nil
+}
+
+func getIndex(list []string, s string) int {
+	for idx, item := range list {
+		if s == item {
+			return idx
+		}
+	}
+	return -1
 }

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -53,7 +53,7 @@ func runUnpackRecursive(ctx context.Context, opts *unpackOptions, visitedRefs []
 	store, err := getStoreForRef(ctx, opts)
 	if err != nil {
 		ref := repo.FormatRepositoryForDisplay(opts.modelRef.String())
-		output.Fatalf("Failed to find reference %s: %s", ref, err)
+		return output.Fatalf("Failed to find reference %s: %s", ref, err)
 	}
 	manifestDesc, err := store.Resolve(ctx, ref.Reference)
 	if err != nil {

--- a/pkg/cmd/unpack/util.go
+++ b/pkg/cmd/unpack/util.go
@@ -1,0 +1,67 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package unpack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"kitops/pkg/lib/constants"
+	"kitops/pkg/lib/repo"
+
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/errdef"
+)
+
+func getStoreForRef(ctx context.Context, opts *unpackOptions) (oras.Target, error) {
+	storageHome := constants.StoragePath(opts.configHome)
+	localStore, err := repo.NewLocalStore(storageHome, opts.modelRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read local storage: %s\n", err)
+	}
+
+	if _, err := localStore.Resolve(ctx, opts.modelRef.Reference); err == nil {
+		// Reference is present in local storage
+		return localStore, nil
+	}
+
+	if opts.modelRef.Registry == repo.DefaultRegistry {
+		return nil, fmt.Errorf("not found")
+	}
+	// Not in local storage, check remote
+	remoteRegistry, err := repo.NewRegistry(opts.modelRef.Registry, &repo.RegistryOptions{
+		PlainHTTP:       opts.PlainHTTP,
+		SkipTLSVerify:   !opts.TlsVerify,
+		CredentialsPath: constants.CredentialsPath(opts.configHome),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve registry %s: %w", opts.modelRef.Registry, err)
+	}
+
+	repo, err := remoteRegistry.Repository(ctx, opts.modelRef.Repository)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve repository %s in registry %s", opts.modelRef.Repository, opts.modelRef.Registry)
+	}
+	if _, err := repo.Resolve(ctx, opts.modelRef.Reference); err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, fmt.Errorf("reference %s is not present in local storage and could not be found in remote", opts.modelRef.String())
+		}
+		return nil, fmt.Errorf("unexpected error retrieving reference from remote: %w", err)
+	}
+
+	return repo, nil
+}

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -48,6 +48,10 @@ const (
 	CodeLayerMediaType = "application/vnd.kitops.modelkit.code.v1.tar+gzip"
 	// Media type for the model config (Kitfile)
 	ModelConfigMediaType = "application/vnd.kitops.modelkit.config.v1+json"
+
+	// MaxModelRefChain is the maximum number of "parent" modelkits a modelkit may have
+	// by e.g. referring to another modelkit in its .model.path
+	MaxModelRefChain = 10
 )
 
 func DefaultKitfileNames() []string {

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -40,6 +40,8 @@ const (
 
 	// Media type for the model layer
 	ModelLayerMediaType = "application/vnd.kitops.modelkit.model.v1.tar+gzip"
+	// Media type for model part layer
+	ModelPartLayerMediaType = "application/vnd.kitops.modelkit.modelpart.v1.tar+gzip"
 	// Media type for the dataset layer
 	DataSetLayerMediaType = "application/vnd.kitops.modelkit.dataset.v1.tar+gzip"
 	// Media type for the code layer

--- a/pkg/lib/filesystem/ignore.go
+++ b/pkg/lib/filesystem/ignore.go
@@ -118,6 +118,9 @@ func layerPathsFromKitfile(kitfile *artifact.KitFile) []string {
 	}
 	if kitfile.Model != nil {
 		layerPaths = append(layerPaths, cleanPath(kitfile.Model.Path))
+		for _, part := range kitfile.Model.Parts {
+			layerPaths = append(layerPaths, cleanPath(part.Path))
+		}
 	}
 	return layerPaths
 }

--- a/pkg/lib/kitfile/resolve.go
+++ b/pkg/lib/kitfile/resolve.go
@@ -1,0 +1,106 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitfile
+
+import (
+	"context"
+	"fmt"
+	"kitops/pkg/artifact"
+	"kitops/pkg/cmd/info"
+	"strings"
+)
+
+const maxImportChain = 25
+
+// ResolveKitfile returns the Kitfile for a reference. Any references to other modelkits
+// are fetched and included in the resolved Kitfile, giving the equivalent Kitfile including
+// the model, datasets, and code from those referenced modelkits.
+func ResolveKitfile(ctx context.Context, configHome, ref string) (*artifact.KitFile, error) {
+	resolved := &artifact.KitFile{}
+	refChain := []string{ref}
+	for i := 0; i < maxImportChain; i++ {
+		kitfile, err := info.GetKitfileForRef(ctx, configHome, ref)
+		if err != nil {
+			return nil, err
+		}
+		resolved = mergeKitfiles(resolved, kitfile)
+		if resolved.Model == nil || !IsModelKitReference(resolved.Model.Path) {
+			return resolved, nil
+		}
+		if idx := getIndex(refChain, resolved.Model.Path); idx != -1 {
+			cycleStr := fmt.Sprintf("[%s=>%s]", strings.Join(refChain[idx:], "=>"), resolved.Model.Path)
+			return nil, fmt.Errorf("Found cycle in modelkit references: %s", cycleStr)
+		}
+		refChain = append(refChain, resolved.Model.Path)
+		ref = resolved.Model.Path
+	}
+
+	return resolved, nil
+}
+
+func mergeKitfiles(into, from *artifact.KitFile) *artifact.KitFile {
+	firstNonEmpty := func(strs ...string) string {
+		for _, s := range strs {
+			if s != "" {
+				return s
+			}
+		}
+		return ""
+	}
+
+	result := &artifact.KitFile{}
+	result.ManifestVersion = firstNonEmpty(into.ManifestVersion, from.ManifestVersion)
+	result.Kit.Name = firstNonEmpty(into.Kit.Name, from.Kit.Name)
+	result.Kit.Description = firstNonEmpty(into.Kit.Description, from.Kit.Description)
+	result.Kit.License = firstNonEmpty(into.Kit.License, from.Kit.License)
+	result.Kit.Version = firstNonEmpty(into.Kit.Version, from.Kit.Version)
+	result.Kit.Authors = append(into.Kit.Authors, from.Kit.Authors...)
+
+	if into.Model != nil || from.Model != nil {
+		result.Model = &artifact.TrainedModel{}
+		intoModel := into.Model
+		fromModel := from.Model
+		if intoModel == nil {
+			intoModel = &artifact.TrainedModel{}
+		}
+		if fromModel == nil {
+			fromModel = &artifact.TrainedModel{}
+		}
+		result.Model.Path = fromModel.Path
+		result.Model.Name = firstNonEmpty(intoModel.Name, fromModel.Name)
+		result.Model.Description = firstNonEmpty(intoModel.Description, fromModel.Description)
+		result.Model.License = firstNonEmpty(intoModel.License, fromModel.License)
+		result.Model.Framework = firstNonEmpty(intoModel.Framework, fromModel.Framework)
+		result.Model.Version = firstNonEmpty(intoModel.Version, fromModel.Version)
+		result.Model.Parts = append(intoModel.Parts, fromModel.Parts...)
+	}
+
+	result.Code = into.Code
+	result.Code = append(result.Code, from.Code...)
+	result.DataSets = into.DataSets
+	result.DataSets = append(result.DataSets, from.DataSets...)
+	return result
+}
+
+func getIndex(list []string, s string) int {
+	for idx, item := range list {
+		if s == item {
+			return idx
+		}
+	}
+	return -1
+}

--- a/pkg/lib/kitfile/util.go
+++ b/pkg/lib/kitfile/util.go
@@ -1,0 +1,60 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitfile
+
+import (
+	"kitops/pkg/artifact"
+	"kitops/pkg/lib/repo"
+	"path/filepath"
+	"strings"
+)
+
+// IsModelKitReference returns true if the ref string "looks" like a modelkit reference
+func IsModelKitReference(ref string) bool {
+	// If it doesn't have ':' or '@' it's probably not a reference
+	if !strings.Contains(ref, ":") && !strings.Contains(ref, "@") {
+		return false
+	}
+	// Does it parse?
+	if _, _, err := repo.ParseReference(ref); err != nil {
+		return false
+	}
+	return true
+}
+
+func LayerPathsFromKitfile(kitfile *artifact.KitFile) []string {
+	cleanPath := func(path string) string {
+		return filepath.Clean(strings.TrimSpace(path))
+	}
+	var layerPaths []string
+	for _, code := range kitfile.Code {
+		layerPaths = append(layerPaths, cleanPath(code.Path))
+	}
+	for _, dataset := range kitfile.DataSets {
+		layerPaths = append(layerPaths, cleanPath(dataset.Path))
+	}
+
+	if kitfile.Model != nil {
+		if kitfile.Model.Path != "" {
+			layerPaths = append(layerPaths, cleanPath(kitfile.Model.Path))
+		}
+		for _, part := range kitfile.Model.Parts {
+			layerPaths = append(layerPaths, cleanPath(part.Path))
+		}
+	}
+	return layerPaths
+}

--- a/pkg/lib/storage/local.go
+++ b/pkg/lib/storage/local.go
@@ -93,6 +93,13 @@ func saveKitfileLayers(ctx context.Context, store repo.LocalStorage, kitfile *ar
 			return nil, err
 		}
 		layers = append(layers, layer)
+		for _, part := range kitfile.Model.Parts {
+			layer, err := saveContentLayer(ctx, store, part.Path, constants.ModelPartLayerMediaType, ignore)
+			if err != nil {
+				return nil, err
+			}
+			layers = append(layers, layer)
+		}
 	}
 	for _, code := range kitfile.Code {
 		layer, err := saveContentLayer(ctx, store, code.Path, constants.CodeLayerMediaType, ignore)
@@ -201,6 +208,8 @@ func layerTypeForMediaType(mediaType string) string {
 		return "config"
 	case constants.ModelLayerMediaType:
 		return "model"
+	case constants.ModelPartLayerMediaType:
+		return "modelpart"
 	}
 	return "<unknown>"
 }

--- a/pkg/output/logging.go
+++ b/pkg/output/logging.go
@@ -17,9 +17,9 @@
 package output
 
 import (
+	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/vbauerster/mpb/v8"
@@ -41,14 +41,16 @@ func Errorf(s string, args ...any) {
 	printFmt(stderr, s, args...)
 }
 
-func Fatalln(s any) {
+// Fatalln is the equivalent of Errorln except it returns a basic error to signal the command has failed
+func Fatalln(s any) error {
 	fmt.Fprintln(stderr, s)
-	os.Exit(1)
+	return errors.New("failed to run")
 }
 
-func Fatalf(s string, args ...any) {
+// Fatalf is the equivalent of Errorf except it returns a basic error to signal the command has failed
+func Fatalf(s string, args ...any) error {
 	printFmt(stderr, s, args...)
-	os.Exit(1)
+	return errors.New("failed to run")
 }
 
 func Debugln(s any) {

--- a/testing/modelkit-refs_test.go
+++ b/testing/modelkit-refs_test.go
@@ -1,0 +1,96 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type modelkitRefTestcase struct {
+	Name        string
+	Description string `yaml:"description"`
+	Modelkits   []struct {
+		Tag           string   `yaml:"tag"`
+		Kitfile       string   `yaml:"kitfile"`
+		Kitignore     string   `yaml:"kitignore"`
+		Files         []string `yaml:"files"`
+		IgnoredFiles  []string `yaml:"ignored"`
+		PackErrRegexp *string  `yaml:"packErrRegexp"`
+	} `yaml:"modelkits"`
+}
+
+func (t modelkitRefTestcase) withName(name string) modelkitRefTestcase {
+	t.Name = name
+	return t
+}
+
+func TestModelKitReferences(t *testing.T) {
+	cleanup := testPreflight(t)
+	defer cleanup(t)
+	tests := loadAllTestCasesOrPanic[modelkitRefTestcase](t, filepath.Join("testdata", "modelkit-refs"))
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.Description), func(t *testing.T) {
+			// Set up temporary directory for work
+			tmpDir, removeTmp := setupTempDir(t)
+			defer removeTmp()
+
+			// Set up directory for KITOPS_HOME
+			contextPath := filepath.Join(tmpDir, ".kitops")
+			if err := os.MkdirAll(contextPath, 0755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("KITOPS_HOME", contextPath)
+
+			// Set up temporary directories for modelkits; note we create one extra for the final unpack
+			for i := 0; i <= len(tt.Modelkits); i++ {
+				if err := os.MkdirAll(filepath.Join(tmpDir, fmt.Sprintf("modelkit-%d", i)), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var allFiles []string
+			for idx, modelkit := range tt.Modelkits {
+				curDir := filepath.Join(tmpDir, fmt.Sprintf("modelkit-%d", idx))
+				nextDir := filepath.Join(tmpDir, fmt.Sprintf("modelkit-%d", idx+1))
+				// Set up modelkit directory
+				setupKitfileAndKitignore(t, curDir, modelkit.Kitfile, modelkit.Kitignore)
+				setupFiles(t, curDir, append(modelkit.Files, modelkit.IgnoredFiles...))
+
+				// Save files that are expected to exist to verify they all end up in the modelkit
+				allFiles = append(allFiles, modelkit.Files...)
+
+				// Pack the current dir, unpack it into the next dir. If we expect this to fail, assert that
+				// output contains expected text
+				if modelkit.PackErrRegexp != nil {
+					packOutput := runCommand(t, expectError, "pack", curDir, "-t", modelkit.Tag, "-v")
+					assertContainsLineRegexp(t, packOutput, *modelkit.PackErrRegexp, true)
+					continue
+				}
+				runCommand(t, expectNoError, "pack", curDir, "-t", modelkit.Tag, "-v")
+				runCommand(t, expectNoError, "list")
+				runCommand(t, expectNoError, "unpack", modelkit.Tag, "-d", nextDir, "-v")
+
+				// Verify unpacked contents
+				checkFilesExist(t, nextDir, allFiles)
+				checkFilesDoNotExist(t, nextDir, modelkit.IgnoredFiles)
+			}
+		})
+	}
+}

--- a/testing/remove_test.go
+++ b/testing/remove_test.go
@@ -50,17 +50,17 @@ func TestRemoveSingleModelkitTag(t *testing.T) {
 	}
 
 	// Pack model kit and tag it
-	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:delete_testing", "-v")
+	packOut := runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:delete_testing", "-v")
 	digest := digestFromPack(t, packOut)
 	modelRegexp := fmt.Sprintf(`^test\s+delete_testing.*%s$`, digest)
 
 	// Ensure modelkit exists in output of 'kit list'
-	listOut := runCommand(t, "list")
+	listOut := runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, modelRegexp, true)
 
 	// Remove modelkit and verify it's no longer in 'kit list'
-	runCommand(t, "remove", "test:delete_testing", "-v")
-	listOut = runCommand(t, "list")
+	runCommand(t, expectNoError, "remove", "test:delete_testing", "-v")
+	listOut = runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, modelRegexp, false)
 }
 
@@ -78,18 +78,18 @@ func TestRemoveSingleModelkitDigest(t *testing.T) {
 	}
 
 	// Pack model kit and tag it
-	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:delete_testing", "-v")
+	packOut := runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:delete_testing", "-v")
 	digest := digestFromPack(t, packOut)
 	modelRegexp := fmt.Sprintf(`^test\s+delete_testing.*%s$`, digest)
 
 	// Ensure modelkit exists in output of 'kit list'
-	listOut := runCommand(t, "list")
+	listOut := runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, modelRegexp, true)
 
 	// Remove modelkit and verify it's no longer in 'kit list'
 	ref := fmt.Sprintf("test@%s", digest)
-	runCommand(t, "remove", ref, "-v")
-	listOut = runCommand(t, "list")
+	runCommand(t, expectNoError, "remove", ref, "-v")
+	listOut = runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, modelRegexp, false)
 }
 
@@ -107,17 +107,17 @@ func TestRemoveSingleModelkitNoTag(t *testing.T) {
 	}
 
 	// Pack model kit and tag it
-	packOut := runCommand(t, "pack", modelKitPath, "-v")
+	packOut := runCommand(t, expectNoError, "pack", modelKitPath, "-v")
 	digest := digestFromPack(t, packOut)
 	modelRegexp := fmt.Sprintf(`^.*%s$`, digest)
 
 	// Ensure modelkit exists in output of 'kit list'
-	listOut := runCommand(t, "list")
+	listOut := runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, modelRegexp, true)
 
 	// Remove modelkit and verify it's no longer in 'kit list'
-	runCommand(t, "remove", digest, "-v")
-	listOut = runCommand(t, "list")
+	runCommand(t, expectNoError, "remove", digest, "-v")
+	listOut = runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, modelRegexp, false)
 }
 
@@ -135,21 +135,21 @@ func TestRemoveModelkitUntagsWhenMultiple(t *testing.T) {
 	}
 
 	// Pack model kit and tag it
-	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:test_tag_1", "-v")
+	packOut := runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:test_tag_1", "-v")
 	digest := digestFromPack(t, packOut)
 	firstModelRegexp := fmt.Sprintf(`^test\s+test_tag_1.*%s$`, digest)
 
-	runCommand(t, "tag", "test:test_tag_1", "test:test_tag_2", "-v")
+	runCommand(t, expectNoError, "tag", "test:test_tag_1", "test:test_tag_2", "-v")
 	secondModelRegexp := fmt.Sprintf(`^test\s+test_tag_2.*%s$`, digest)
 
 	// Ensure modelkit exists in output of 'kit list'
-	listOut := runCommand(t, "list")
+	listOut := runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, firstModelRegexp, true)
 	assertContainsLineRegexp(t, listOut, secondModelRegexp, true)
 
 	// Remove modelkit and verify it's no longer in 'kit list'
-	runCommand(t, "remove", "test:test_tag_1", "-v")
-	listOut = runCommand(t, "list")
+	runCommand(t, expectNoError, "remove", "test:test_tag_1", "-v")
+	listOut = runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, firstModelRegexp, false)
 	assertContainsLineRegexp(t, listOut, secondModelRegexp, true)
 }
@@ -168,22 +168,22 @@ func TestRemoveModelkitUntagsAllWhenDigest(t *testing.T) {
 	}
 
 	// Pack model kit and tag it
-	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:test_tag_1", "-v")
+	packOut := runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:test_tag_1", "-v")
 	digest := digestFromPack(t, packOut)
 	firstModelRegexp := fmt.Sprintf(`^test\s+test_tag_1.*%s$`, digest)
 
-	runCommand(t, "tag", "test:test_tag_1", "test:test_tag_2", "-v")
+	runCommand(t, expectNoError, "tag", "test:test_tag_1", "test:test_tag_2", "-v")
 	secondModelRegexp := fmt.Sprintf(`^test\s+test_tag_2.*%s$`, digest)
 
 	// Ensure modelkit exists in output of 'kit list'
-	listOut := runCommand(t, "list")
+	listOut := runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, firstModelRegexp, true)
 	assertContainsLineRegexp(t, listOut, secondModelRegexp, true)
 
 	// Remove modelkit and verify it's no longer in 'kit list'
 	ref := fmt.Sprintf("test@%s", digest)
-	runCommand(t, "remove", ref, "-v")
-	listOut = runCommand(t, "list")
+	runCommand(t, expectNoError, "remove", ref, "-v")
+	listOut = runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, firstModelRegexp, false)
 	assertContainsLineRegexp(t, listOut, secondModelRegexp, false)
 }
@@ -202,30 +202,30 @@ func TestRemoveModelkitUntagged(t *testing.T) {
 	}
 
 	// Pack model kit and tag it
-	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	packOut := runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
 	digestOne := digestFromPack(t, packOut)
 	regexpOne := fmt.Sprintf("^test.*%s$", digestOne)
 
 	// Create files to pack with a different digests
 	setupFiles(t, modelKitPath, []string{"testfile-1"})
-	packOut = runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	packOut = runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
 	digestTwo := digestFromPack(t, packOut)
 	regexpTwo := fmt.Sprintf("^test.*%s$", digestTwo)
 
 	setupFiles(t, modelKitPath, []string{"testfile-2"})
-	packOut = runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	packOut = runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
 	digestThree := digestFromPack(t, packOut)
 	regexpThree := fmt.Sprintf(`^test\s+testing-tag.*%s$`, digestThree)
 
 	// Ensure modelkit exists in output of 'kit list'
-	listOut := runCommand(t, "list")
+	listOut := runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, regexpOne, true)
 	assertContainsLineRegexp(t, listOut, regexpTwo, true)
 	assertContainsLineRegexp(t, listOut, regexpThree, true)
 
 	// Remove modelkit and verify it's no longer in 'kit list'
-	runCommand(t, "remove", "--all", "-v")
-	listOut = runCommand(t, "list")
+	runCommand(t, expectNoError, "remove", "--all", "-v")
+	listOut = runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, regexpOne, false)
 	assertContainsLineRegexp(t, listOut, regexpTwo, false)
 	assertContainsLineRegexp(t, listOut, regexpThree, true)
@@ -245,30 +245,30 @@ func TestRemoveModelkitAll(t *testing.T) {
 	}
 
 	// Pack model kit and tag it
-	packOut := runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	packOut := runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
 	digestOne := digestFromPack(t, packOut)
 	regexpOne := fmt.Sprintf("^test.*%s$", digestOne)
 
 	// Create files to pack with a different digests
 	setupFiles(t, modelKitPath, []string{"testfile-1"})
-	packOut = runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	packOut = runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
 	digestTwo := digestFromPack(t, packOut)
 	regexpTwo := fmt.Sprintf("^test.*%s$", digestTwo)
 
 	setupFiles(t, modelKitPath, []string{"testfile-2"})
-	packOut = runCommand(t, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
+	packOut = runCommand(t, expectNoError, "pack", modelKitPath, "-t", "test:testing-tag", "-v")
 	digestThree := digestFromPack(t, packOut)
 	regexpThree := fmt.Sprintf(`^test\s+testing-tag.*%s$`, digestThree)
 
 	// Ensure modelkit exists in output of 'kit list'
-	listOut := runCommand(t, "list")
+	listOut := runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, regexpOne, true)
 	assertContainsLineRegexp(t, listOut, regexpTwo, true)
 	assertContainsLineRegexp(t, listOut, regexpThree, true)
 
 	// Remove modelkit and verify it's no longer in 'kit list'
-	runCommand(t, "remove", "--all", "--force", "-v")
-	listOut = runCommand(t, "list")
+	runCommand(t, expectNoError, "remove", "--all", "--force", "-v")
+	listOut = runCommand(t, expectNoError, "list")
 	assertContainsLineRegexp(t, listOut, regexpOne, false)
 	assertContainsLineRegexp(t, listOut, regexpTwo, false)
 	assertContainsLineRegexp(t, listOut, regexpThree, false)

--- a/testing/testdata/modelkit-refs/test_reference-basic.yaml
+++ b/testing/testdata/modelkit-refs/test_reference-basic.yaml
@@ -1,0 +1,63 @@
+description: "Test that pack works with modelkit references"
+modelkits:
+  - tag: test-ref:model-1
+    kitfile: |
+      manifestVersion: 1.0.0
+      package:
+        name: model-1
+      model:
+        name: model-1
+        path: my-model/
+        parts:
+        - name: model-1-part-1
+          path: my-model-alt/model-1-part-1.txt
+        - name: model-1-part-2
+          path: model-1-part-2.txt
+    files:
+    - my-model/model-1-file-1.txt
+    - my-model/model-1-file-2.txt
+    - my-model/model-1-subdir/model-1-file-3.txt
+    - my-model-alt/model-1-part-1.txt
+    - model-1-part-2.txt
+  - tag: test-ref:model-2
+    kitfile: |
+      manifestVersion: 1.0.0
+      package:
+        name: model-2
+      model:
+        name: model-2
+        path: test-ref:model-1
+        parts:
+        - name: model-2-part-1
+          path: my-model/model-2-dir-1
+        - name: model-2-part-2
+          path: my-model-alt/model-2-part-1.txt
+        - name: model-2-part-3
+          path: model-2-part-3.txt
+    files:
+    - my-model/model-2-dir-1/model-2-subdir-part-1.txt
+    - my-model/model-2-dir-1/model-2-subdir-part-2.txt
+    - my-model-alt/model-2-part-1.txt
+    - model-2-part-3.txt
+  - tag: test-ref:model-3
+    kitfile: |
+      manifestVersion: 1.0.0
+      package:
+        name: model-3
+      model:
+        name: model-3
+        path: test-ref:model-2
+        parts:
+        - name: model-3-part-1
+          path: my-model/model-2-dir-1/model-3-part-1.txt
+        - name: model-3-part-2
+          path: my-model/model-3-part-2.txt
+        - name: model-3-part-3
+          path: my-model-alt/model-3-part-1.txt
+        - name: model-3-part-4
+          path: model-3-part-4.txt
+    files:
+    - my-model/model-2-dir-1/model-3-part-1.txt
+    - my-model/model-3-part-2.txt
+    - my-model-alt/model-3-part-1.txt
+    - model-3-part-4.txt

--- a/testing/testdata/modelkit-refs/test_reference-long-chain.yaml
+++ b/testing/testdata/modelkit-refs/test_reference-long-chain.yaml
@@ -1,0 +1,65 @@
+description: "Test that long modelkit reference chains fail to pack"
+modelkits:
+  - tag: test-ref:model-1
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: file-1.txt
+    files:
+      - file-1.txt
+  - tag: test-ref:model-2
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-1
+  - tag: test-ref:model-3
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-2
+  - tag: test-ref:model-4
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-3
+  - tag: test-ref:model-5
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-4
+  - tag: test-ref:model-6
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-5
+  - tag: test-ref:model-7
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-6
+  - tag: test-ref:model-8
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-7
+  - tag: test-ref:model-9
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-8
+  - tag: test-ref:model-10
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-9
+  - tag: test-ref:model-11
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-10
+  - tag: test-ref:model-12
+    kitfile: |
+      manifestVersion: 1.0.0
+      model:
+        path: test-ref:model-11
+    packErrRegexp: Reached maximum number of model references

--- a/testing/testdata/modelkit-refs/test_reference-loop.yaml
+++ b/testing/testdata/modelkit-refs/test_reference-loop.yaml
@@ -1,0 +1,37 @@
+description: "Test that pack fails when modelkit references form a loop"
+modelkits:
+  - tag: test-ref:model-1
+    kitfile: |
+      manifestVersion: 1.0.0
+      package:
+        name: model-1
+      model:
+        name: model-1
+        path: file-1.txt
+    files:
+      - file-1.txt
+  - tag: test-ref:model-2
+    kitfile: |
+      manifestVersion: 1.0.0
+      package:
+        name: model-2
+      model:
+        name: model-2
+        path: test-ref:model-1
+  - tag: test-ref:model-3
+    kitfile: |
+      manifestVersion: 1.0.0
+      package:
+        name: model-3
+      model:
+        name: model-3
+        path: test-ref:model-2
+  - tag: test-ref:model-1
+    kitfile: |
+      manifestVersion: 1.0.0
+      package:
+        name: model-1
+      model:
+        name: model-1
+        path: test-ref:model-3
+    packErrRegexp: "Found cycle in modelkit references"

--- a/testing/testdata/pack-unpack/test_pack-modelkit-parts-kitignore.yaml
+++ b/testing/testdata/pack-unpack/test_pack-modelkit-parts-kitignore.yaml
@@ -1,0 +1,31 @@
+name: Packs and unpacks modelKit parts with kitignore
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-model-parts-ignore
+  model:
+    name: test-model
+    path: ./model
+    parts:
+    - name: part1
+      path: model/part1/
+    - name: part2
+      path: model/part2/
+    - name: part3
+      path: part3/
+kitignore: |
+  **/*.md
+  **/part2/ignored
+files:
+  - model/main-model1
+  - model/main-model2
+  - model/part1/part1A
+  - model/part1/part1B
+  - model/part2/part2A
+  - model/part2/part2B
+  - part3/part3A
+ignored:
+  - model/main-ignored.md
+  - model/part1/part1-ignored.md
+  - model/part2/ignored/ignored-file.txt
+  - part3/ignored.md

--- a/testing/testdata/pack-unpack/test_pack-modelkit-parts.yaml
+++ b/testing/testdata/pack-unpack/test_pack-modelkit-parts.yaml
@@ -1,0 +1,21 @@
+name: Packs and unpacks modelKit parts
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-model-parts
+  model:
+    name: test-model
+    path: ./model
+    parts:
+      - name: part1
+        path: ./model/part1
+      - name: part2
+        path: model/part2
+      - name: part3
+        path: ./part3
+files:
+  - model/main-model-1
+  - model/main-model-2
+  - model/part1
+  - model/part2
+  - part3


### PR DESCRIPTION
### Description
This PR makes a number of changes:

1. We're adding a field to the Kitfile, under `model`:
    ```yaml
    model:
      name: <model-name>
      path: <path>
      parts: # New
        - name: readme
          path: my-readme.md
          description: My Readme file
        - <another part>
    ```
    The parts field is currently a list of structs that look similar to models. It can be used to e.g. store a license/readme alongside binary model data.

2. Kitfiles now allow you to refer to other modelkits in the model's `path` field:
    ```yaml
    model:
      name: <model-name>
      path: ghcr.io/jozu-ai/llama-2:7b-text-q4_0
      parts:
        - name: additional-file
          path: ./my-file.bin
    ```
    I've kept the field `path` even though it could be a model reference now for compatibility.

### Testing
For testing purposes, I've packed and pushed two images: `docker.io/amisevsk/artifact-test:base` and `docker.io/amisevsk/artifact-test:sub`. The `sub` image references the `base` image in its Kitfile (see `kit info --remote docker.io/amisevsk/artifact-test:sub`)
 
I intend to add tests for packing+unpacking modelkits with references as above, hopefully soon.

### Linked issues
Closes #85 

