### PR TITLE
Set SilenceErrors and SilenceUsage on root command PersistentPreRun

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,11 @@ func RunCommand() *cobra.Command {
 			}
 			ctx := context.WithValue(cmd.Context(), constants.ConfigKey{}, configHome)
 			cmd.SetContext(ctx)
+			// At this point, we've parsed the command tree and args; the CLI is being correctly
+			// so we don't want to print usage. Each subcommand should print its error message before
+			// returning
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
 		},
 	}
 	addSubcommands(cmd)

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -74,10 +74,6 @@ func InfoCommand() *cobra.Command {
 
 func runCommand(opts *infoOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -74,10 +74,6 @@ func InspectCommand() *cobra.Command {
 
 func runCommand(opts *inspectOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -103,10 +103,6 @@ func ListCommand() *cobra.Command {
 
 func runCommand(opts *listOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/login/cmd.go
+++ b/pkg/cmd/login/cmd.go
@@ -61,10 +61,6 @@ func LoginCommand() *cobra.Command {
 
 func runCommand(opts *loginOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/logout/cmd.go
+++ b/pkg/cmd/logout/cmd.go
@@ -42,10 +42,6 @@ func LogoutCommand() *cobra.Command {
 
 func runCommand(opts *logoutOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -68,10 +68,6 @@ func PackCommand() *cobra.Command {
 
 func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		err := opts.complete(cmd.Context(), args)
 		if err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -83,10 +83,6 @@ func PullCommand() *cobra.Command {
 
 func runCommand(opts *pullOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -89,10 +89,6 @@ func PushCommand() *cobra.Command {
 
 func runCommand(opts *pushOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -117,10 +117,6 @@ func RemoveCommand() *cobra.Command {
 
 func runCommand(opts *removeOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/tag/cmd.go
+++ b/pkg/cmd/tag/cmd.go
@@ -110,10 +110,6 @@ func TagCommand() *cobra.Command {
 
 func runCommand(opts *tagOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -126,10 +126,6 @@ func UnpackCommand() *cobra.Command {
 
 func runCommand(opts *unpackOptions) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Don't want to output usage and placeholder error if this command fails. We can't set this higher up
-		// since it will suppress usage and error messages for actual incorrect usage (e.g. wrong number of args)
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}


### PR DESCRIPTION
### Description
Set options in the pre-run instead of manually in each subcommand. A little cleaner.

### Linked issues
Related: https://github.com/jozu-ai/kitops/pull/260#discussion_r1579899116