### PR TITLE
Add support for docs layers

### DIFF
--- a/pkg/artifact/kit-file.go
+++ b/pkg/artifact/kit-file.go
@@ -32,6 +32,12 @@ type (
 		Model           *TrainedModel `json:"model,omitempty" yaml:"model,omitempty"`
 		Code            []Code        `json:"code,omitempty" yaml:"code,omitempty"`
 		DataSets        []DataSet     `json:"datasets,omitempty" yaml:"datasets,omitempty"`
+		Docs            []Docs        `json:"docs,omitempty" yaml:"docs,omitempty"`
+	}
+
+	Docs struct {
+		Path        string `json:"path" yaml:"path"`
+		Description string `json:"description" yaml:"description"`
 	}
 
 	ModelKit struct {

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -66,6 +66,7 @@ type unpackConf struct {
 	unpackModels   bool
 	unpackCode     bool
 	unpackDatasets bool
+	unpackDocs     bool
 }
 
 func (opts *unpackOptions) complete(ctx context.Context, args []string) error {
@@ -89,6 +90,7 @@ func (opts *unpackOptions) complete(ctx context.Context, args []string) error {
 		opts.unpackConf.unpackModels = true
 		opts.unpackConf.unpackCode = true
 		opts.unpackConf.unpackDatasets = true
+		opts.unpackConf.unpackDocs = true
 	}
 
 	absDir, err := filepath.Abs(opts.unpackDir)
@@ -119,6 +121,7 @@ func UnpackCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackModels, "model", false, "Unpack only model")
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackCode, "code", false, "Unpack only code")
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackDatasets, "datasets", false, "Unpack only datasets")
+	cmd.Flags().BoolVar(&opts.unpackConf.unpackDocs, "docs", false, "Unpack only docs")
 	opts.AddNetworkFlags(cmd)
 
 	return cmd

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -78,7 +78,7 @@ func runUnpackRecursive(ctx context.Context, opts *unpackOptions, visitedRefs []
 
 	// Since there might be multiple models, etc. we need to synchronously iterate
 	// through the config's relevant field to get the correct path for unpacking
-	var modelPartIdx, codeIdx, datasetIdx int
+	var modelPartIdx, codeIdx, datasetIdx, docsIdx int
 	for _, layerDesc := range manifest.Layers {
 		var relPath string
 		mediaType := constants.ParseMediaType(layerDesc.MediaType)
@@ -128,7 +128,17 @@ func runUnpackRecursive(ctx context.Context, opts *unpackOptions, visitedRefs []
 			}
 			output.Infof("Unpacking dataset %s to %s", datasetEntry.Name, relPath)
 			datasetIdx += 1
+
+		case constants.DocsType:
+			docsEntry := config.Docs[docsIdx]
+			_, relPath, err = filesystem.VerifySubpath(opts.unpackDir, docsEntry.Path)
+			if err != nil {
+				return fmt.Errorf("Error resolving path %s for docs: %w", docsEntry.Path, err)
+			}
+			output.Infof("Unpacking docs to %s", docsEntry.Path)
+			docsIdx += 1
 		}
+
 		if err := unpackLayer(ctx, store, layerDesc, relPath, opts.overwrite, mediaType.Compression); err != nil {
 			return fmt.Errorf("Failed to unpack: %w", err)
 		}

--- a/pkg/lib/constants/mediaType.go
+++ b/pkg/lib/constants/mediaType.go
@@ -27,6 +27,7 @@ const (
 	ModelPartType = "modelpart"
 	DatasetType   = "dataset"
 	CodeType      = "code"
+	DocsType      = "docs"
 )
 
 const (

--- a/pkg/lib/kitfile/resolve.go
+++ b/pkg/lib/kitfile/resolve.go
@@ -94,6 +94,8 @@ func mergeKitfiles(into, from *artifact.KitFile) *artifact.KitFile {
 	result.Code = append(result.Code, from.Code...)
 	result.DataSets = into.DataSets
 	result.DataSets = append(result.DataSets, from.DataSets...)
+	result.Docs = into.Docs
+	result.Docs = append(result.Docs, from.Docs...)
 	return result
 }
 

--- a/pkg/lib/kitfile/util.go
+++ b/pkg/lib/kitfile/util.go
@@ -47,6 +47,9 @@ func LayerPathsFromKitfile(kitfile *artifact.KitFile) []string {
 	for _, dataset := range kitfile.DataSets {
 		layerPaths = append(layerPaths, cleanPath(dataset.Path))
 	}
+	for _, docs := range kitfile.Docs {
+		layerPaths = append(layerPaths, docs.Path)
+	}
 
 	if kitfile.Model != nil {
 		if kitfile.Model.Path != "" {

--- a/pkg/lib/kitfile/validate.go
+++ b/pkg/lib/kitfile/validate.go
@@ -69,6 +69,9 @@ func ValidateKitfile(kf *artifact.KitFile) error {
 	for idx, code := range kf.Code {
 		addPath(code.Path, fmt.Sprintf("code layer %d", idx))
 	}
+	for idx, docs := range kf.Docs {
+		addPath(docs.Path, fmt.Sprintf("docs layer %d", idx))
+	}
 
 	for layerPath, layerIds := range paths {
 		if len := len(layerIds); len > 1 {

--- a/pkg/lib/storage/local.go
+++ b/pkg/lib/storage/local.go
@@ -137,6 +137,18 @@ func saveKitfileLayers(ctx context.Context, store repo.LocalStorage, kitfile *ar
 		}
 		layers = append(layers, layer)
 	}
+	for _, docs := range kitfile.Docs {
+		mediaType := constants.MediaType{
+			BaseType:    constants.DocsType,
+			Compression: compression,
+		}
+		layer, err := saveContentLayer(ctx, store, docs.Path, mediaType, ignore)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, layer)
+	}
+
 	return layers, nil
 }
 


### PR DESCRIPTION
### Description
Adds a new field to Kitfiles:
```yaml
manifestVersion: 1.0.0
package:
  - name: my-modelkit
docs:
  - path: ./path/to/doc
    description: "short description of the doc"
```

Currently, docs are stored identically to other layers (code, datasets, model) -- i.e. as tarballs with (optional) compression.

Some considerations before merging:
* Do we want to do something specific with docs to aid retrieval (i.e. gzip single files so that they can be displayed in a browser?)
* Fields on each `docs` entry are preliminary -- do we want name/type/etc., or some way to determine what the doc should be used for (e.g. license vs readme vs ???)?
* If we stick with just path and description, do we want to limit the length of the description?


### Linked issues
Closes #84 
