### PR TITLE
Add validation for Kitfiles

### DIFF
--- a/pkg/cmd/pack/pack.go
+++ b/pkg/cmd/pack/pack.go
@@ -81,7 +81,7 @@ func pack(ctx context.Context, opts *packOptions, kitfile *artifact.KitFile, sto
 		baseRef := repo.FormatRepositoryForDisplay(opts.modelRef.String())
 		parentKitfile, err := kfutils.ResolveKitfile(ctx, opts.configHome, kitfile.Model.Path, baseRef)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed to resolve referenced modelkit %s: %w", kitfile.Model.Path, err)
 		}
 		extraLayerPaths = kfutils.LayerPathsFromKitfile(parentKitfile)
 	}
@@ -107,6 +107,9 @@ func readKitfile(modelFile string) (*artifact.KitFile, error) {
 	}
 	defer kitfileContentReader.Close()
 	if err := kitfile.LoadModel(kitfileContentReader); err != nil {
+		return nil, err
+	}
+	if err := kfutils.ValidateKitfile(kitfile); err != nil {
 		return nil, err
 	}
 	return kitfile, nil

--- a/pkg/lib/kitfile/resolve.go
+++ b/pkg/lib/kitfile/resolve.go
@@ -38,6 +38,9 @@ func ResolveKitfile(ctx context.Context, configHome, kitfileRef, baseRef string)
 		}
 		resolved = mergeKitfiles(resolved, kitfile)
 		if resolved.Model == nil || !IsModelKitReference(resolved.Model.Path) {
+			if err := ValidateKitfile(resolved); err != nil {
+				return nil, err
+			}
 			return resolved, nil
 		}
 		if idx := getIndex(refChain, resolved.Model.Path); idx != -1 {

--- a/pkg/lib/kitfile/validate.go
+++ b/pkg/lib/kitfile/validate.go
@@ -1,0 +1,72 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitfile
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"kitops/pkg/artifact"
+)
+
+// ValidateKitfile returns an error if the parsed Kitfile is not valid. The error string
+// is multiple lines, each consisting of an issue in the kitfile (e.g. duplicate path).
+func ValidateKitfile(kf *artifact.KitFile) error {
+	// Map of paths to the component that uses them; used to detect duplicate paths
+	paths := map[string][]string{}
+	addPath := func(path, source string) {
+		if path == "" {
+			path = "."
+		}
+		paths[path] = append(paths[path], source)
+	}
+
+	if kf.Model != nil {
+		addPath(kf.Model.Path, fmt.Sprintf("model %s", kf.Model.Name))
+		for _, part := range kf.Model.Parts {
+			addPath(part.Path, fmt.Sprintf("modelpart %s", part.Name))
+		}
+	}
+	for _, dataset := range kf.DataSets {
+		addPath(dataset.Path, fmt.Sprintf("dataset %s", dataset.Name))
+	}
+	for idx, code := range kf.Code {
+		addPath(code.Path, fmt.Sprintf("code layer %d", idx))
+	}
+
+	var errs []string
+	for layerPath, layerIds := range paths {
+		if len := len(layerIds); len > 1 {
+			errMsg := fmt.Sprintf("  * %s and %s use the same path %s", strings.Join(layerIds[:len-1], ", "), layerIds[len-1], layerPath)
+			errs = append(errs, errMsg)
+		}
+		if path.IsAbs(layerPath) || filepath.IsAbs(layerPath) {
+			errMsg := fmt.Sprintf("  * absolute paths are not supported in a Kitfile (path %s in %s)", layerPath, layerIds[0])
+			errs = append(errs, errMsg)
+		}
+	}
+	if len(errs) > 0 {
+		// Iterating through the paths map is random; sort to get a consistent message
+		slices.Sort(errs)
+		return fmt.Errorf("errors while validating Kitfile: \n%s", strings.Join(errs, "\n"))
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Description
Add some basic validation to Kitfiles, printing an error if

* Multiple layers share the same path (makes unpacking/ignoring unclear)
* Any layer is an absolute path rather than relative
* Model part's type field is invalid: (max 64 characters, alphanumeric with `.`, `-`, and `_`; must start with alphanumeric)

### Testing
You can see all of the failure cases by trying to pack the following Kitfile

<details>
<summary>Kitfile</summary>

```yaml
manifestVersion: 1.0.0
package:
  name: test-kf
model:
  name: my-model
  path: path1
  parts:
    - name: part1
      path: path1
    - name: part2
      path: /abs/path
    - name: part3
      path: valid-path
      type: test type with space
    - name: part4
      path: also-valid
      type: really-long-but-otherwise-valid-type---this-line-is-65-chars-long
datasets:
  - name: dataset1
    path: path1
  - name: dataset2
    path: path3
  - name: dataset3
    path: /abs/path/2
code:
  - path: path1
  - path: path3
  - path: /abs/path/3
```
</details>

### Linked issues
<!-- link any issues in this repository that are related to the PR; use "closes <issue>" or "fixes <issue>" to automatically link issues to this PR -->
Closes #81 