### PR TITLE
Add canonical urls to the header

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -111,6 +111,18 @@ export default defineConfig({
     }
   },
 
+  transformPageData(pageData) {
+    const canonicalUrl = `https://kitops.ml/${pageData.relativePath}`
+      .replace(/index\.md$/, '')
+      .replace(/\.md$/, '.html')
+
+    pageData.frontmatter.head ??= []
+    pageData.frontmatter.head.push([
+      'link',
+      { rel: 'canonical', href: canonicalUrl }
+    ])
+  },
+
   vite: {
     resolve: {
       alias: [

--- a/docs/src/blog.md
+++ b/docs/src/blog.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 sidebar: false
+title: Blog
 ---
 <script setup lang="ts">
 import { computed } from 'vue'


### PR DESCRIPTION
This PR fixes #295 .

It adds a `link canonical` meta tag to the head of each generated url so crawlers can know what's the original content source when referred from other sites (or even internally).

Sample produced tag; the same generates for each page:
```
<link rel="canonical" href="https://kitops.ml/docs/overview.html">
```

This should also fix 301's warnings in the search console caused by `www.kitops.ml` going to `kitops.ml` becase `kitops.ml` will now have a canonical that defines it as the source of truth.