### PR TITLE
Update colors used for terminal output and update default prefixes

### DIFF
--- a/pkg/output/level.go
+++ b/pkg/output/level.go
@@ -37,10 +37,10 @@ const (
 
 var (
 	colorNone  = "\033[0m"
-	colorTrace = "\033[0;92m" // Bright green
+	colorTrace = "\033[0m"    // No color
 	colorDebug = "\033[0;34m" // Blue
-	colorInfo  = "\033[0;36m" // Cyan
-	colorWarn  = "\033[0;33m" // Yellow
+	colorInfo  = "\033[0;32m" // Green
+	colorWarn  = "\033[0;93m" // Yellow
 	colorError = "\033[0;31m" // Red
 )
 
@@ -69,20 +69,27 @@ func (l LogLevel) getOutput() io.Writer {
 
 func (l LogLevel) getPrefix() string {
 	if logLevel == LogLevelInfo {
-		// By default, don't include log level in message
-		return ""
-	}
-	switch l {
-	case LogLevelTrace:
-		return fmt.Sprintf("%s[TRACE] %s", colorTrace, colorNone)
-	case LogLevelDebug:
-		return fmt.Sprintf("%s[DEBUG] %s", colorDebug, colorNone)
-	case LogLevelInfo:
-		return fmt.Sprintf("%s[INFO ] %s", colorInfo, colorNone)
-	case LogLevelWarn:
-		return fmt.Sprintf("%s[WARN ] %s", colorWarn, colorNone)
-	case LogLevelError:
-		return fmt.Sprintf("%s[ERROR] %s", colorError, colorNone)
+		switch l {
+		case LogLevelInfo:
+			return ""
+		case LogLevelWarn:
+			return fmt.Sprintf("%s[WARN ] %s", colorWarn, colorNone)
+		case LogLevelError:
+			return fmt.Sprintf("%s[ERROR] %s", colorError, colorNone)
+		}
+	} else {
+		switch l {
+		case LogLevelTrace:
+			return fmt.Sprintf("%s[TRACE] %s", colorTrace, colorNone)
+		case LogLevelDebug:
+			return fmt.Sprintf("%s[DEBUG] %s", colorDebug, colorNone)
+		case LogLevelInfo:
+			return fmt.Sprintf("%s[INFO ] %s", colorInfo, colorNone)
+		case LogLevelWarn:
+			return fmt.Sprintf("%s[WARN ] %s", colorWarn, colorNone)
+		case LogLevelError:
+			return fmt.Sprintf("%s[ERROR] %s", colorError, colorNone)
+		}
 	}
 	return ""
 }

--- a/pkg/output/logging.go
+++ b/pkg/output/logging.go
@@ -82,9 +82,7 @@ func loglnTo(output io.Writer, level LogLevel, s any) {
 		str := fmt.Sprintln(s)
 		// Capitalize first letter in string for nicer output, in case it's not already capitalized
 		str = strings.ToUpper(str[:1]) + str[1:]
-		if logLevel != LogLevelInfo {
-			str = level.getPrefix() + str
-		}
+		str = level.getPrefix() + str
 		fmt.Fprint(output, str)
 	}
 }
@@ -102,9 +100,7 @@ func logfTo(output io.Writer, level LogLevel, s string, args ...any) {
 		str := fmt.Sprintf(s, args...)
 		// Capitalize first letter in string for nicer output, in case it's not already capitalized
 		str = strings.ToUpper(str[:1]) + str[1:]
-		if logLevel != LogLevelInfo {
-			str = level.getPrefix() + str
-		}
+		str = level.getPrefix() + str
 		fmt.Fprint(output, str)
 	}
 }


### PR DESCRIPTION
### Description
Update colors to roughly match (depending on color scheme)
* \[TRACE]: no color (there's not a safe "grey" we can pick)
* \[DEBUG]: blue
* \[INFO ]: green
* \[WARN ]: "bright" yellow
* \[ERROR]: red

When the log level is the default, show the prefixes for 'warning' and 'error' level messages to better highlight them.

### Screenshots
![2024-06-12-11:32:54](https://github.com/jozu-ai/kitops/assets/16168279/39d03ac2-fc38-4363-93f0-b1838c9a8f89)
![2024-06-12-11:33:08](https://github.com/jozu-ai/kitops/assets/16168279/cb252daf-61ea-4d6f-b155-27890d8c0769)
![2024-06-12-11:33:33](https://github.com/jozu-ai/kitops/assets/16168279/ffd1f7b1-7f7f-4f6a-9cb1-b49188a6d43f)
![2024-06-12-11:33:42](https://github.com/jozu-ai/kitops/assets/16168279/1a4ae64e-f433-4093-bd1e-96e516aa1fdb)

Sample output for a modelkit push
![2024-06-12-11:34:27](https://github.com/jozu-ai/kitops/assets/16168279/78eeb1de-2735-4141-8f8d-57951e60cb99)


### Linked issues
Closes #78
