### PR TITLE
Use no compression for model layers by default

### DIFF
--- a/pkg/cmd/list/remote.go
+++ b/pkg/cmd/list/remote.go
@@ -89,7 +89,7 @@ func listImageTag(ctx context.Context, repo registry.Repository, ref *registry.R
 	if err := json.Unmarshal(manifestBytes, manifest); err != nil {
 		return nil, fmt.Errorf("failed to parse manifest: %w", err)
 	}
-	if manifest.Config.MediaType != constants.ModelConfigMediaType {
+	if manifest.Config.MediaType != constants.ModelConfigMediaType.String() {
 		return nil, nil
 	}
 

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -122,11 +122,8 @@ func (opts *packOptions) complete(ctx context.Context, args []string) error {
 		opts.modelRef = repo.DefaultReference()
 	}
 
-	switch opts.compression {
-	case constants.NoneCompression, constants.GzipCompression:
-		break
-	default:
-		return fmt.Errorf("Invalid option for --compression flag: must be one of 'none' or 'gzip'")
+	if err := constants.IsValidCompression(opts.compression); err != nil {
+		return err
 	}
 
 	printConfig(opts)

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -46,6 +46,7 @@ type packOptions struct {
 	configHome  string
 	storageHome string
 	fullTagRef  string
+	compression string
 	modelRef    *registry.Reference
 	extraRefs   []string
 }
@@ -62,6 +63,7 @@ func PackCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&opts.modelFile, "file", "f", "", "Specifies the path to the Kitfile explictly (use \"-\" to read from standard input)")
 	cmd.Flags().StringVarP(&opts.fullTagRef, "tag", "t", "", "Assigns one or more tags to the built modelkit. Example: -t registry/repository:tag1,tag2")
+	cmd.Flags().StringVar(&opts.compression, "compression", "gzip", "Compression format to use for layers")
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd
 }
@@ -119,6 +121,14 @@ func (opts *packOptions) complete(ctx context.Context, args []string) error {
 	} else {
 		opts.modelRef = repo.DefaultReference()
 	}
+
+	switch opts.compression {
+	case constants.NoneCompression, constants.GzipCompression:
+		break
+	default:
+		return fmt.Errorf("Invalid option for --compression flag: must be one of 'none' or 'gzip'")
+	}
+
 	printConfig(opts)
 	return nil
 }

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -63,7 +63,7 @@ func PackCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&opts.modelFile, "file", "f", "", "Specifies the path to the Kitfile explictly (use \"-\" to read from standard input)")
 	cmd.Flags().StringVarP(&opts.fullTagRef, "tag", "t", "", "Assigns one or more tags to the built modelkit. Example: -t registry/repository:tag1,tag2")
-	cmd.Flags().StringVar(&opts.compression, "compression", "gzip", "Compression format to use for layers")
+	cmd.Flags().StringVar(&opts.compression, "compression", "none", "Compression format to use for layers. Valid options: 'none' (default), 'gzip', 'gzip-fastest'")
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd
 }

--- a/pkg/cmd/pack/pack.go
+++ b/pkg/cmd/pack/pack.go
@@ -91,7 +91,7 @@ func pack(ctx context.Context, opts *packOptions, kitfile *artifact.KitFile, sto
 		return nil, err
 	}
 
