### PR TITLE
Add different log-levels to output; name per-request trace logging for registry operations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ Find more information at: http://kitops.ml`
 type rootOptions struct {
 	configHome   string
 	verbose      bool
+	loglevel     string
 	progressBars string
 }
 
@@ -49,7 +50,13 @@ func RunCommand() *cobra.Command {
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			output.SetOut(cmd.OutOrStdout())
 			output.SetErr(cmd.ErrOrStderr())
-			output.SetDebug(opts.verbose)
+			if err := output.SetLogLevelFromString(opts.loglevel); err != nil {
+				output.Fatalln(err)
+			}
+			if opts.verbose {
+				output.SetLogLevel(output.LogLevelDebug)
+			}
+
 			output.SetProgressBars(opts.progressBars)
 
 			configHome, err := getConfigHome(opts)
@@ -69,7 +76,8 @@ func RunCommand() *cobra.Command {
 	}
 	addSubcommands(cmd)
 	cmd.PersistentFlags().StringVar(&opts.configHome, "config", "", "Alternate path to root storage directory for CLI")
-	cmd.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "Include additional information in output (default false)")
+	cmd.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "Include additional information in output. Alias for --log-level=debug")
+	cmd.PersistentFlags().StringVar(&opts.loglevel, "log-level", "info", "Log messages above specified level ('trace', 'debug', 'info', 'warn', 'error') (default 'info')")
 	cmd.PersistentFlags().StringVar(&opts.progressBars, "progress", "plain", "Configure progress bars for longer operations (options: none, plain, fancy)")
 
 	cmd.SetHelpTemplate(helpTemplate)

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -78,7 +78,7 @@ func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) error
 		// Change working directory to context path to make sure relative paths within
 		// tarballs are correct. This is the equivalent of using the -C parameter for tar
 		if err := os.Chdir(opts.contextDir); err != nil {
-			return output.Fatalf("Failed to use context path %s: %w", opts.contextDir, err)
+			return output.Fatalf("Failed to use context path %s: %s", opts.contextDir, err)
 		}
 
 		err = runPack(cmd.Context(), opts)

