### PR TITLE
Add more info to output of `kit inspect`

### DIFF
--- a/pkg/cmd/info/info.go
+++ b/pkg/cmd/info/info.go
@@ -38,7 +38,7 @@ func getLocalConfig(ctx context.Context, opts *infoOptions) (*artifact.KitFile, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to read local storage: %w", err)
 	}
-	_, config, err := repo.ResolveManifestAndConfig(ctx, store, opts.modelRef.Reference)
+	_, _, config, err := repo.ResolveManifestAndConfig(ctx, store, opts.modelRef.Reference)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func getRemoteConfig(ctx context.Context, opts *infoOptions) (*artifact.KitFile,
 	if err != nil {
 		return nil, err
 	}
-	_, config, err := repo.ResolveManifestAndConfig(ctx, repository, opts.modelRef.Reference)
+	_, _, config, err := repo.ResolveManifestAndConfig(ctx, repository, opts.modelRef.Reference)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -77,18 +77,18 @@ func runCommand(opts *inspectOptions) func(*cobra.Command, []string) error {
 		if err := opts.complete(cmd.Context(), args); err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}
-		manifest, err := inspectReference(cmd.Context(), opts)
+		inspectInfo, err := inspectReference(cmd.Context(), opts)
 		if err != nil {
 			if errors.Is(err, errdef.ErrNotFound) {
 				return output.Fatalf("Could not find modelkit %s", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
 			}
 			return output.Fatalf("Error resolving modelkit: %s", err)
 		}
-		jsonBytes, err := json.MarshalIndent(manifest, "", "  ")
+		jsonBytes, err := json.MarshalIndent(inspectInfo, "", "  ")
 		if err != nil {
-			return output.Fatalf("Error formatting manifest: %w", err)
+			return fmt.Errorf("Error formatting manifest: %w", err)
 		}
-		fmt.Println(string(jsonBytes))
+		output.Infoln(string(jsonBytes))
 		return nil
 	}
 }