-	manifestDesc, err := storage.SaveModel(ctx, store, kitfile, ignore)
+	manifestDesc, err := storage.SaveModel(ctx, store, kitfile, ignore, opts.compression)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pull/pull.go
+++ b/pkg/cmd/pull/pull.go
@@ -119,7 +119,7 @@ func referenceIsModel(ctx context.Context, ref *registry.Reference, repo registr
 	if err := json.Unmarshal(manifestBytes, manifest); err != nil {
 		return fmt.Errorf("failed to parse manifest: %w", err)
 	}
-	if manifest.Config.MediaType != constants.ModelConfigMediaType {
+	if manifest.Config.MediaType != constants.ModelConfigMediaType.String() {
 		return fmt.Errorf("reference %s does not refer to a model", ref.String())
 	}
 	return nil

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -195,7 +195,7 @@ func unpackLayer(ctx context.Context, store content.Storage, desc ocispec.Descri
 	var cr io.ReadCloser
 	var cErr error
 	switch compression {
-	case constants.GzipCompression:
+	case constants.GzipCompression, constants.GzipFastestCompression:
 		cr, cErr = gzip.NewReader(rc)
 	case constants.NoneCompression:
 		cr = rc

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -41,17 +41,6 @@ const (
 	HarnessProcessFile  = "process.pid"
 	HarnessLogFile      = "harness.log"
 
-	// Media type for the model layer
-	ModelLayerMediaType = "application/vnd.kitops.modelkit.model.v1.tar+gzip"
-	// Media type for model part layer
-	ModelPartLayerMediaType = "application/vnd.kitops.modelkit.modelpart.v1.tar+gzip"
-	// Media type for the dataset layer
-	DataSetLayerMediaType = "application/vnd.kitops.modelkit.dataset.v1.tar+gzip"
-	// Media type for the code layer
-	CodeLayerMediaType = "application/vnd.kitops.modelkit.code.v1.tar+gzip"
-	// Media type for the model config (Kitfile)
-	ModelConfigMediaType = "application/vnd.kitops.modelkit.config.v1+json"
-
 	// Kitops-specific annotations for modelkit artifacts
 	CliVersionAnnotation = "ml.kitops.modelkit.cli-version"
 

--- a/pkg/lib/constants/mediaType.go
+++ b/pkg/lib/constants/mediaType.go
@@ -30,8 +30,9 @@ const (
 )
 
 const (
-	NoneCompression = "none"
-	GzipCompression = "gzip"
+	NoneCompression        = "none"
+	GzipCompression        = "gzip"
+	GzipFastestCompression = "gzip-fastest"
 )
 
 var mediaTypeRegexp = regexp.MustCompile(`^application/vnd.kitops.modelkit.(\w+).v1.tar(?:\+(\w+))?`)
@@ -52,7 +53,11 @@ func (t MediaType) String() string {
 	if t.Compression == NoneCompression {
 		return fmt.Sprintf("application/vnd.kitops.modelkit.%s.v1.tar", t.BaseType)
 	}
-	return fmt.Sprintf("application/vnd.kitops.modelkit.%s.v1.tar+%s", t.BaseType, t.Compression)
+	comp := t.Compression
+	if comp == GzipFastestCompression {
+		comp = GzipCompression
+	}
+	return fmt.Sprintf("application/vnd.kitops.modelkit.%s.v1.tar+%s", t.BaseType, comp)
 }
 
 func ParseMediaType(s string) MediaType {
@@ -73,4 +78,13 @@ func ParseMediaType(s string) MediaType {
 		mediaType.Compression = NoneCompression
 	}
 	return mediaType
+}
+
+func IsValidCompression(compression string) error {
+	switch compression {
+	case NoneCompression, GzipCompression, GzipFastestCompression:
+		return nil
+	default:
+		return fmt.Errorf("Invalid option for --compression flag: must be one of 'none', 'gzip', or 'gzip-fastest'")
+	}
 }

--- a/pkg/lib/constants/mediaType.go
+++ b/pkg/lib/constants/mediaType.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	ConfigType    = "config"
+	ModelType     = "model"
+	ModelPartType = "modelpart"
+	DatasetType   = "dataset"
+	CodeType      = "code"
+)
+
+const (
+	NoneCompression = "none"
+	GzipCompression = "gzip"
+)
+
+var mediaTypeRegexp = regexp.MustCompile(`^application/vnd.kitops.modelkit.(\w+).v1.tar(?:\+(\w+))?`)
+
+type MediaType struct {
+	BaseType    string
+	Compression string
+}
+
+var ModelConfigMediaType = MediaType{
+	BaseType: ConfigType,
+}
+
+func (t MediaType) String() string {
+	if t.BaseType == ConfigType {
+		return "application/vnd.kitops.modelkit.config.v1+json"
+	}
+	if t.Compression == NoneCompression {
+		return fmt.Sprintf("application/vnd.kitops.modelkit.%s.v1.tar", t.BaseType)
+	}
+	return fmt.Sprintf("application/vnd.kitops.modelkit.%s.v1.tar+%s", t.BaseType, t.Compression)
+}
+
+func ParseMediaType(s string) MediaType {
+	if s == "application/vnd.kitops.modelkit.config.v1+json" {
+		return MediaType{
+			BaseType: ConfigType,
+		}
+	}
+	match := mediaTypeRegexp.FindStringSubmatch(s)
+	if match == nil {
+		return MediaType{}
+	}
+	mediaType := MediaType{
+		BaseType:    match[1],
+		Compression: match[2],
+	}
+	if mediaType.Compression == "" {
+		mediaType.Compression = NoneCompression
+	}
+	return mediaType
+}

--- a/pkg/lib/repo/repo.go
+++ b/pkg/lib/repo/repo.go
@@ -192,7 +192,7 @@ func GetManifest(ctx context.Context, store content.Storage, manifestDesc ocispe
 	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
 		return nil, fmt.Errorf("failed to parse manifest %s: %w", manifestDesc.Digest, err)
 	}
-	if manifest.Config.MediaType != constants.ModelConfigMediaType {
+	if manifest.Config.MediaType != constants.ModelConfigMediaType.String() {
 		return nil, fmt.Errorf("reference exists but is not a model")
 	}
 
@@ -202,7 +202,7 @@ func GetManifest(ctx context.Context, store content.Storage, manifestDesc ocispe
 // GetConfig returns the config (Kitfile) described by a descriptor. Returns an error if the config blob cannot
 // be resolved or if the descriptor does not describe a Kitfile.
 func GetConfig(ctx context.Context, store content.Storage, configDesc ocispec.Descriptor) (*artifact.KitFile, error) {
-	if configDesc.MediaType != constants.ModelConfigMediaType {
+	if configDesc.MediaType != constants.ModelConfigMediaType.String() {
 		return nil, fmt.Errorf("configuration descriptor does not describe a Kitfile")
 	}
 	configBytes, err := content.FetchAll(ctx, store, configDesc)

--- a/pkg/lib/storage/layer.go
+++ b/pkg/lib/storage/layer.go
@@ -77,6 +77,12 @@ func compressLayer(path string, mediaType constants.MediaType, ignore filesystem
 	case constants.GzipCompression:
 		cw = gzip.NewWriter(mw)
 		tw = tar.NewWriter(cw)
+	case constants.GzipFastestCompression:
+		cw, err = gzip.NewWriterLevel(mw, gzip.BestSpeed)
+		if err != nil {
+			return "", ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to set up gzip compression: %w", err)
+		}
+		tw = tar.NewWriter(cw)
 	case constants.NoneCompression:
 		tw = tar.NewWriter(mw)
 	}


### PR DESCRIPTION
### Description
This PR is adapted from the [compression-opts](https://github.com/jozu-ai/kitops/tree/compression-opts) branch. See discussion on #257 for details. This PR drops the `zstd` option from that branch.

This PR adds the flag `--compression` to `kit pack`, with valid options `none`, `gzip`, and `gzip-fastest`:
* `none`: no compression of layers, store layers as plain tarballs
* `gzip`: current default behavior, compress layer tarballs with gzip
* `gzip-fastest`: compress layer tarballs with gzip at the lowest compression level

The new default behavior is `none`, i.e. layers are stored in tar format with no compression. In testing, this was found to be a _lot_ faster with minimal effect on modelkit size. 

In addition, the `gzip-fastest` option is added as testing showed that it could decrease pack time by a factor of 2-10x with minimal loss in compression ratio.

### Linked issues
Closes #257 
