### PR TITLE
Add support for authenticating via client certificates

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,7 @@ func RunCommand() *cobra.Command {
 			configHome, err := getConfigHome(opts)
 			if err != nil {
 				output.Errorf("Failed to read base config directory")
-				output.Infof("Use the --config flag or set the $KITOPS_HOME environment variable to provide a default")
+				output.Infof("Use the --config flag or set the $%s environment variable to provide a default", constants.KitopsHomeEnvVar)
 				output.Debugf("Error: %s", err)
 				return errors.New("exit")
 			}
@@ -152,12 +152,12 @@ func getConfigHome(opts *rootOptions) (string, error) {
 		return absHome, nil
 	}
 
-	envHome := os.Getenv("KITOPS_HOME")
+	envHome := os.Getenv(constants.KitopsHomeEnvVar)
 	if envHome != "" {
 		output.Debugf("Using config directory from environment variable: %s", envHome)
 		absHome, err := filepath.Abs(envHome)
 		if err != nil {
-			return "", fmt.Errorf("failed to get absolute path for $KITOPS_HOME: %w", err)
+			return "", fmt.Errorf("failed to get absolute path for %s: %w", constants.KitopsHomeEnvVar, err)
 		}
 		return absHome, nil
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,17 +103,18 @@ func RunCommand() *cobra.Command {
 		},
 	}
 	addSubcommands(cmd)
-	cmd.PersistentFlags().StringVar(&opts.configHome, "config", "", "Alternate path to root storage directory for CLI")
-	cmd.PersistentFlags().CountVarP(&opts.verbosity, "verbose", "v", "Increase verbosity of output (use -vv for more)")
 	cmd.PersistentFlags().StringVar(&opts.loglevel, "log-level", "info", "Log messages above specified level ('trace', 'debug', 'info', 'warn', 'error') (default 'info')")
 	cmd.PersistentFlags().StringVar(&opts.progressBars, "progress", "plain", "Configure progress bars for longer operations (options: none, plain, fancy)")
+	cmd.PersistentFlags().StringVar(&opts.configHome, "config", "", "Alternate path to root storage directory for CLI")
+	cmd.PersistentFlags().CountVarP(&opts.verbosity, "verbose", "v", "Increase verbosity of output (use -vv for more)")
+	cmd.PersistentFlags().SortFlags = false
+	cmd.Flags().SortFlags = false
 
 	cmd.SetHelpTemplate(helpTemplate)
 	cmd.SetUsageTemplate(usageTemplate)
 	cobra.AddTemplateFunc("indent", indentBlock)
 	cobra.AddTemplateFunc("sectionHead", sectionHead)
 	cobra.AddTemplateFunc("ensureTrailingNewline", ensureTrailingNewline)
-
 	return cmd
 }
 

--- a/pkg/cmd/dev/cmd.go
+++ b/pkg/cmd/dev/cmd.go
@@ -53,6 +53,8 @@ func DevStartCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.modelFile, "file", "f", "", "Path to the kitfile")
 	cmd.Flags().StringVar(&opts.host, "host", "127.0.0.1", "Host for the development server")
 	cmd.Flags().IntVar(&opts.port, "port", 0, "Port for development server to listen on")
+	cmd.Flags().SortFlags = false
+
 	return cmd
 }
 

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -114,5 +114,9 @@ func (opts *infoOptions) complete(ctx context.Context, args []string) error {
 		return fmt.Errorf("can not check remote: %s does not contain registry", util.FormatRepositoryForDisplay(opts.modelRef.String()))
 	}
 
+	if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -70,6 +70,8 @@ func InfoCommand() *cobra.Command {
 
 	opts.AddNetworkFlags(cmd)
 	cmd.Flags().BoolVarP(&opts.checkRemote, "remote", "r", false, "Check remote registry instead of local storage")
+	cmd.Flags().SortFlags = false
+
 	return cmd
 }
 

