### PR TITLE
Add support for resumable downloads; clean up ingest directory; add `--concurrency` flag

### DIFF
--- a/pkg/cmd/options/network.go
+++ b/pkg/cmd/options/network.go
@@ -34,6 +34,7 @@ type NetworkOptions struct {
 	CredentialsPath   string
 	ClientCertPath    string
 	ClientCertKeyPath string
+	Concurrency       int
 }
 
 func (o *NetworkOptions) AddNetworkFlags(cmd *cobra.Command) {
@@ -43,6 +44,7 @@ func (o *NetworkOptions) AddNetworkFlags(cmd *cobra.Command) {
 		fmt.Sprintf("Path to client certificate used for authentication (can also be set via environment variable %s)", constants.ClientCertEnvVar))
 	cmd.Flags().StringVar(&o.ClientCertKeyPath, "key", "",
 		fmt.Sprintf("Path to client certificate key used for authentication (can also be set via environment variable %s)", constants.ClientCertKeyEnvVar))
+	cmd.Flags().IntVar(&o.Concurrency, "concurrency", 5, "Maximum number of simultaneous uploads/downloads")
 }
 
 func (o *NetworkOptions) Complete(ctx context.Context, args []string) error {
@@ -57,6 +59,9 @@ func (o *NetworkOptions) Complete(ctx context.Context, args []string) error {
 	}
 	if certKeyPath := os.Getenv(constants.ClientCertKeyEnvVar); certKeyPath != "" {
 		o.ClientCertKeyPath = certKeyPath
+	}
+	if o.Concurrency < 1 {
+		o.Concurrency = 5
 	}
 
 	return nil

--- a/pkg/cmd/pull/cmd.go
+++ b/pkg/cmd/pull/cmd.go
@@ -96,7 +96,7 @@ func runCommand(opts *pullOptions) func(*cobra.Command, []string) error {
 		output.Infof("Pulling %s", opts.modelRef.String())
 		desc, err := runPull(cmd.Context(), opts)
 		if err != nil {
-			return output.Fatalf("Failed to pull: %s", err)
+			return output.Fatalln(err)
 		}
 		output.Infof("Pulled %s", desc.Digest)
 		return nil

--- a/pkg/cmd/pull/pull.go
+++ b/pkg/cmd/pull/pull.go
@@ -87,12 +87,9 @@ func pullModel(ctx context.Context, localRepo local.LocalRepo, opts *pullOptions
 
 	// TODO: progress bars...
 	desc, err := localRepo.PullModel(ctx, repo, *opts.modelRef, &opts.NetworkOptions)
-	// trackedRepo, logger := output.WrapTarget(localRepo)
-	// desc, err := oras.Copy(ctx, repo, ref.Reference, trackedRepo, ref.Reference, oras.DefaultCopyOptions)
 	if err != nil {
 		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to pull: %w", err)
 	}
-	// logger.Wait()
 
 	return desc, nil
 }

--- a/pkg/cmd/pull/pull.go
+++ b/pkg/cmd/pull/pull.go
@@ -85,7 +85,6 @@ func pullModel(ctx context.Context, localRepo local.LocalRepo, opts *pullOptions
 		return ocispec.DescriptorEmptyJSON, err
 	}
 
-	// TODO: progress bars...
 	desc, err := localRepo.PullModel(ctx, repo, *opts.modelRef, &opts.NetworkOptions)
 	if err != nil {
 		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to pull: %w", err)

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -116,7 +116,7 @@ func runCommand(opts *pushOptions) func(*cobra.Command, []string) error {
 		}
 
 		output.Infof("Pushing %s", opts.modelRef.String())
-		desc, err := PushModel(cmd.Context(), localRepo, remoteRepo, opts.modelRef)
+		desc, err := PushModel(cmd.Context(), localRepo, remoteRepo, opts)
 		if err != nil {
 			return output.Fatalf("Failed to push: %s", err)
 		}

--- a/pkg/cmd/push/push.go
+++ b/pkg/cmd/push/push.go
@@ -15,9 +15,12 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
-func PushModel(ctx context.Context, localRepo local.LocalRepo, repo registry.Repository, ref *registry.Reference) (ocispec.Descriptor, error) {
+func PushModel(ctx context.Context, localRepo local.LocalRepo, repo registry.Repository, opts *pushOptions) (ocispec.Descriptor, error) {
 	trackedRepo, logger := output.WrapTarget(repo)
-	desc, err := oras.Copy(ctx, localRepo, ref.Reference, trackedRepo, ref.Reference, oras.DefaultCopyOptions)
+	ref := opts.modelRef.Reference
+	copyOpts := oras.CopyOptions{}
+	copyOpts.Concurrency = opts.Concurrency
+	desc, err := oras.Copy(ctx, localRepo, ref, trackedRepo, ref, copyOpts)
 	if err != nil {
 		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to copy to remote: %w", err)
 	}

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -103,6 +103,10 @@ func StoragePath(configBase string) string {
 	return filepath.Join(configBase, StorageSubpath)
 }
 
+func IngestPath(storageBase string) string {
+	return filepath.Join(storageBase, "ingest")
+}
+
 func HarnessPath(configBase string) string {
 	return filepath.Join(configBase, HarnessSubpath)
 }

--- a/pkg/lib/constants/mediaType.go
+++ b/pkg/lib/constants/mediaType.go
@@ -19,6 +19,8 @@ package constants
 import (
 	"fmt"
 	"regexp"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (
@@ -88,4 +90,12 @@ func IsValidCompression(compression string) error {
 	default:
 		return fmt.Errorf("Invalid option for --compression flag: must be one of 'none', 'gzip', or 'gzip-fastest'")
 	}
+}
+
+func FormatMediaTypeForUser(mediaType string) string {
+	if mediaType == ocispec.MediaTypeImageManifest {
+		return "manifest"
+	}
+	parsed := ParseMediaType(mediaType)
+	return parsed.BaseType
 }

--- a/pkg/lib/repo/local/pull.go
+++ b/pkg/lib/repo/local/pull.go
@@ -1,0 +1,132 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"kitops/pkg/cmd/options"
+	"kitops/pkg/lib/constants"
+	"kitops/pkg/lib/repo/util"
+	"kitops/pkg/output"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry"
+)
+
+func (l *localRepo) PullModel(ctx context.Context, src oras.ReadOnlyTarget, ref registry.Reference, opts *options.NetworkOptions) (ocispec.Descriptor, error) {
+	// Only support pulling image manifests
+	desc, err := src.Resolve(ctx, ref.Reference)
+	if err != nil {
+		return ocispec.DescriptorEmptyJSON, err
+	}
+	if desc.MediaType != ocispec.MediaTypeImageManifest {
+		return ocispec.DescriptorEmptyJSON, fmt.Errorf("expected manifest for pull but got %s", desc.MediaType)
+	}
+
+	if err := l.ensurePullDirs(); err != nil {
+		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to set up directories for pull: %w", err)
+	}
+
+	manifest, err := util.GetManifest(ctx, src, desc)
+	if err != nil {
+		return ocispec.DescriptorEmptyJSON, err
+	}
+	if err := l.pullNode(ctx, src, manifest.Config); err != nil {
+		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to get config: %w", err)
+	}
+	for _, layerDesc := range manifest.Layers {
+		if err := l.pullNode(ctx, src, layerDesc); err != nil {
+			return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to get layer: %w", err)
+		}
+	}
+	if err := l.pullNode(ctx, src, desc); err != nil {
+		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to get manifest: %w", err)
+	}
+	if err := l.localIndex.addManifest(desc); err != nil {
+		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to add manifest to index: %w", err)
+	}
+	if !util.ReferenceIsDigest(ref.Reference) {
+		if err := l.localIndex.tag(desc, ref.Reference); err != nil {
+			return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to save tag: %w", err)
+		}
+	}
+
+	return desc, nil
+}
+
+func (l *localRepo) pullNode(ctx context.Context, src oras.ReadOnlyTarget, desc ocispec.Descriptor) error {
+	blob, err := src.Fetch(ctx, desc)
+	if err != nil {
+		return fmt.Errorf("failed to fetch: %w", err)
+	}
+	return l.downloadFile(desc, blob)
+}
+
+func (l *localRepo) downloadFile(desc ocispec.Descriptor, blob io.ReadCloser) (ingestErr error) {
+	ingestDir := constants.IngestPath(l.storagePath)
+	ingestFile, err := os.CreateTemp(ingestDir, desc.Digest.Encoded()+"_*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary ingest file: %w", err)
+	}
+
+	ingestFilename := ingestFile.Name()
+	// If we return an error anywhere after this point, we want to delete the ingest file we're
+	// working on, since it will never be reused.
+	defer func() {
+		if err := ingestFile.Close(); err != nil && !errors.Is(err, fs.ErrClosed) {
+			output.Errorf("Error closing temporary ingest file: %s", err)
+		}
+		if ingestErr != nil {
+			os.Remove(ingestFilename)
+		}
+	}()
+
+	verifier := desc.Digest.Verifier()
+	mw := io.MultiWriter(ingestFile, verifier)
+	if _, err := io.Copy(mw, blob); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	if !verifier.Verified() {
+		return fmt.Errorf("downloaded file hash does not match descriptor")
+	}
+	if err := ingestFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary ingest file: %w", err)
+	}
+
+	blobPath := l.BlobPath(desc)
+	if err := os.Rename(ingestFilename, blobPath); err != nil {
+		return fmt.Errorf("failed to move downloaded file into storage: %w", err)
+	}
+	return nil
+}
+
+func (l *localRepo) ensurePullDirs() error {
+	blobsPath := filepath.Join(l.storagePath, ocispec.ImageBlobsDir, "sha256")
+	if err := os.MkdirAll(blobsPath, 0755); err != nil {
+		return err
+	}
+	ingestPath := constants.IngestPath(l.storagePath)
+	return os.MkdirAll(ingestPath, 0755)
+}

--- a/pkg/lib/repo/local/pull.go
+++ b/pkg/lib/repo/local/pull.go
@@ -61,7 +61,7 @@ func (l *localRepo) PullModel(ctx context.Context, src oras.ReadOnlyTarget, ref 
 	toPull := []ocispec.Descriptor{manifest.Config}
 	toPull = append(toPull, manifest.Layers...)
 	toPull = append(toPull, desc)
-	sem := semaphore.NewWeighted(5)
+	sem := semaphore.NewWeighted(int64(opts.Concurrency))
 	errs, errCtx := errgroup.WithContext(ctx)
 	fmtErr := func(desc ocispec.Descriptor, err error) error {
 		if err == nil {

--- a/pkg/lib/repo/local/pull.go
+++ b/pkg/lib/repo/local/pull.go
@@ -84,6 +84,12 @@ func (l *localRepo) PullModel(ctx context.Context, src oras.ReadOnlyTarget, ref 
 }
 
 func (l *localRepo) pullNode(ctx context.Context, src oras.ReadOnlyTarget, desc ocispec.Descriptor, p *output.PullProgress) error {
+	if exists, err := l.Exists(ctx, desc); err != nil {
+		return fmt.Errorf("failed to check local storage: %w", err)
+	} else if exists {
+		return nil
+	}
+
 	blob, err := src.Fetch(ctx, desc)
 	if err != nil {
 		return fmt.Errorf("failed to fetch: %w", err)

--- a/pkg/lib/repo/local/pull.go
+++ b/pkg/lib/repo/local/pull.go
@@ -171,6 +171,9 @@ func (l *localRepo) resumeAndDownloadFile(desc ocispec.Descriptor, blob io.ReadS
 	if err := os.Rename(ingestFilename, blobPath); err != nil {
 		return fmt.Errorf("failed to move downloaded file into storage: %w", err)
 	}
+	if err := os.Chmod(blobPath, 0600); err != nil {
+		return fmt.Errorf("failed to set permissions on blob: %w", err)
+	}
 
 	return nil
 }
@@ -211,6 +214,10 @@ func (l *localRepo) downloadFile(desc ocispec.Descriptor, blob io.ReadCloser, p 
 	if err := os.Rename(ingestFilename, blobPath); err != nil {
 		return fmt.Errorf("failed to move downloaded file into storage: %w", err)
 	}
+	if err := os.Chmod(blobPath, 0600); err != nil {
+		return fmt.Errorf("failed to set permissions on blob: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/lib/repo/local/registry.go
+++ b/pkg/lib/repo/local/registry.go
@@ -28,6 +28,7 @@ import (
 	"slices"
 	"strings"
 
+	"kitops/pkg/cmd/options"
 	"kitops/pkg/lib/constants"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -43,6 +44,7 @@ type LocalRepo interface {
 	BlobPath(ocispec.Descriptor) string
 	GetAllModels() []ocispec.Descriptor
 	GetTags(ocispec.Descriptor) []string
+	PullModel(context.Context, oras.ReadOnlyTarget, registry.Reference, *options.NetworkOptions) (ocispec.Descriptor, error)
 	oras.Target
 	content.Deleter
 	content.Untagger
@@ -123,7 +125,7 @@ func (r *localRepo) GetRepoName() string {
 }
 
 func (r *localRepo) BlobPath(desc ocispec.Descriptor) string {
-	return filepath.Join(r.storagePath, "blobs", "sha256", desc.Digest.Encoded())
+	return filepath.Join(r.storagePath, ocispec.ImageBlobsDir, desc.Digest.Algorithm().String(), desc.Digest.Encoded())
 }
 
 func (l *localRepo) Delete(ctx context.Context, target ocispec.Descriptor) error {

--- a/pkg/lib/repo/local/util.go
+++ b/pkg/lib/repo/local/util.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/registry"
 )
 
 // parseIndexJson parses an OCI index at specified path
@@ -78,4 +80,16 @@ func canSafelyDeleteManifest(ctx context.Context, storagePath string, desc ocisp
 		}
 	}
 	return refCount <= 1, nil
+}
+
+func getBaseBlobDownloadUrl(ref registry.Reference, plainHttp bool) string {
+	scheme := "https"
+	if plainHttp {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s/v2/%s/blobs/", scheme, ref.Host(), ref.Repository)
+}
+
+func blobUrlForDescriptor(baseUrl string, digest string) (string, error) {
+	return url.JoinPath(baseUrl, digest)
 }

--- a/pkg/lib/repo/util/reference.go
+++ b/pkg/lib/repo/util/reference.go
@@ -176,7 +176,7 @@ func RepoPath(storagePath string, ref *registry.Reference) string {
 
 // GetManifestAndConfig returns the manifest and config (Kitfile) for a manifest Descriptor.
 // Calls GetManifest and GetConfig.
-func GetManifestAndConfig(ctx context.Context, store content.Storage, manifestDesc ocispec.Descriptor) (*ocispec.Manifest, *artifact.KitFile, error) {
+func GetManifestAndConfig(ctx context.Context, store oras.ReadOnlyTarget, manifestDesc ocispec.Descriptor) (*ocispec.Manifest, *artifact.KitFile, error) {
 	manifest, err := GetManifest(ctx, store, manifestDesc)
 	if err != nil {
 		return nil, nil, err
@@ -190,7 +190,7 @@ func GetManifestAndConfig(ctx context.Context, store content.Storage, manifestDe
 
 // GetManifest returns the Manifest described by a Descriptor. Returns an error if the manifest blob cannot be
 // resolved or does not represent a modelkit manifest.
-func GetManifest(ctx context.Context, store content.Storage, manifestDesc ocispec.Descriptor) (*ocispec.Manifest, error) {
+func GetManifest(ctx context.Context, store oras.ReadOnlyTarget, manifestDesc ocispec.Descriptor) (*ocispec.Manifest, error) {
 	manifestBytes, err := content.FetchAll(ctx, store, manifestDesc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read manifest %s: %w", manifestDesc.Digest, err)
@@ -208,7 +208,7 @@ func GetManifest(ctx context.Context, store content.Storage, manifestDesc ocispe
 
 // GetConfig returns the config (Kitfile) described by a descriptor. Returns an error if the config blob cannot
 // be resolved or if the descriptor does not describe a Kitfile.
-func GetConfig(ctx context.Context, store content.Storage, configDesc ocispec.Descriptor) (*artifact.KitFile, error) {
+func GetConfig(ctx context.Context, store oras.ReadOnlyTarget, configDesc ocispec.Descriptor) (*artifact.KitFile, error) {
 	if configDesc.MediaType != constants.ModelConfigMediaType.String() {
 		return nil, fmt.Errorf("configuration descriptor does not describe a Kitfile")
 	}

--- a/pkg/output/logging.go
+++ b/pkg/output/logging.go
@@ -156,3 +156,15 @@ func (pw *ProgressLogger) Debugf(s string, args ...any) {
 		logfTo(pw.output, LogLevelDebug, s, args...)
 	}
 }
+
+func (pw *ProgressLogger) Logln(level LogLevel, s any) {
+	if logLevel.shouldPrint(level) {
+		loglnTo(pw.output, level, s)
+	}
+}
+
+func (pw *ProgressLogger) Logf(level LogLevel, s string, args ...any) {
+	if logLevel.shouldPrint(level) {
+		logfTo(pw.output, level, s, args...)
+	}
+}


### PR DESCRIPTION
### Description
Add support for resuming downloads that were cancelled/hit an error in an earlier invocation. Doing this required implementing our own Pull routine, separate from oras.Copy, which is used elsewhere.

If a server responds with header `Accept-Ranges: "bytes"`, treat the download as resumable; otherwise, pull behaves as before. For resumable downloads:

* Files are saved to `$KITOPS_HOME/storage/ingest/<blob-digest>`
* If a file exists, we first read it to get a digest from the start to where the download ended, then seek the download reader to that point and resume downloading
* Once completed, we verify the digest and move it to the normal location

There's some risk of corruption if e.g. two separate kit pulls are pulling the same resumable download simultaneously, though I think the risk is fairly low and I'm not sure we care to support running `kit` in parallel at this moment.

When a pull is completed, all data in the ingest directory is removed. This is to ensure we don't leave files lying around with no easy path to their removal, which can happen with non-resumable downloads that are e.g. cancelled via ctrl-C. This means that completing a pull effectively cancels all other downloads.

Finally, since I had to add reimplement concurrency for the pull operation, I've added a `--concurrency` flag to allow configuring it. It's available on all commands that take the standard network options, but is currently only used for pull and push.

### Linked issues
Closes #311 
Closes #387 