--- a/pkg/lib/harness/llm-harness.go
+++ b/pkg/lib/harness/llm-harness.go
@@ -37,11 +37,11 @@ type LLMHarness struct {
 func (harness *LLMHarness) Init() error {
 	err := extractServer(constants.HarnessPath(harness.ConfigHome), "llama.cpp/build/*/*/*/bin/**")
 	if err != nil {
-		return fmt.Errorf("Failed to extract dev server files: %s", err)
+		return fmt.Errorf("failed to extract dev server files: %s", err)
 	}
 	err = extractUI(constants.HarnessPath(harness.ConfigHome))
 	if err != nil {
-		return fmt.Errorf("Failed to extract dev UI files: %s", err)
+		return fmt.Errorf("failed to extract dev UI files: %s", err)
 	}
 	return nil
 }
@@ -59,7 +59,7 @@ func (harness *LLMHarness) Start(modelPath string) error {
 		}
 		// Check if the process is still running.
 		if isProcessRunning(pid) {
-			return fmt.Errorf("A server process with PID %d is already running", pid)
+			return fmt.Errorf("a server process with PID %d is already running", pid)
 		} else {
 			output.Infoln("The process previously recorded is not running. Proceeding to start a new process.")
 		}
@@ -74,7 +74,7 @@ func (harness *LLMHarness) Start(modelPath string) error {
 	cmd.Dir = harnessPath
 	logs, err := os.OpenFile(logFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
-		return fmt.Errorf("Failed to open log file for harness: %w", err)
+		return fmt.Errorf("failed to open log file for harness: %w", err)
 	}
 	defer logs.Close()
 	output.Debugf("Saving server logs to %s", logFile)
@@ -82,12 +82,12 @@ func (harness *LLMHarness) Start(modelPath string) error {
 	cmd.Stderr = logs
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("Error starting llm harness: %s", err)
+		return fmt.Errorf("error starting llm harness: %s", err)
 	}
 
 	pid := cmd.Process.Pid
 	if err := writePIDFile(pidFile, pid); err != nil {
-		return fmt.Errorf("Failed to write PID file: %w", err)
+		return fmt.Errorf("failed to write PID file: %w", err)
 	}
 
 	output.Debugf("Started harness with PID %d and saved to file.\n", pid)
@@ -100,7 +100,7 @@ func (harness *LLMHarness) Stop() error {
 
 	pid, err := readPIDFromFile(pidFile)
 	if os.IsNotExist(err) {
-		return fmt.Errorf("No Running server found")
+		return fmt.Errorf("no Running server found")
 	}
 	if err != nil {
 		return err
@@ -108,13 +108,13 @@ func (harness *LLMHarness) Stop() error {
 
 	// Check if the process is still running.
 	if !isProcessRunning(pid) {
-		return fmt.Errorf("No running process found with PID %d.", pid)
+		return fmt.Errorf("no running process found with PID %d", pid)
 	}
 
 	// Kill the process using the PID.
 	process, err := os.FindProcess(pid)
 	if err != nil {
-		return fmt.Errorf("Error finding process: %s\n", err)
+		return fmt.Errorf("error finding process: %s", err)
 	}
 
 	err = process.Signal(syscall.SIGTERM) // Try to kill it gently
@@ -123,15 +123,15 @@ func (harness *LLMHarness) Stop() error {
 		// If SIGTERM failed, kill it with SIGKILL
 		err = process.Kill()
 		if err != nil {
-			return fmt.Errorf("Error killing process: %s", err)
+			return fmt.Errorf("error killing process: %s", err)
 		}
 	}
 
-	output.Debugf("Process with PID %d has been killed.\n", pid)
+	output.Debugf("Process with PID %d has been killed.", pid)
 	// Delete the PID file to clean up.
 	err = os.Remove(pidFile)
 	if err != nil {
-		return fmt.Errorf("Error removing PID file: %s\n", err)
+		return fmt.Errorf("error removing PID file: %s", err)
 	}
 
 	return nil

--- a/pkg/lib/repo/registry.go
+++ b/pkg/lib/repo/registry.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"kitops/pkg/lib/network"
+	"kitops/pkg/output"
 
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
@@ -44,8 +45,8 @@ func NewRegistry(hostname string, opts *RegistryOptions) (*remote.Registry, erro
 	if err != nil {
 		return nil, err
 	}
-	client := network.ClientWithAuth(credentialStore, &network.ClientOpts{TLSSkipVerify: opts.SkipTLSVerify})
-	reg.Client = client
+	authClient := network.ClientWithAuth(credentialStore, &network.ClientOpts{TLSSkipVerify: opts.SkipTLSVerify})
+	reg.Client = output.WrapClient(authClient)
 
 	return reg, nil
 }

--- a/pkg/output/client.go
+++ b/pkg/output/client.go
@@ -1,0 +1,51 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"net/http"
+	"time"
+
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+type LoggingClient struct {
+	remote.Client
+}
+
+func (c *LoggingClient) Do(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := c.Client.Do(req)
+	duration := float64(time.Since(start)) / float64(time.Millisecond)
+	if err != nil {
+		SafeLogf(LogLevelTrace, "%s %s -> ERROR -- duration %.2f ms", req.Method, req.URL, duration)
+	} else {
+		SafeLogf(LogLevelTrace, "%s %s -> %d -- duration %.2f ms", req.Method, req.URL, resp.StatusCode, duration)
+	}
+	return resp, err
+}
+
+// WrapClient returns a remote.Client that logs every request at a 'trace' level.
+// If the currently set logging level would not print 'trace' logs, this is a no-op.
+func WrapClient(c remote.Client) remote.Client {
+	if logLevel.shouldPrint(LogLevelTrace) {
+		return &LoggingClient{
+			Client: c,
+		}
+	}
+	return c
+}

--- a/pkg/output/config.go
+++ b/pkg/output/config.go
@@ -17,20 +17,62 @@
 package output
 
 import (
+	"fmt"
 	"io"
 	"os"
 )
 
+type LogLevel int
+
+const (
+	LogLevelTrace LogLevel = iota
+	LogLevelDebug
+	LogLevelInfo
+	LogLevelWarn
+	LogLevelError
+)
+
+func (l LogLevel) shouldPrint(atLevel LogLevel) bool {
+	return l <= atLevel
+}
+
+func (l LogLevel) getOutput() io.Writer {
+	switch l {
+	case LogLevelError, LogLevelWarn:
+		return stderr
+	default:
+		return stdout
+	}
+}
+
 var (
-	printDebug                = false
+	logLevel                  = LogLevelInfo
 	progressStyle             = "plain"
-	progressEnabled           = false
+	progressEnabled           = true
 	stdout          io.Writer = os.Stdout
 	stderr          io.Writer = os.Stderr
 )
 
-func SetDebug(debug bool) {
-	printDebug = debug
+func SetLogLevel(level LogLevel) {
+	logLevel = level
+}
+
+func SetLogLevelFromString(level string) error {
+	switch level {
+	case "trace":
+		logLevel = LogLevelTrace
+	case "debug":
+		logLevel = LogLevelDebug
+	case "info":
+		logLevel = LogLevelInfo
+	case "warn":
+		logLevel = LogLevelWarn
+	case "error":
+		logLevel = LogLevelError
+	default:
+		return fmt.Errorf("invalid log level '%s'. Options are 'trace', 'debug', 'info', 'warn', 'error'", level)
+	}
+	return nil
 }
 
 func SetProgressBars(style string) {

--- a/pkg/output/config.go
+++ b/pkg/output/config.go
@@ -45,6 +45,26 @@ func (l LogLevel) getOutput() io.Writer {
 	}
 }
 
+func (l LogLevel) getPrefix() string {
+	if logLevel == LogLevelInfo {
+		// By default, don't include log level in message
+		return ""
+	}
+	switch l {
+	case LogLevelTrace:
+		return "[TRACE] "
+	case LogLevelDebug:
+		return "[DEBUG] "
+	case LogLevelInfo:
+		return "[INFO]  "
+	case LogLevelWarn:
+		return "[WARN]  "
+	case LogLevelError:
+		return "[ERROR] "
+	}
+	return ""
+}
+
 var (
 	logLevel                  = LogLevelInfo
 	progressStyle             = "plain"

--- a/pkg/output/config.go
+++ b/pkg/output/config.go
@@ -22,49 +22,6 @@ import (
 	"os"
 )
 
-type LogLevel int
-
-const (
-	LogLevelTrace LogLevel = iota
-	LogLevelDebug
-	LogLevelInfo
-	LogLevelWarn
-	LogLevelError
-)
-
-func (l LogLevel) shouldPrint(atLevel LogLevel) bool {
-	return l <= atLevel
-}
-
-func (l LogLevel) getOutput() io.Writer {
-	switch l {
-	case LogLevelError, LogLevelWarn:
-		return stderr
-	default:
-		return stdout
-	}
-}
-
-func (l LogLevel) getPrefix() string {
-	if logLevel == LogLevelInfo {
-		// By default, don't include log level in message
-		return ""
-	}
-	switch l {
-	case LogLevelTrace:
-		return "[TRACE] "
-	case LogLevelDebug:
-		return "[DEBUG] "
-	case LogLevelInfo:
-		return "[INFO]  "
-	case LogLevelWarn:
-		return "[WARN]  "
-	case LogLevelError:
-		return "[ERROR] "
-	}
-	return ""
-}
-
 var (
 	logLevel                  = LogLevelInfo
 	progressStyle             = "plain"

--- a/pkg/output/level.go
+++ b/pkg/output/level.go
@@ -1,0 +1,88 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+
+	"golang.org/x/term"
+)
+
+type LogLevel int
+
+const (
+	LogLevelTrace LogLevel = iota
+	LogLevelDebug
+	LogLevelInfo
+	LogLevelWarn
+	LogLevelError
+)
+
+var (
+	colorNone  = "\033[0m"
+	colorTrace = "\033[0;92m" // Bright green
+	colorDebug = "\033[0;34m" // Blue
+	colorInfo  = "\033[0;36m" // Cyan
+	colorWarn  = "\033[0;33m" // Yellow
+	colorError = "\033[0;31m" // Red
+)
+
+func init() {
+	if runtime.GOOS == "windows" || !term.IsTerminal(int(os.Stdout.Fd())) {
+		colorNone = ""
+		colorError = ""
+		colorWarn = ""
+		colorDebug = ""
+		colorTrace = ""
+	}
+}
+
+func (l LogLevel) shouldPrint(atLevel LogLevel) bool {
+	return l <= atLevel
+}
+
+func (l LogLevel) getOutput() io.Writer {
+	switch l {
+	case LogLevelError, LogLevelWarn:
+		return stderr
+	default:
+		return stdout
+	}
+}
+
+func (l LogLevel) getPrefix() string {
+	if logLevel == LogLevelInfo {
+		// By default, don't include log level in message
+		return ""
+	}
+	switch l {
+	case LogLevelTrace:
+		return fmt.Sprintf("%s[TRACE] %s", colorTrace, colorNone)
+	case LogLevelDebug:
+		return fmt.Sprintf("%s[DEBUG] %s", colorDebug, colorNone)
+	case LogLevelInfo:
+		return fmt.Sprintf("%s[INFO ] %s", colorInfo, colorNone)
+	case LogLevelWarn:
+		return fmt.Sprintf("%s[WARN ] %s", colorWarn, colorNone)
+	case LogLevelError:
+		return fmt.Sprintf("%s[ERROR] %s", colorError, colorNone)
+	}
+	return ""
+}

--- a/pkg/output/logging.go
+++ b/pkg/output/logging.go
@@ -82,6 +82,9 @@ func loglnTo(output io.Writer, level LogLevel, s any) {
 		str := fmt.Sprintln(s)
 		// Capitalize first letter in string for nicer output, in case it's not already capitalized
 		str = strings.ToUpper(str[:1]) + str[1:]
+		if logLevel != LogLevelInfo {
+			str = level.getPrefix() + str
+		}
 		fmt.Fprint(output, str)
 	}
 }
@@ -99,6 +102,9 @@ func logfTo(output io.Writer, level LogLevel, s string, args ...any) {
 		str := fmt.Sprintf(s, args...)
 		// Capitalize first letter in string for nicer output, in case it's not already capitalized
 		str = strings.ToUpper(str[:1]) + str[1:]
+		if logLevel != LogLevelInfo {
+			str = level.getPrefix() + str
+		}
 		fmt.Fprint(output, str)
 	}
 }


### PR DESCRIPTION
### Description
Add support for multiple log levels (`error`, `warn`, `info`, `debug`, and `trace`) with a corresponding flag `--log-level`. The old `-v | --verbose` flag is left in place for convenience. Currently, the only 'trace' level logging is per-request info while pushing/pulling a registry. Also, if the log-level is not `info`, we output a prefix indicating log level for each line, to make it a little more readable.

![2024-06-06-11:49:33](https://github.com/jozu-ai/kitops/assets/16168279/bc91909a-50e9-4464-b0d9-89b488f987b2)
![2024-06-06-11:58:30](https://github.com/jozu-ai/kitops/assets/16168279/594ab0f2-8947-47ca-9230-b3da98ff1167)


If the log-level is 'info", the output is unchanged.

### Linked issues
Closes #338