### PR TITLE
Add --remote flag to kit remove

### DIFF
--- a/pkg/cmd/remove/remove.go
+++ b/pkg/cmd/remove/remove.go
@@ -38,14 +38,14 @@ import (
 func removeAllModels(ctx context.Context, opts *removeOptions) error {
 	stores, err := repo.GetAllLocalStores(constants.StoragePath(opts.configHome))
 	if err != nil {
-		return fmt.Errorf("Failed to read local storage: %w", err)
+		return fmt.Errorf("failed to read local storage: %w", err)
 	}
 	for _, store := range stores {
 		repository := repo.FormatRepositoryForDisplay(store.GetRepo())
 
 		index, err := store.GetIndex()
 		if err != nil {
-			return fmt.Errorf("Failed to read index for %s: %w", repository, err)
+			return fmt.Errorf("failed to read index for %s: %w", repository, err)
 		}
 
 		// Store a list of removed manifests for this LocalStore. This is necessary
@@ -85,13 +85,13 @@ func removeAllModels(ctx context.Context, opts *removeOptions) error {
 func removeUntaggedModels(ctx context.Context, opts *removeOptions) error {
 	stores, err := repo.GetAllLocalStores(constants.StoragePath(opts.configHome))
 	if err != nil {
-		return fmt.Errorf("Failed to read local storage: %w", err)
+		return fmt.Errorf("failed to read local storage: %w", err)
 	}
 	for _, store := range stores {
 		index, err := store.GetIndex()
 		repo := repo.FormatRepositoryForDisplay(store.GetRepo())
 		if err != nil {
-			return fmt.Errorf("Failed to read index for %s: %w", repo, err)
+			return fmt.Errorf("failed to read index for %s: %w", repo, err)
 		}
 		for _, manifestDesc := range index.Manifests {
 			if tag, ok := manifestDesc.Annotations[ocispec.AnnotationRefName]; ok {
@@ -112,11 +112,11 @@ func removeModel(ctx context.Context, opts *removeOptions) error {
 	storageRoot := constants.StoragePath(opts.configHome)
 	localStore, err := repo.NewLocalStore(storageRoot, opts.modelRef)
 	if err != nil {
-		return fmt.Errorf("Failed to read local storage: %s", storageRoot)
+		return fmt.Errorf("failed to read local storage at path %s: %w", storageRoot, err)
 	}
 	desc, err := removeModelRef(ctx, localStore, opts.modelRef, opts.forceDelete)
 	if err != nil {
-		return fmt.Errorf("Failed to remove: %s", err)
+		return fmt.Errorf("failed to remove: %s", err)
 	}
 	displayRef := repo.FormatRepositoryForDisplay(opts.modelRef.String())
 	output.Infof("Removed %s (digest %s)", displayRef, desc.Digest)
@@ -151,15 +151,15 @@ func removeRemoteModel(ctx context.Context, opts *removeOptions) error {
 	desc, err := repository.Resolve(ctx, opts.modelRef.Reference)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
-			return fmt.Errorf("Model %s not found", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
+			return fmt.Errorf("model %s not found", repo.FormatRepositoryForDisplay(opts.modelRef.String()))
 		}
-		return fmt.Errorf("Error resolving modelkit: %w", err)
+		return fmt.Errorf("error resolving modelkit: %w", err)
 	}
 	if err := repository.Delete(ctx, desc); err != nil {
 		if errResp, ok := err.(*errcode.ErrorResponse); ok && errResp.StatusCode == http.StatusMethodNotAllowed {
-			return fmt.Errorf("Removing models is unsupported by registry %s", opts.modelRef.Registry)
+			return fmt.Errorf("removing models is unsupported by registry %s", opts.modelRef.Registry)
 		}
-		return fmt.Errorf("Failed to remove remote model: %w", err)
+		return fmt.Errorf("failed to remove remote model: %w", err)
 	}
 	return nil
 }

--- a/pkg/output/logging.go
+++ b/pkg/output/logging.go
@@ -26,7 +26,7 @@ import (
 )
 
 func Infoln(s any) {
-	fmt.Fprintln(stdout, s)
+	printLn(stdout, s)
 }
 
 func Infof(s string, args ...any) {
@@ -34,7 +34,7 @@ func Infof(s string, args ...any) {
 }
 
 func Errorln(s any) {
-	fmt.Fprintln(stderr, s)
+	printLn(stderr, s)
 }
 
 func Errorf(s string, args ...any) {
@@ -43,7 +43,7 @@ func Errorf(s string, args ...any) {
 
 // Fatalln is the equivalent of Errorln except it returns a basic error to signal the command has failed
 func Fatalln(s any) error {
-	fmt.Fprintln(stderr, s)
+	printLn(stderr, s)
 	return errors.New("failed to run")
 }
 
@@ -55,7 +55,7 @@ func Fatalf(s string, args ...any) error {
 
 func Debugln(s any) {
 	if printDebug {
-		fmt.Fprintln(stdout, s)
+		printLn(stdout, s)
 	}
 }
 
@@ -82,7 +82,7 @@ func (pw *ProgressLogger) Wait() {
 }
 
 func (pw *ProgressLogger) Infoln(s any) {
-	fmt.Fprintln(pw.output, s)
+	printLn(pw.output, s)
 }
 
 func (pw *ProgressLogger) Infof(s string, args ...any) {
@@ -91,7 +91,7 @@ func (pw *ProgressLogger) Infof(s string, args ...any) {
 
 func (pw *ProgressLogger) Debugln(s any) {
 	if printDebug {
-		fmt.Fprintln(pw.output, s)
+		printLn(pw.output, s)
 	}
 }
 
@@ -101,10 +101,20 @@ func (pw *ProgressLogger) Debugf(s string, args ...any) {
 	}
 }
 
+func printLn(w io.Writer, s any) {
+	str := fmt.Sprintln(s)
+	// Capitalize first letter in string for nicer output, in case it's not already capitalized
+	str = strings.ToUpper(str[:1]) + str[1:]
+	fmt.Fprint(w, str)
+}
+
 func printFmt(w io.Writer, s string, args ...any) {
 	// Avoid printing incomplete lines
 	if !strings.HasSuffix(s, "\n") {
 		s = s + "\n"
 	}
-	fmt.Fprintf(w, s, args...)
+	str := fmt.Sprintf(s, args...)
+	// Capitalize first letter in string for nicer output, in case it's not already capitalized
+	str = strings.ToUpper(str[:1]) + str[1:]
+	fmt.Fprint(w, str)
 }


### PR DESCRIPTION
### Description
Add `--remote` flag to `kit remove`, to allow removing modelkits from remote repositories (where supported). If the operation is unsupported, kit logs
```
Removing models is unsupported by registry <registry>
```

### Linked issues
Closes https://github.com/jozu-ai/kitops/issues/326