### PR TITLE
Add support for arbitrary parameters in models

### DIFF
--- a/pkg/artifact/kit-file.go
+++ b/pkg/artifact/kit-file.go
@@ -66,6 +66,13 @@ type (
 		Training    *Training   `json:"training,omitempty" yaml:"training,omitempty"`
 		Validation  *Validation `json:"validation,omitempty" yaml:"validation,omitempty"`
 		Parts       []ModelPart `json:"parts,omitempty" yaml:"parts,omitempty"`
+		// Parameters is an arbitrary section of yaml that can be used to store any additional
+		// data that may be relevant to the current model, with a few caveats:
+		//  * Only a json-compatible subset of yaml is supported
+		//  * Strings will be serialized without flow parameters, etc.
+		//  * Numbers will be converted to decimal representations (0xFF -> 255, 1.2e+3 -> 1200)
+		//  * Maps will be sorted alphabetically by key
+		Parameters any `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	}
 
 	ModelPart struct {

--- a/pkg/artifact/kit-file_test.go
+++ b/pkg/artifact/kit-file_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+type parameterTestCase struct {
+	Name        string
+	Description string `yaml:"description"`
+	KitfileYaml string `yaml:"kitfileYaml"`
+	KitfileJson string `yaml:"kitfileJson"`
+}
+
+func (tc parameterTestCase) withName(name string) parameterTestCase {
+	tc.Name = name
+	return tc
+}
+
+func TestParameterMarshalUnmarshal(t *testing.T) {
+	tests := loadAllTestCasesOrPanic[parameterTestCase](t, filepath.Join("testdata", "parameters"))
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.Description), func(t *testing.T) {
+			kf := &KitFile{}
+			rc := io.NopCloser(strings.NewReader(tt.KitfileYaml))
+			err := kf.LoadModel(rc)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			unmarshalledYaml, err := kf.MarshalToYAML()
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, tt.KitfileYaml, string(unmarshalledYaml))
+
+			unmarshalledJson, err := kf.MarshalToJSON()
+			if !assert.NoError(t, err) {
+				return
+			}
+			if tt.KitfileJson != "" {
+				assert.Equal(t, tt.KitfileJson, string(unmarshalledJson))
+			}
+		})
+	}
+}
+
+func loadAllTestCasesOrPanic[T interface{ withName(string) T }](t *testing.T, testsPath string) []T {
+	files, err := os.ReadDir(testsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tests []T
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		bytes, err := os.ReadFile(filepath.Join(testsPath, file.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var testcase T
+		if err := yaml.Unmarshal(bytes, &testcase); err != nil {
+			t.Fatal(err)
+		}
+		testcase = testcase.withName(file.Name())
+		tests = append(tests, testcase)
+	}
+	return tests
+}

--- a/pkg/artifact/testdata/parameters/test-basic-parameters.yaml
+++ b/pkg/artifact/testdata/parameters/test-basic-parameters.yaml
@@ -1,0 +1,13 @@
+description: "Can round-trip basic parameters"
+kitfileYaml: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-kitfile
+  model:
+    name: test-model
+    path: /tmp/path/to/model
+    parameters:
+      test-a: a
+      test-b: b
+      test-c: c
+kitfileJson: '{"manifestVersion":"1.0.0","package":{"name":"test-kitfile"},"model":{"name":"test-model","path":"/tmp/path/to/model","parameters":{"test-a":"a","test-b":"b","test-c":"c"}}}'

--- a/pkg/artifact/testdata/parameters/test-data-types.yaml
+++ b/pkg/artifact/testdata/parameters/test-data-types.yaml
@@ -1,0 +1,16 @@
+description: "Can round-trip basic data types"
+kitfileYaml: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-kitfile
+  model:
+    name: test-model
+    path: /tmp/path/to/model
+    parameters:
+      test-bool: true
+      test-bool-str: "true"
+      test-float: 12.3
+      test-negative: -123
+      test-number: 123
+      test-string: string
+kitfileJson: '{"manifestVersion":"1.0.0","package":{"name":"test-kitfile"},"model":{"name":"test-model","path":"/tmp/path/to/model","parameters":{"test-bool":true,"test-bool-str":"true","test-float":12.3,"test-negative":-123,"test-number":123,"test-string":"string"}}}'

--- a/pkg/artifact/testdata/parameters/test-list-parameters.yaml
+++ b/pkg/artifact/testdata/parameters/test-list-parameters.yaml
@@ -1,0 +1,13 @@
+description: "Can round-trip parameters as a list"
+kitfileYaml: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-kitfile
+  model:
+    name: test-model
+    path: /tmp/path/to/model
+    parameters:
+      - item-a
+      - item-b
+      - item-c
+kitfileJson: '{"manifestVersion":"1.0.0","package":{"name":"test-kitfile"},"model":{"name":"test-model","path":"/tmp/path/to/model","parameters":["item-a","item-b","item-c"]}}'

--- a/pkg/artifact/testdata/parameters/test-nested-parameters.yaml
+++ b/pkg/artifact/testdata/parameters/test-nested-parameters.yaml
@@ -1,0 +1,31 @@
+description: "Can round-trip maps and lists parameters"
+kitfileYaml: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-kitfile
+  model:
+    name: test-model
+    path: /tmp/path/to/model
+    parameters:
+      test-list-of-lists:
+        - - a-1
+          - a-2
+        - - b-1
+          - b-2
+      test-maps:
+        a:
+          b:
+            c:
+              d:
+                e: f
+      test-nested-list:
+        - item-a
+        - item-b
+        - item-object:
+            - subfield-1: 1
+            - subfield-2: 2
+      test-nested-map:
+        test-a: a
+        test-b: b
+        test-c: c
+kitfileJson: '{"manifestVersion":"1.0.0","package":{"name":"test-kitfile"},"model":{"name":"test-model","path":"/tmp/path/to/model","parameters":{"test-list-of-lists":[["a-1","a-2"],["b-1","b-2"]],"test-maps":{"a":{"b":{"c":{"d":{"e":"f"}}}}},"test-nested-list":["item-a","item-b",{"item-object":[{"subfield-1":1},{"subfield-2":2}]}],"test-nested-map":{"test-a":"a","test-b":"b","test-c":"c"}}}}'

--- a/pkg/artifact/testdata/parameters/test-single-value.yaml
+++ b/pkg/artifact/testdata/parameters/test-single-value.yaml
@@ -1,0 +1,11 @@
+description: "Can handle basic string as parameters"
+kitfileYaml: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-kitfile
+  model:
+    name: test-model
+    path: /tmp/path/to/model
+    parameters: |
+      test-string
+kitfileJson: '{"manifestVersion":"1.0.0","package":{"name":"test-kitfile"},"model":{"name":"test-model","path":"/tmp/path/to/model","parameters":"test-string\n"}}'


### PR DESCRIPTION
### Description
Add ability to store arbitrary additional data in a Kitfile's model, e.g.

```yaml
model:
  - name: my-model
    path: ./model.bin
    parameters:
      <any valid yaml>
```

This comes with some caveats in serialization:
* Numerical fields will be converted to decimal representation, so `0xFF` will be come `255`, `1.2e+3` will become `1200`
* Strings will be serialized ignoring flow/etc.
* Anything yaml-specific (i.e. not included in JSON) is unsupported
* Maps will have their keys sorted alphabetically (`{b: b, a: a} -> {a: a, b: b}`)

The net effect of this is that the unpacked model may have a (superficially) different Kitfile than the original, but both Kitfiles will pack to the same digest.

### Linked issues
Closes #366 