--- a/pkg/cmd/inspect/inspect.go
+++ b/pkg/cmd/inspect/inspect.go
@@ -19,6 +19,7 @@ package inspect
 import (
 	"context"
 	"fmt"
+	"kitops/pkg/artifact"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/repo"
 
@@ -30,6 +31,7 @@ import (
 type inspectInfo struct {
 	Digest     digest.Digest     `json:"digest,omitempty" yaml:"digest,omitempty"`
 	CLIVersion string            `json:"cliVersion,omitempty" yaml:"cliVersion,omitempty"`
+	Kitfile    *artifact.KitFile `json:"kitfile,omitempty" yaml:"kitfile,omitempty"`
 	Manifest   *ocispec.Manifest `json:"manifest,omitempty" yaml:"manifest,omitempty"`
 }
 
@@ -47,7 +49,7 @@ func getLocalManifest(ctx context.Context, opts *inspectOptions) (*inspectInfo, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to read local storage: %w", err)
 	}
-	desc, manifest, err := repo.ResolveManifest(ctx, store, opts.modelRef.Reference)
+	desc, manifest, config, err := repo.ResolveManifestAndConfig(ctx, store, opts.modelRef.Reference)
 	if err != nil {
 		return nil, err
 	}
@@ -58,6 +60,7 @@ func getLocalManifest(ctx context.Context, opts *inspectOptions) (*inspectInfo, 
 	return &inspectInfo{
 		Digest:     desc.Digest,
 		CLIVersion: version,
+		Kitfile:    config,
 		Manifest:   manifest,
 	}, nil
 }
@@ -71,7 +74,7 @@ func getRemoteManifest(ctx context.Context, opts *inspectOptions) (*inspectInfo,
 	if err != nil {
 		return nil, err
 	}
-	desc, manifest, err := repo.ResolveManifest(ctx, repository, opts.modelRef.Reference)
+	desc, manifest, config, err := repo.ResolveManifestAndConfig(ctx, repository, opts.modelRef.Reference)
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +85,7 @@ func getRemoteManifest(ctx context.Context, opts *inspectOptions) (*inspectInfo,
 	return &inspectInfo{
 		Digest:     desc.Digest,
 		CLIVersion: version,
+		Kitfile:    config,
 		Manifest:   manifest,
 	}, nil
 }

--- a/pkg/cmd/inspect/inspect.go
+++ b/pkg/cmd/inspect/inspect.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
 )
 
 // Utility struct for formatting output of inspect
@@ -37,35 +38,22 @@ type inspectInfo struct {
 
 func inspectReference(ctx context.Context, opts *inspectOptions) (*inspectInfo, error) {
 	if opts.checkRemote {
-		return getRemoteManifest(ctx, opts)
+		return getRemoteInspect(ctx, opts)
 	} else {
-		return getLocalManifest(ctx, opts)
+		return getLocalInspect(ctx, opts)
 	}
 }
 
-func getLocalManifest(ctx context.Context, opts *inspectOptions) (*inspectInfo, error) {
+func getLocalInspect(ctx context.Context, opts *inspectOptions) (*inspectInfo, error) {
 	storageRoot := constants.StoragePath(opts.configHome)
 	store, err := repo.NewLocalStore(storageRoot, opts.modelRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read local storage: %w", err)
 	}
-	desc, manifest, config, err := repo.ResolveManifestAndConfig(ctx, store, opts.modelRef.Reference)
-	if err != nil {
-		return nil, err
-	}
-	version := "unknown"
-	if manifest.Annotations != nil && manifest.Annotations[constants.CliVersionAnnotation] != "" {
-		version = manifest.Annotations[constants.CliVersionAnnotation]
-	}
-	return &inspectInfo{
-		Digest:     desc.Digest,
-		CLIVersion: version,
-		Kitfile:    config,
-		Manifest:   manifest,
-	}, nil
+	return getInspectInfo(ctx, store, opts.modelRef.Reference)
 }
 
-func getRemoteManifest(ctx context.Context, opts *inspectOptions) (*inspectInfo, error) {
+func getRemoteInspect(ctx context.Context, opts *inspectOptions) (*inspectInfo, error) {
 	repository, err := repo.NewRepository(ctx, opts.modelRef.Registry, opts.modelRef.Repository, &repo.RegistryOptions{
 		PlainHTTP:       opts.PlainHTTP,
 		SkipTLSVerify:   !opts.TlsVerify,
@@ -74,7 +62,11 @@ func getRemoteManifest(ctx context.Context, opts *inspectOptions) (*inspectInfo,
 	if err != nil {
 		return nil, err
 	}
-	desc, manifest, config, err := repo.ResolveManifestAndConfig(ctx, repository, opts.modelRef.Reference)
+	return getInspectInfo(ctx, repository, opts.modelRef.Reference)
+}
+
+func getInspectInfo(ctx context.Context, repository oras.Target, ref string) (*inspectInfo, error) {
+	desc, manifest, kitfile, err := repo.ResolveManifestAndConfig(ctx, repository, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +77,7 @@ func getRemoteManifest(ctx context.Context, opts *inspectOptions) (*inspectInfo,
 	return &inspectInfo{
 		Digest:     desc.Digest,
 		CLIVersion: version,
-		Kitfile:    config,
+		Kitfile:    kitfile,
 		Manifest:   manifest,
 	}, nil
 }

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -52,6 +52,9 @@ const (
 	// Media type for the model config (Kitfile)
 	ModelConfigMediaType = "application/vnd.kitops.modelkit.config.v1+json"
 
+	// Kitops-specific annotations for modelkit artifacts
+	CliVersionAnnotation = "ml.kitops.modelkit.cli-version"
+
 	// MaxModelRefChain is the maximum number of "parent" modelkits a modelkit may have
 	// by e.g. referring to another modelkit in its .model.path
 	MaxModelRefChain = 10

--- a/pkg/lib/repo/repo.go
+++ b/pkg/lib/repo/repo.go
@@ -220,7 +220,7 @@ func GetConfig(ctx context.Context, store content.Storage, configDesc ocispec.De
 func ResolveManifest(ctx context.Context, store oras.Target, reference string) (ocispec.Descriptor, *ocispec.Manifest, error) {
 	desc, err := store.Resolve(ctx, reference)
 	if err != nil {
-		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("reference %s not found in remote repository: %w", reference, err)
+		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("reference %s not found in repository: %w", reference, err)
 	}
 	manifest, err := GetManifest(ctx, store, desc)
 	if err != nil {

--- a/pkg/lib/repo/repo.go
+++ b/pkg/lib/repo/repo.go
@@ -217,26 +217,30 @@ func GetConfig(ctx context.Context, store content.Storage, configDesc ocispec.De
 }
 
 // ResolveManifest returns the manifest for a reference (tag), if present in the target store
-func ResolveManifest(ctx context.Context, store oras.Target, reference string) (*ocispec.Manifest, error) {
+func ResolveManifest(ctx context.Context, store oras.Target, reference string) (ocispec.Descriptor, *ocispec.Manifest, error) {
 	desc, err := store.Resolve(ctx, reference)
 	if err != nil {
-		return nil, fmt.Errorf("reference %s not found in remote repository: %w", reference, err)
+		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("reference %s not found in remote repository: %w", reference, err)
 	}
-	return GetManifest(ctx, store, desc)
+	manifest, err := GetManifest(ctx, store, desc)
+	if err != nil {
+		return ocispec.DescriptorEmptyJSON, nil, err
+	}
+	return desc, manifest, nil
 }
 
 // ResolveManifestAndConfig returns the manifest and config (Kitfile) for a given reference (tag), if present
 // in the store. Calls ResolveManifest and GetConfig.
-func ResolveManifestAndConfig(ctx context.Context, store oras.Target, reference string) (*ocispec.Manifest, *artifact.KitFile, error) {
-	manifest, err := ResolveManifest(ctx, store, reference)
+func ResolveManifestAndConfig(ctx context.Context, store oras.Target, reference string) (ocispec.Descriptor, *ocispec.Manifest, *artifact.KitFile, error) {
+	desc, manifest, err := ResolveManifest(ctx, store, reference)
 	if err != nil {
-		return nil, nil, err
+		return ocispec.DescriptorEmptyJSON, nil, nil, err
 	}
 	config, err := GetConfig(ctx, store, manifest.Config)
 	if err != nil {
-		return nil, nil, err
+		return ocispec.DescriptorEmptyJSON, nil, nil, err
 	}
-	return manifest, config, nil
+	return desc, manifest, config, nil
 }
 
 // GetTagsForDescriptor returns the list of tags that reference a particular descriptor (SHA256 hash) in LocalStorage.

--- a/pkg/lib/storage/local.go
+++ b/pkg/lib/storage/local.go
@@ -25,6 +25,7 @@ import (
 	"os"
 
 	"kitops/pkg/artifact"
+	"kitops/pkg/cmd/version"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/filesystem"
 	kfutils "kitops/pkg/lib/kitfile"
@@ -51,6 +52,7 @@ func SaveModel(ctx context.Context, store repo.LocalStorage, kitfile *artifact.K
 	}
 
 	manifest := CreateManifest(configDesc, layerDescs)
+
 	manifestDesc, err := saveModelManifest(ctx, store, manifest)
 	if err != nil {
 		return nil, err
@@ -193,10 +195,12 @@ func saveModelManifest(ctx context.Context, store oras.Target, manifest ocispec.
 
 func CreateManifest(configDesc ocispec.Descriptor, layerDescs []ocispec.Descriptor) ocispec.Manifest {
 	manifest := ocispec.Manifest{
-		Versioned:   specs.Versioned{SchemaVersion: 2},
-		Config:      configDesc,
-		Layers:      layerDescs,
-		Annotations: map[string]string{},
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		Config:    configDesc,
+		Layers:    layerDescs,
+		Annotations: map[string]string{
+			constants.CliVersionAnnotation: version.Version,
+		},
 	}
 
 	return manifest


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/jozu-ai/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/jozu-ai/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description
Add additional information to the output of `kit inspect`:
```jsonc
{
  "digest": "<modelkit-digest>",
  "cliVersion": "<cli-version>",
  "kitfile": {
    // Kitfile
  },
  "manifest": {
    // Manifest  
  }
}
```

Note this change does mean that both `kit inspect` and `kit info` produce the Kitfile for the modelkit. I've left both commands intact because `kit info` outputs the Kitfile in YAML format (easier to read) whereas `inspect` outputs JSON. We can't yet produce yaml output for inspect since the OCI manifest struct does not have yaml tags and `gopkg.in/yaml.v3` does not respect json tags.

Note: to test version labelling, you will need to build `kit` with the version fields set:
```bash
go build -o kit -ldflags "-s -w -X kitops/pkg/cmd/version.Version=v0.0.1+test"
```

### Linked issues
Closes #271 