--- a/pkg/cmd/info/info.go
+++ b/pkg/cmd/info/info.go
@@ -49,11 +49,7 @@ func getLocalConfig(ctx context.Context, opts *infoOptions) (*artifact.KitFile, 
 }
 
 func getRemoteConfig(ctx context.Context, opts *infoOptions) (*artifact.KitFile, error) {
-	repository, err := remote.NewRepository(ctx, opts.modelRef.Registry, opts.modelRef.Repository, &remote.RegistryOptions{
-		PlainHTTP:       opts.PlainHTTP,
-		SkipTLSVerify:   !opts.TlsVerify,
-		CredentialsPath: constants.CredentialsPath(opts.configHome),
-	})
+	repository, err := remote.NewRepository(ctx, opts.modelRef.Registry, opts.modelRef.Repository, &opts.NetworkOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -114,5 +114,9 @@ func (opts *inspectOptions) complete(ctx context.Context, args []string) error {
 		return fmt.Errorf("can not check remote: %s does not contain registry", util.FormatRepositoryForDisplay(opts.modelRef.String()))
 	}
 
+	if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -70,6 +70,8 @@ func InspectCommand() *cobra.Command {
 
 	opts.AddNetworkFlags(cmd)
 	cmd.Flags().BoolVarP(&opts.checkRemote, "remote", "r", false, "Check remote registry instead of local storage")
+	cmd.Flags().SortFlags = false
+
 	return cmd
 }
 

--- a/pkg/cmd/inspect/inspect.go
+++ b/pkg/cmd/inspect/inspect.go
@@ -57,11 +57,7 @@ func getLocalInspect(ctx context.Context, opts *inspectOptions) (*inspectInfo, e
 }
 
 func getRemoteInspect(ctx context.Context, opts *inspectOptions) (*inspectInfo, error) {
-	repository, err := remote.NewRepository(ctx, opts.modelRef.Registry, opts.modelRef.Repository, &remote.RegistryOptions{
-		PlainHTTP:       opts.PlainHTTP,
-		SkipTLSVerify:   !opts.TlsVerify,
-		CredentialsPath: constants.CredentialsPath(opts.configHome),
-	})
+	repository, err := remote.NewRepository(ctx, opts.modelRef.Registry, opts.modelRef.Repository, &opts.NetworkOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -102,6 +102,7 @@ func ListCommand() *cobra.Command {
 
 	cmd.Args = cobra.MaximumNArgs(1)
 	opts.AddNetworkFlags(cmd)
+	cmd.Flags().SortFlags = false
 
 	return cmd
 }

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -80,6 +80,10 @@ func (opts *listOptions) complete(ctx context.Context, args []string) error {
 		opts.remoteRef = remoteRef
 	}
 
+	if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
+		return err
+	}
+
 	printConfig(opts)
 	return nil
 }

--- a/pkg/cmd/list/remote.go
+++ b/pkg/cmd/list/remote.go
@@ -28,11 +28,7 @@ import (
 )
 
 func listRemoteKits(ctx context.Context, opts *listOptions) ([]string, error) {
-	remoteRegistry, err := remote.NewRegistry(opts.remoteRef.Registry, &remote.RegistryOptions{
-		PlainHTTP:       opts.PlainHTTP,
-		SkipTLSVerify:   !opts.TlsVerify,
-		CredentialsPath: constants.CredentialsPath(opts.configHome),
-	})
+	remoteRegistry, err := remote.NewRegistry(opts.remoteRef.Registry, &opts.NetworkOptions)
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve registry %s: %w", opts.remoteRef.Registry, err)
 	}

--- a/pkg/cmd/login/cmd.go
+++ b/pkg/cmd/login/cmd.go
@@ -59,6 +59,7 @@ func LoginCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "registry password or token")
 	cmd.Flags().BoolVar(&opts.passwordFromStdIn, "password-stdin", false, "read password from stdin")
 	opts.AddNetworkFlags(cmd)
+	cmd.Flags().SortFlags = false
 
 	return cmd
 }

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -34,11 +34,7 @@ func login(ctx context.Context, opts *loginOptions) error {
 	if err != nil {
 		return err
 	}
-	registry, err := remote.NewRegistry(opts.registry, &remote.RegistryOptions{
-		PlainHTTP:       opts.PlainHTTP,
-		SkipTLSVerify:   !opts.TlsVerify,
-		CredentialsPath: credentialsStorePath,
-	})
+	registry, err := remote.NewRegistry(opts.registry, &opts.NetworkOptions)
 	if err != nil {
 		return fmt.Errorf("could not resolve registry %s: %w", opts.registry, err)
 	}

--- a/pkg/cmd/options/network.go
+++ b/pkg/cmd/options/network.go
@@ -28,14 +28,18 @@ import (
 // NetworkOptions represent common networking-related flags that are used by multiple commands.
 // The flags should be added to the command via AddNetworkFlags before running.
 type NetworkOptions struct {
-	PlainHTTP       bool
-	TLSVerify       bool
-	CredentialsPath string
+	PlainHTTP         bool
+	TLSVerify         bool
+	CredentialsPath   string
+	ClientCertPath    string
+	ClientCertKeyPath string
 }
 
 func (o *NetworkOptions) AddNetworkFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.PlainHTTP, "plain-http", false, "Use plain HTTP when connecting to remote registries")
 	cmd.Flags().BoolVar(&o.TLSVerify, "tls-verify", true, "Require TLS and verify certificates when connecting to remote registries")
+	cmd.Flags().StringVar(&o.ClientCertPath, "cert", "", "Path to client certificate used for authentication")
+	cmd.Flags().StringVar(&o.ClientCertKeyPath, "key", "", "Path to client certificate key used for authentication")
 }
 
 func (o *NetworkOptions) Complete(ctx context.Context, args []string) error {

--- a/pkg/cmd/options/network.go
+++ b/pkg/cmd/options/network.go
@@ -19,6 +19,7 @@ package options
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"kitops/pkg/lib/constants"
 
@@ -38,8 +39,10 @@ type NetworkOptions struct {
 func (o *NetworkOptions) AddNetworkFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.PlainHTTP, "plain-http", false, "Use plain HTTP when connecting to remote registries")
 	cmd.Flags().BoolVar(&o.TLSVerify, "tls-verify", true, "Require TLS and verify certificates when connecting to remote registries")
-	cmd.Flags().StringVar(&o.ClientCertPath, "cert", "", "Path to client certificate used for authentication")
-	cmd.Flags().StringVar(&o.ClientCertKeyPath, "key", "", "Path to client certificate key used for authentication")
+	cmd.Flags().StringVar(&o.ClientCertPath, "cert", "",
+		fmt.Sprintf("Path to client certificate used for authentication (can also be set via environment variable %s)", constants.ClientCertEnvVar))
+	cmd.Flags().StringVar(&o.ClientCertKeyPath, "key", "",
+		fmt.Sprintf("Path to client certificate key used for authentication (can also be set via environment variable %s)", constants.ClientCertKeyEnvVar))
 }
 
 func (o *NetworkOptions) Complete(ctx context.Context, args []string) error {
@@ -48,6 +51,14 @@ func (o *NetworkOptions) Complete(ctx context.Context, args []string) error {
 		return fmt.Errorf("default config path not set on command context")
 	}
 	o.CredentialsPath = constants.CredentialsPath(configHome)
+
+	if certPath := os.Getenv(constants.ClientCertEnvVar); certPath != "" {
+		o.ClientCertPath = certPath
+	}
+	if certKeyPath := os.Getenv(constants.ClientCertKeyEnvVar); certKeyPath != "" {
+		o.ClientCertKeyPath = certKeyPath
+	}
+
 	return nil
 }
 

