### PR TITLE
Fixup regexp used for validating repository names

### DIFF
--- a/pkg/lib/repo/repo.go
+++ b/pkg/lib/repo/repo.go
@@ -39,8 +39,7 @@ const (
 )
 
 var (
-	validTagRegex        = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$`)
-	startEndAlphanumeric = regexp.MustCompile(`[a-z0-9].*[a-z0-9]`)
+	startEndAlphanumeric = regexp.MustCompile(`[a-z0-9](.*[a-z0-9])?`)
 )
 
 // ParseReference parses a reference string into a Reference struct. It attempts to make


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/jozu-ai/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/jozu-ai/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description
Fixup regexp for repository names to avoid (start and end with alphanumeric character) to not reject single-letter repository names

### Linked issues
N/A