### PR TITLE
Pack tarballs using linux path separators on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
 kit
+kit.exe
 dist/
 pkg/lib/harness/ui.tar.gz

--- a/pkg/lib/filesystem/paths.go
+++ b/pkg/lib/filesystem/paths.go
@@ -32,6 +32,10 @@ func VerifySubpath(context, subDir string) (absPath, relPath string, err error) 
 		return "", "", fmt.Errorf("absolute paths are not supported (%s)", subDir)
 	}
 
+	if !filepath.IsLocal(subDir) {
+		return "", "", fmt.Errorf("layer paths must stay within context directory")
+	}
+
 	// Get absolute path for context
 	absContext, err := filepath.Abs(context)
 	if err != nil {
@@ -50,7 +54,7 @@ func VerifySubpath(context, subDir string) (absPath, relPath string, err error) 
 	if _, exists := PathExists(fullPath); exists {
 		res, err := filepath.EvalSymlinks(fullPath)
 		if err != nil {
-			return "", "", fmt.Errorf("error resolving %s: %w", absContext, err)
+			return "", "", fmt.Errorf("error resolving %s: %w", fullPath, err)
 		}
 		fullPath = res
 	}

--- a/pkg/lib/storage/layer.go
+++ b/pkg/lib/storage/layer.go
@@ -252,6 +252,10 @@ func removeTempFile(filepath string) {
 }
 
 func sanitizeTarHeader(header *tar.Header) {
+	// On windows, store paths linux-style (forward slashes). This is a no-op if
+	// filepath.Separator is '/'
+	header.Name = filepath.ToSlash(header.Name)
+	// Clear fields that break reproducible tars
 	header.AccessTime = time.Time{}
 	header.ModTime = time.Time{}
 	header.ChangeTime = time.Time{}


### PR DESCRIPTION

### Description
Store paths in layer tarballs using linux-style paths (i.e. using separator `/`) on Windows to avoid issues unpacking windows-packed modelkits on Linux/MacOS

### Linked issues
Closes #291 