--- a/pkg/cmd/options/network.go
+++ b/pkg/cmd/options/network.go
@@ -17,17 +17,40 @@
 package options
 
 import (
+	"context"
+	"fmt"
+
+	"kitops/pkg/lib/constants"
+
 	"github.com/spf13/cobra"
 )
 
 // NetworkOptions represent common networking-related flags that are used by multiple commands.
 // The flags should be added to the command via AddNetworkFlags before running.
 type NetworkOptions struct {
-	PlainHTTP bool
-	TlsVerify bool
+	PlainHTTP       bool
+	TLSVerify       bool
+	CredentialsPath string
 }
 
 func (o *NetworkOptions) AddNetworkFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.PlainHTTP, "plain-http", false, "Use plain HTTP when connecting to remote registries")
-	cmd.Flags().BoolVar(&o.TlsVerify, "tls-verify", true, "Require TLS and verify certificates when connecting to remote registries")
+	cmd.Flags().BoolVar(&o.TLSVerify, "tls-verify", true, "Require TLS and verify certificates when connecting to remote registries")
+}
+
+func (o *NetworkOptions) Complete(ctx context.Context, args []string) error {
+	configHome, ok := ctx.Value(constants.ConfigKey{}).(string)
+	if !ok {
+		return fmt.Errorf("default config path not set on command context")
+	}
+	o.CredentialsPath = constants.CredentialsPath(configHome)
+	return nil
+}
+
+func DefaultNetworkOptions(configHome string) *NetworkOptions {
+	return &NetworkOptions{
+		PlainHTTP:       false,
+		TLSVerify:       true,
+		CredentialsPath: constants.CredentialsPath(configHome),
+	}
 }

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -65,6 +65,7 @@ func PackCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.modelFile, "file", "f", "", "Specifies the path to the Kitfile explictly (use \"-\" to read from standard input)")
 	cmd.Flags().StringVarP(&opts.fullTagRef, "tag", "t", "", "Assigns one or more tags to the built modelkit. Example: -t registry/repository:tag1,tag2")
 	cmd.Flags().StringVar(&opts.compression, "compression", "none", "Compression format to use for layers. Valid options: 'none' (default), 'gzip', 'gzip-fastest'")
