### PR TITLE
Include current CLI version in generated docs page

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -201,6 +201,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
 
+          (cd docs; npm pkg set version=$TAG_NAME)
           ./docs/src/docs/cli/generate.sh > /dev/null
           git add --all
           git commit -m "docs: update CLI documentation for ${{ github.ref_name }}"

--- a/docs/.vitepress/theme/components/VersionInfo.vue
+++ b/docs/.vitepress/theme/components/VersionInfo.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { version } from '../../../package.json'
+</script>
+
+<template>
+  <div class="flex justify-between items-center">
+    <h1 id="kit-cli-reference" tabindex="-1">
+      Kit CLI Reference
+      <a class="header-anchor" href="#kit-cli-reference" aria-label="Permalink to &quot;Kit CLI Reference&quot;">​</a>
+    </h1>
+    <div class="text-gray-05 text-med font-mono">
+      {{version}}
+    </div>
+  </div>
+</template>

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "v0.1.3",
+  "version": "v0.2.4",
   "peerDependencies": {
     "vue": "^3.4"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "v0.1.3",
   "peerDependencies": {
     "vue": "^3.4"
   },

--- a/docs/src/docs/cli/cli-reference.header
+++ b/docs/src/docs/cli/cli-reference.header
@@ -1,5 +1,8 @@
 ---
 outline: 2
+title: "Kit CLI Reference"
 ---
-# Kit CLI Reference
-
+<script setup>
+  import { version } from '../../../package.json'
+</script>
+# Kit CLI Reference {{ version }}

--- a/docs/src/docs/cli/cli-reference.header
+++ b/docs/src/docs/cli/cli-reference.header
@@ -3,6 +3,7 @@ outline: 2
 title: "Kit CLI Reference"
 ---
 <script setup>
-  import { version } from '../../../package.json'
+import VersionInfo from '@theme/components/VersionInfo.vue'
 </script>
-# Kit CLI Reference {{ version }}
+
+<VersionInfo />

--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -3,9 +3,10 @@ outline: 2
 title: "Kit CLI Reference"
 ---
 <script setup>
-  import { version } from '../../../package.json'
+import VersionInfo from '@theme/components/VersionInfo.vue'
 </script>
-# Kit CLI Reference {{ version }}
+
+<VersionInfo />
 
 ## kit dev
 

--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -1,7 +1,11 @@
 ---
 outline: 2
+title: "Kit CLI Reference"
 ---
-# Kit CLI Reference
+<script setup>
+  import { version } from '../../../package.json'
+</script>
+# Kit CLI Reference {{ version }}
 
 ## kit dev
 


### PR DESCRIPTION
### Description
Add version to CLI reference page, now (slightly) less ugly:

<img width="1512" alt="Screenshot 2024-05-15 at 5 53 07 PM" src="https://github.com/jozu-ai/kitops/assets/16168279/dd97d453-00af-4701-b943-5ae45bdbe9d7">

### Linked issues
Closes #146 
