### PR TITLE
Fixup validation - typo in regexp

### DIFF
--- a/pkg/lib/kitfile/validate.go
+++ b/pkg/lib/kitfile/validate.go
@@ -29,7 +29,7 @@ import (
 
 const partTypeMaxLen = 64
 
-var partTypeRegexp = regexp.MustCompile(`^[\w][\w.-]$`)
+var partTypeRegexp = regexp.MustCompile(`^[\w][\w.-]*$`)
 
 // ValidateKitfile returns an error if the parsed Kitfile is not valid. The error string
 // is multiple lines, each consisting of an issue in the kitfile (e.g. duplicate path).


### PR DESCRIPTION
### Description
In changing the regexp to check max length separately, I forgot to add the `*` instead of `{0,64}`, meaning we're only allowing types that are 2 characters long.

### Linked issues
<!-- link any issues in this repository that are related to the PR; use "closes <issue>" or "fixes <issue>" to automatically link issues to this PR -->