+	cmd.Flags().SortFlags = false
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd
 }

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -63,6 +63,10 @@ func (opts *pullOptions) complete(ctx context.Context, args []string) error {
 	}
 	opts.modelRef = modelRef
 
+	if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -82,6 +82,7 @@ func PullCommand() *cobra.Command {
 
 	cmd.Args = cobra.ExactArgs(1)
 	opts.AddNetworkFlags(cmd)
+	cmd.Flags().SortFlags = false
 
 	return cmd
 }

--- a/pkg/cmd/pull/pull.go
+++ b/pkg/cmd/pull/pull.go
@@ -43,11 +43,7 @@ func runPullRecursive(ctx context.Context, localRepo local.LocalRepo, opts *pull
 		return ocispec.DescriptorEmptyJSON, fmt.Errorf("reached maximum number of model references: [%s]", strings.Join(pulledRefs, "=>"))
 	}
 
-	remoteRegistry, err := remote.NewRegistry(opts.modelRef.Registry, &remote.RegistryOptions{
-		PlainHTTP:       opts.PlainHTTP,
-		SkipTLSVerify:   !opts.TlsVerify,
-		CredentialsPath: constants.CredentialsPath(opts.configHome),
-	})
+	remoteRegistry, err := remote.NewRegistry(opts.modelRef.Registry, &opts.NetworkOptions)
 	if err != nil {
 		return ocispec.DescriptorEmptyJSON, fmt.Errorf("could not resolve registry: %w", err)
 	}

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -89,6 +89,7 @@ func PushCommand() *cobra.Command {
 
 	cmd.Args = cobra.ExactArgs(1)
 	opts.AddNetworkFlags(cmd)
+	cmd.Flags().SortFlags = false
 
 	return cmd
 }

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -70,6 +70,10 @@ func (opts *pushOptions) complete(ctx context.Context, args []string) error {
 	}
 	opts.modelRef = modelRef
 
+	if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -99,11 +103,8 @@ func runCommand(opts *pushOptions) func(*cobra.Command, []string) error {
 			cmd.Context(),
 			opts.modelRef.Registry,
 			opts.modelRef.Repository,
-			&remote.RegistryOptions{
-				PlainHTTP:       opts.PlainHTTP,
-				SkipTLSVerify:   !opts.TlsVerify,
-				CredentialsPath: constants.CredentialsPath(opts.configHome),
-			})
+			&opts.NetworkOptions,
+		)
 		if err != nil {
 			return output.Fatalln(err)
 		}

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -108,6 +108,7 @@ func RemoveCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.removeAll, "all", "a", false, "remove all untagged modelkits")
 	cmd.Flags().BoolVarP(&opts.remote, "remote", "r", false, "remove modelkit from remote registry")
 	opts.AddNetworkFlags(cmd)
+	cmd.Flags().SortFlags = false
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
 		switch len(args) {

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -86,6 +86,10 @@ func (opts *removeOptions) complete(ctx context.Context, args []string) error {
 		return fmt.Errorf("cannot use --all or --force with --remote")
 	}
 
+	if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
+		return err
+	}
+
 	printConfig(opts)
 	return nil
 }

