### PR TITLE
Fix issue when using relative paths for KITOPS_HOME

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,9 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"kitops/pkg/cmd/dev"
 	"kitops/pkg/cmd/info"
@@ -117,13 +119,21 @@ func Execute() {
 func getConfigHome(opts *rootOptions) (string, error) {
 	if opts.configHome != "" {
 		output.Debugf("Using config directory from flag: %s", opts.configHome)
-		return opts.configHome, nil
+		absHome, err := filepath.Abs(opts.configHome)
+		if err != nil {
+			return "", fmt.Errorf("failed to get absolute path for %s: %w", opts.configHome, err)
+		}
+		return absHome, nil
 	}
 
 	envHome := os.Getenv("KITOPS_HOME")
 	if envHome != "" {
 		output.Debugf("Using config directory from environment variable: %s", envHome)
-		return envHome, nil
+		absHome, err := filepath.Abs(envHome)
+		if err != nil {
+			return "", fmt.Errorf("failed to get absolute path for $KITOPS_HOME: %w", err)
+		}
+		return absHome, nil
 	}
 
 	defaultHome, err := constants.DefaultConfigPath()


### PR DESCRIPTION
### Description
Since kit sometimes changes directory while packing/unpacking, using a relative path for KITOPS_HOME (or the --config parameter) would lead to the CLI using an unexpected location -- for example, running

```
  KITOPS_HOME=./my-kitops-storage
  kit pack -t my-model ./my-model-path
```

would lead to kit storing the model in `./my-model-path/my-kitops-storage` instead of the expected `./my-kitops-storage`.

Instead, we take the absolute path for the parameter at the beginning and use that.


### Linked issues
Closes https://github.com/jozu-ai/kitops/issues/381