### PR TITLE
fixes #375

### DIFF
--- a/docs/src/docs/cli/installation.md
+++ b/docs/src/docs/cli/installation.md
@@ -33,7 +33,7 @@ There are two generations of Mac hardware, if you aren't sure which you have [ch
   Intel / x86_64
 </a>
 
-Once the file is downloaded, open your Finder and double-click the `.zip` file to unpack it. Then select the unpacked folder and move it to `/usr/local/bin`.
+Once the file is downloaded, open your Finder and double-click the `.zip` file to unpack it. Then select the executable file named `kit` from unpacked folder and move it to `/usr/local/bin`.
 
 You can verify that `kit` is correctly installed by opening a new terminal or command prompt and typing:
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/jozu-ai/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/jozu-ai/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description
Changed the installation instruction on Mac. Previously it was,

> Once the file is downloaded, open your Finder and double-click the `.zip` file to unpack it. Then select the unpacked folder and move it to `/usr/local/bin`.

Changed it to : 

> Once the file is downloaded, open your Finder and double-click the `.zip` file to unpack it. Then select the executable file named `kit` from unpacked folder and move it to `/usr/local/bin`.

### Linked issues
#375 