--- a/pkg/cmd/remove/remove.go
+++ b/pkg/cmd/remove/remove.go
@@ -131,11 +131,7 @@ func removeModel(ctx context.Context, opts *removeOptions) error {
 }
 
 func removeRemoteModel(ctx context.Context, opts *removeOptions) error {
-	registry, err := remote.NewRegistry(opts.modelRef.Registry, &remote.RegistryOptions{
-		PlainHTTP:       opts.PlainHTTP,
-		SkipTLSVerify:   !opts.TlsVerify,
-		CredentialsPath: constants.CredentialsPath(opts.configHome),
-	})
+	registry, err := remote.NewRegistry(opts.modelRef.Registry, &opts.NetworkOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -100,6 +100,10 @@ func (opts *unpackOptions) complete(ctx context.Context, args []string) error {
 	}
 	opts.unpackDir = absDir
 
+	if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
+		return err
+	}
+
 	printConfig(opts)
 	return nil
 }

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -128,6 +128,7 @@ func UnpackCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackDatasets, "datasets", false, "Unpack only datasets")
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackDocs, "docs", false, "Unpack only docs")
 	opts.AddNetworkFlags(cmd)
+	cmd.Flags().SortFlags = false
 
 	return cmd
 }

--- a/pkg/cmd/unpack/util.go
+++ b/pkg/cmd/unpack/util.go
@@ -46,11 +46,7 @@ func getStoreForRef(ctx context.Context, opts *unpackOptions) (oras.Target, erro
 		return nil, fmt.Errorf("not found")
 	}
 	// Not in local storage, check remote
-	remoteRegistry, err := remote.NewRegistry(opts.modelRef.Registry, &remote.RegistryOptions{
-		PlainHTTP:       opts.PlainHTTP,
-		SkipTLSVerify:   !opts.TlsVerify,
-		CredentialsPath: constants.CredentialsPath(opts.configHome),
-	})
+	remoteRegistry, err := remote.NewRegistry(opts.modelRef.Registry, &opts.NetworkOptions)
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve registry %s: %w", opts.modelRef.Registry, err)
 	}

--- a/pkg/lib/constants/env.go
+++ b/pkg/lib/constants/env.go
@@ -1,0 +1,23 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+const (
+	KitopsHomeEnvVar    = "KITOPS_HOME"
+	ClientCertEnvVar    = "KITOPS_CLIENT_CERT"
+	ClientCertKeyEnvVar = "KITOPS_CLIENT_KEY"
+)

--- a/pkg/lib/kitfile/resolve.go
+++ b/pkg/lib/kitfile/resolve.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"kitops/pkg/artifact"
+	"kitops/pkg/cmd/options"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/repo/local"
 	"kitops/pkg/lib/repo/remote"
@@ -50,7 +51,7 @@ func GetKitfileForRef(ctx context.Context, configHome string, ref *registry.Refe
 		return localKitfile, nil
 	}
 
-	repository, err := remote.NewRepository(ctx, ref.Registry, ref.Repository, remote.DefaultRegistryOptions(configHome))
+	repository, err := remote.NewRepository(ctx, ref.Registry, ref.Repository, options.DefaultNetworkOptions(configHome))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/network/auth.go
+++ b/pkg/lib/network/auth.go
@@ -19,16 +19,13 @@ package network
 import (
 	"net/http"
 
+	"kitops/pkg/cmd/options"
 	"kitops/pkg/lib/constants"
 
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
 	"oras.land/oras-go/v2/registry/remote/retry"
 )
