### PR TITLE
Avoid copying layer into local storage during pack

### DIFF
--- a/pkg/lib/repo/local.go
+++ b/pkg/lib/repo/local.go
@@ -35,6 +35,7 @@ import (
 type LocalStorage interface {
 	GetRepo() string
 	GetIndex() (*ocispec.Index, error)
+	getStorePath() string
 	oras.Target
 	content.Deleter
 	content.Untagger
@@ -104,6 +105,14 @@ func (s *LocalStore) GetIndex() (*ocispec.Index, error) {
 // GetRepo returns the registry and repository for the current OCI store.
 func (s *LocalStore) GetRepo() string {
 	return s.repo
+}
+
+func (s *LocalStore) getStorePath() string {
+	return s.storePath
+}
+
+func BlobPathForManifest(store LocalStorage, desc ocispec.Descriptor) string {
+	return filepath.Join(store.getStorePath(), "blobs", "sha256", desc.Digest.Encoded())
 }
 
 // findStoragePaths walks the filesystem rooted at storageRoot looking for index.json


### PR DESCRIPTION
### Description
Avoid requiring a data copy during the packing process to cut down on peak storage usage and slightly increase speed. Previously, the process was

1. Compress layer files to a `.tar.gz` in `$TMPDIR` and read digest from file
2. Construct a manifest and push the `.tar.gz` into local OCI storage (requires copying)
3. Remove the temporary `.tar.gz` from step 1.

Since OCI storage is content-addressible, instead of pushing into OCI storage during step 2, we instead copy the temporary `.tar.gz` directly into its expected location and verify that the OCI store has picked it up correctly.

### Linked issues
N/A