### PR TITLE
Don't fail remote list operations if repo contains non-modelkits

### DIFF
--- a/pkg/cmd/list/list.go
+++ b/pkg/cmd/list/list.go
@@ -5,6 +5,7 @@ package list
 
 import (
 	"context"
+	"errors"
 	"sort"
 
 	"kitops/pkg/lib/constants"
@@ -36,7 +37,7 @@ func readInfoFromRepo(ctx context.Context, repo local.LocalRepo) ([]string, erro
 	manifestDescs := repo.GetAllModels()
 	for _, manifestDesc := range manifestDescs {
 		manifest, config, err := util.GetManifestAndConfig(ctx, repo, manifestDesc)
-		if err != nil {
+		if err != nil && !errors.Is(err, util.ErrNotAModelKit) {
 			return nil, err
 		}
 		tags := repo.GetTags(manifestDesc)

--- a/pkg/cmd/list/remote.go
+++ b/pkg/cmd/list/remote.go
@@ -18,6 +18,7 @@ package list
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"kitops/pkg/lib/constants"
@@ -61,7 +62,7 @@ func listTags(ctx context.Context, repo registry.Repository, ref *registry.Refer
 			Reference:  tag,
 		}
 		infoLines, err := listImageTag(ctx, repo, tagRef)
-		if err != nil {
+		if err != nil && !errors.Is(err, util.ErrNotAModelKit) {
 			return nil, err
 		}
 		allLines = append(allLines, infoLines...)

--- a/pkg/lib/repo/util/errors.go
+++ b/pkg/lib/repo/util/errors.go
@@ -1,0 +1,21 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import "errors"
+
+var ErrNotAModelKit = errors.New("reference exists but is not a modelkit")

--- a/pkg/lib/repo/util/reference.go
+++ b/pkg/lib/repo/util/reference.go
@@ -200,7 +200,7 @@ func GetManifest(ctx context.Context, store content.Storage, manifestDesc ocispe
 		return nil, fmt.Errorf("failed to parse manifest %s: %w", manifestDesc.Digest, err)
 	}
 	if manifest.Config.MediaType != constants.ModelConfigMediaType.String() {
-		return nil, fmt.Errorf("reference exists but is not a model")
+		return nil, ErrNotAModelKit
 	}
 
 	return manifest, nil


### PR DESCRIPTION

### Description
Normally, attempting to read a manifest from a repo fails if that descriptor does not refer to a modelkit. However, for the `kit list` operation, we want to just ignore such errors to allow listing all modelkits in repositories that may also contain e.g. docker images or other OCI artifacts.

### Linked issues
Closes #403