-
-type ClientOpts struct {
-	TLSSkipVerify bool
-}
 
 func NewCredentialStore(storePath string) (credentials.Store, error) {
 	return credentials.NewStore(storePath, credentials.StoreOptions{
@@ -39,7 +36,7 @@ func NewCredentialStore(storePath string) (credentials.Store, error) {
 
 // ClientWithAuth returns a default *auth.Client using the provided credentials
 // store
-func ClientWithAuth(store credentials.Store, opts *ClientOpts) *auth.Client {
+func ClientWithAuth(store credentials.Store, opts *options.NetworkOptions) *auth.Client {
 	client := DefaultClient(opts)
 	client.Credential = credentials.Credential(store)
 
@@ -48,11 +45,9 @@ func ClientWithAuth(store credentials.Store, opts *ClientOpts) *auth.Client {
 
 // DefaultClient returns an *auth.Client with a default User-Agent header and TLS
 // configured from opts (optionally disabling TLS verification)
-func DefaultClient(opts *ClientOpts) *auth.Client {
+func DefaultClient(opts *options.NetworkOptions) *auth.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	if opts.TLSSkipVerify {
-		transport.TLSClientConfig.InsecureSkipVerify = true
-	}
+	transport.TLSClientConfig.InsecureSkipVerify = !opts.TLSVerify
 
 	client := &auth.Client{
 		Client: &http.Client{

--- a/pkg/lib/repo/remote/registry.go
+++ b/pkg/lib/repo/remote/registry.go
@@ -41,7 +41,10 @@ func NewRegistry(hostname string, opts *options.NetworkOptions) (*remote.Registr
 	if err != nil {
 		return nil, err
 	}
-	authClient := network.ClientWithAuth(credentialStore, opts)
+	authClient, err := network.ClientWithAuth(credentialStore, opts)
+	if err != nil {
+		return nil, err
+	}
 	reg.Client = output.WrapClient(authClient)
 
 	return reg, nil

--- a/pkg/lib/repo/remote/registry.go
+++ b/pkg/lib/repo/remote/registry.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"kitops/pkg/lib/constants"
+	"kitops/pkg/cmd/options"
 	"kitops/pkg/lib/network"
 	"kitops/pkg/output"
 
@@ -28,23 +28,9 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 )
 
-type RegistryOptions struct {
-	PlainHTTP       bool
-	SkipTLSVerify   bool
-	CredentialsPath string
-}
-
-func DefaultRegistryOptions(configHome string) *RegistryOptions {
-	return &RegistryOptions{
-		PlainHTTP:       false,
-		SkipTLSVerify:   false,
-		CredentialsPath: constants.CredentialsPath(configHome),
-	}
-}
-
 // NewRegistry returns a new *remote.Registry for hostname, with credentials and TLS
 // configured.
-func NewRegistry(hostname string, opts *RegistryOptions) (*remote.Registry, error) {
+func NewRegistry(hostname string, opts *options.NetworkOptions) (*remote.Registry, error) {
 	reg, err := remote.NewRegistry(hostname)
 	if err != nil {
 		return nil, err
@@ -55,13 +41,13 @@ func NewRegistry(hostname string, opts *RegistryOptions) (*remote.Registry, erro
 	if err != nil {
 		return nil, err
 	}
-	authClient := network.ClientWithAuth(credentialStore, &network.ClientOpts{TLSSkipVerify: opts.SkipTLSVerify})
+	authClient := network.ClientWithAuth(credentialStore, opts)
 	reg.Client = output.WrapClient(authClient)
 
 	return reg, nil
 }
 
-func NewRepository(ctx context.Context, hostname, repository string, opts *RegistryOptions) (registry.Repository, error) {
+func NewRepository(ctx context.Context, hostname, repository string, opts *options.NetworkOptions) (registry.Repository, error) {
 	reg, err := NewRegistry(hostname, opts)
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve registry: %w", err)

--- a/testing/modelkit-refs_test.go
+++ b/testing/modelkit-refs_test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"kitops/pkg/lib/constants"
 )
 
 type modelkitRefTestcase struct {
@@ -56,7 +58,7 @@ func TestModelKitReferences(t *testing.T) {
 			if err := os.MkdirAll(contextPath, 0755); err != nil {
 				t.Fatal(err)
 			}
-			t.Setenv("KITOPS_HOME", contextPath)
+			t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 			// Set up temporary directories for modelkits; note we create one extra for the final unpack
 			for i := 0; i <= len(tt.Modelkits); i++ {

--- a/testing/pack-unpack_test.go
+++ b/testing/pack-unpack_test.go
@@ -58,7 +58,7 @@ func TestPackUnpack(t *testing.T) {
 
 			// Set up paths to use for test
 			modelKitPath, unpackPath, contextPath := setupTestDirs(t, tmpDir)
-			t.Setenv("KITOPS_HOME", contextPath)
+			t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 			// Create Kitfile
 			setupKitfileAndKitignore(t, modelKitPath, tt.Kitfile, tt.Kitignore)
@@ -80,7 +80,7 @@ func TestPackReproducibility(t *testing.T) {
 	defer removeTmp()
 
 	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
-	t.Setenv("KITOPS_HOME", contextPath)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 	testKitfile := `
 manifestVersion: 1.0.0

--- a/testing/remove_test.go
+++ b/testing/remove_test.go
@@ -43,7 +43,7 @@ func TestRemoveSingleModelkitTag(t *testing.T) {
 	defer removeTmp()
 
 	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
-	t.Setenv("KITOPS_HOME", contextPath)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
 	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
@@ -71,7 +71,7 @@ func TestRemoveSingleModelkitDigest(t *testing.T) {
 	defer removeTmp()
 
 	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
-	t.Setenv("KITOPS_HOME", contextPath)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
 	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
@@ -100,7 +100,7 @@ func TestRemoveSingleModelkitNoTag(t *testing.T) {
 	defer removeTmp()
 
 	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
-	t.Setenv("KITOPS_HOME", contextPath)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
 	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
@@ -128,7 +128,7 @@ func TestRemoveModelkitUntagsWhenMultiple(t *testing.T) {
 	defer removeTmp()
 
 	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
-	t.Setenv("KITOPS_HOME", contextPath)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
 	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
@@ -161,7 +161,7 @@ func TestRemoveModelkitUntagsAllWhenDigest(t *testing.T) {
 	defer removeTmp()
 
 	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
-	t.Setenv("KITOPS_HOME", contextPath)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
 	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
@@ -195,7 +195,7 @@ func TestRemoveModelkitUntagged(t *testing.T) {
 	defer removeTmp()
 
 	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
-	t.Setenv("KITOPS_HOME", contextPath)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
 	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
@@ -238,7 +238,7 @@ func TestRemoveModelkitAll(t *testing.T) {
 	defer removeTmp()
 
 	modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
-	t.Setenv("KITOPS_HOME", contextPath)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
 
 	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
 	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {


### PR DESCRIPTION
### Description
Add support for authenticating with remote registries via client certificates. This PR adds two options to most commands (anything that might contact a remote registry):

```
      --cert string   Path to client certificate used for authentication (can also be set via environment variable KITOPS_CLIENT_CERT)
      --key string    Path to client certificate key used for authentication (can also be set via environment variable KITOPS_CLIENT_KEY)
```

For convenience, values can also be set via environment variables. The env vars take precedence, if set.

Less interesting, but this PR also refactors how we pass networking options around, to use the same struct everywhere rather than creating 3 similar-but-slight-different structs we have to convert between.

### Testing
I've briefly tested this with the `registry` image behind an nginx proxy and didn't find any issues. I used the following compose.yml and nginx.conf to test:

<details>
<summary>compose.yml</summary>

```yaml
version: "3"

services:
  registry:
    image: registry
    ports:
      - 5050:5050
    environment:
      REGISTRY_HTTP_ADDR: ":5050"

  nginx:
    image: nginx
    ports:
      - "8443:8443"
      - "8080:8080"
    volumes:
      - ./nginx.conf:/etc/nginx/conf.d/default.conf:z
      - ./certs/server.crt:/etc/ssl/server.crt:z
      - ./certs/server.key:/etc/ssl/server.key:z
      - ./certs/ca.crt:/etc/nginx/client_certs/ca.crt:z
    depends_on:
      - registry
```

</details>

<details>
<summary>nginx.conf</summary>

```conf
server {
  listen         8080;
  location / {
    return       301 https://$host$request_uri;
  }
}

server {
  listen                     8443 ssl;

  ssl_certificate            /etc/ssl/server.crt;
  ssl_certificate_key        /etc/ssl/server.key;
  ssl_protocols              TLSv1.1 TLSv1.2;
  ssl_ciphers                'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
  ssl_prefer_server_ciphers  on;
  ssl_session_cache          shared:SSL:10m;

  ssl_client_certificate     /etc/nginx/client_certs/ca.crt;
  ssl_verify_client          optional;
  ssl_verify_depth           2;

  # disable any limits to avoid HTTP 413 for large image uploads
  client_max_body_size       0;

  location / {
    if ($ssl_client_verify != SUCCESS) { return 403; }

    proxy_set_header         SSL_Client_Issuer $ssl_client_i_dn;
    proxy_set_header         SSL_Client $ssl_client_s_dn;
    proxy_set_header         SSL_Client_Verify $ssl_client_verify;

    proxy_pass               http://registry:5050;
  }
}
```

</details>


### Linked issues
Closes #401 
