### PR TITLE
Add third verbosity level to disable progress bars too

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,16 +56,22 @@ func RunCommand() *cobra.Command {
 			if err := output.SetLogLevelFromString(opts.loglevel); err != nil {
 				return output.Fatalln(err)
 			}
+			output.SetProgressBars(opts.progressBars)
+
 			switch opts.verbosity {
+			case 0:
+				break
 			case 1:
 				output.Debugf("Setting verbosity to %s", output.LogLevelDebug)
 				output.SetLogLevel(output.LogLevelDebug)
 			case 2:
 				output.Debugf("Setting verbosity to %s", output.LogLevelTrace)
 				output.SetLogLevel(output.LogLevelTrace)
+			default:
+				output.Debugf("Setting verbosity to %s and disabling progress bars", output.LogLevelTrace)
+				output.SetLogLevel(output.LogLevelTrace)
+				output.SetProgressBars("none")
 			}
-
-			output.SetProgressBars(opts.progressBars)
 
 			configHome, err := getConfigHome(opts)
 			if err != nil {


### PR DESCRIPTION
### Description
Add `-vvv` option, to disable progress bars as well as set log level to trace to get _all_ logs.

### Linked issues
<!-- link any issues in this repository that are related to the PR; use "closes <issue>" or "fixes <issue>" to automatically link issues to this PR -->
