### PR TITLE
jozu hub compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ KitOps is a packaging and versioning system for AI/ML projects that uses open st
 
 KitOps makes it easy for organizations to track, control, and audit access and changes to their AI project artifacts. It simplifies the handoffs between data scientists, application developers, and SREs working with LLMs and other AI/ML models. KitOps' ModelKits are an OCI-compliant package for models, their dependencies, configurations, codebases, features, hyperparmeters, and any other documentation. ModelKits are portable, reproducible, and work with the tools you already use.
 
-Teams and enterprises use KitOps as a gate between development and production deployment. This ensures that projects are complete, versioned, and immutable before they are deployed and makes rollbacks and other production operations simpler and safer. 
+Teams and enterprises use KitOps as a gate between development and production deployment. This ensures that projects are complete, versioned, and immutable before they are deployed and makes rollbacks and other production operations simpler and safer.
 
 Use KitOps to speed up and de-risk all types of AI projects from small analysis models to large language models, including fine-tuning and RAG.
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,16 @@
 
 KitOps is a packaging and versioning system for AI/ML projects that uses open standards so it works with the AI/ML, development, and DevOps tools you are already using, and can be stored in your enterprise registry. It's tamper-proof, signable, and auditable.
 
-KitOps makes it easy for organizations to track, control, and audit access and changes to their AI project artifacts. It simplifies the handoffs between data scientists, application developers, and SREs working with LLMs and other AI/ML models. KitOps' ModelKits are an OCI-compliant package for models, their dependencies, configurations, and codebases. ModelKits are portable, reproducible, and work with the tools you already use.
+KitOps makes it easy for organizations to track, control, and audit access and changes to their AI project artifacts. It simplifies the handoffs between data scientists, application developers, and SREs working with LLMs and other AI/ML models. KitOps' ModelKits are an OCI-compliant package for models, their dependencies, configurations, codebases, features, hyperparmeters, and any other documentation. ModelKits are portable, reproducible, and work with the tools you already use.
 
-Teams and enterprises use KitOps to speed up and de-risk all types of AI projects from small analysis models to large language models, including fine-tuning and RAG.
+Teams and enterprises use KitOps as a gate between development and production deployment. This ensures that projects are complete, versioned, and immutable before they are deployed and makes rollbacks and other production operations simpler and safer. 
+
+Use KitOps to speed up and de-risk all types of AI projects from small analysis models to large language models, including fine-tuning and RAG.
+
+### 🎉 New
+
+Get the most out of KitOps' ModelKits by using them with the **[Jozu Hub](https://jozu.ml/discover)** repository (don't worry - ModelKits are still compatible with any OCI registry).
+
 
 ### Features
 
@@ -27,15 +34,16 @@ Teams and enterprises use KitOps to speed up and de-risk all types of AI project
 * 🏭 **[Versioning](https://kitops.ml/docs/cli/cli-reference.html#kit-tag):** Each ModelKit is tagged so everyone knows which dataset and model work together.
 * 🤖 **[Automation](https://github.com/marketplace/actions/setup-kit-cli):** Pack or unpack a ModelKit locally or as part of your CI/CD workflow for testing, integration, or deployment.
 * 🪛 **[LLM fine-tuning](https://dev.to/kitops/fine-tune-your-first-large-language-model-llm-with-lora-llamacpp-and-kitops-in-5-easy-steps-1g7f):** Use KitOps to fine-tune a large language model using LoRA.
-* 🎯 **RAG pipelines:** Create a RAG pipeline for tailoring an LLM with KitOps.
+* 🎯 **[RAG pipelines](https://www.codeproject.com/Articles/5384392/A-Step-by-Step-Guide-to-Building-and-Distributing):** Create a RAG pipeline for tailoring an LLM with KitOps.
 * 🔒 **[Tamper-proofing](https://kitops.ml/docs/modelkit/spec.html):** Each ModelKit package includes a SHA digest for itself, and every artifact it holds.
-* 🌈 **[Standards-based](https://kitops.ml/docs/modelkit/compatibility.html):** Store ModelKits in any container or artifact registry.
+* 📝 **[Artifact signing](./docs/src/docs/next-steps.md):** ModelKits and their assets can be signed so you can be confident of their provenance.
+* 🌈 **[Standards-based](https://kitops.ml/docs/modelkit/compatibility.html):** Store ModelKits in any OCI 1.1-compliant container or artifact registry.
 * 🥧 **[Simple syntax](https://kitops.ml/docs/kitfile/kf-overview.html):** Kitfiles are easy to write and read, using a familiar YAML syntax.
 * 🏃‍♂️‍➡️ **[Run locally](./docs/src/docs/quick-start.md#_8-run-an-llm-locally):** Kit's Dev Mode lets your run an LLM locally, configure it, and prompt/chat with it instantly.
-* 📝 **[Signed packages](./docs/src/docs/next-steps.md):** ModelKits and their assets can be signed so you can be confident of their provenance.
 * 🐳 **Deploy containers:** Generate a Docker container as part of your `kit unpack` (coming soon).
 * 🚢 **Kubernetes-ready:** Generate a Kubernetes / KServe deployment config as part of your `kit unpack` (coming soon).
-* 🤗 **Flexible:** ModelKits can be used with any AI, ML, or LLM project - even multi-modal models.
+* 🩰 **Flexible:** Store key-value pairs, or any YAML-compatible JSON data in your Kitfile - use it to keep features, hyperparameters, links to MLOps tool experiments our validation output...whatever you want!
+* 🤗 **Universal:** ModelKits can be used with any AI, ML, or LLM project - even multi-modal models.
 
 ### See KitOps in Action
 
@@ -60,12 +68,13 @@ For those who prefer to build from the source, follow [these steps](https://kito
 
 We've been busy and shipping quickly!
 
-* 🎯 Use KitOps to do LLM fine-tuning or package a RAG pipeline
-* 👩‍💻 Use Kit Dev mode to run an LLM instantly (no GPUs or internet required)
-* 🏎️ Reduced ModelKit packing time by >97%
-* 🤓 Read Kitfile from `stdin`
+* 📝 Add any arbitrary metadata to your Kitfile - hyperparameters, test results, links to resources, etc...
 * 🔼 Automatic chunking of uploads to registries
 * 🪵 New log-levels and per-request trace logging
+* 🏎️ Reduced ModelKit packing time by >97%
+* 🎯 Use KitOps to do LLM fine-tuning or package a RAG pipeline
+* 🤓 Read Kitfile from `stdin`
+* 👩‍💻 Use Kit Dev mode to run an LLM instantly (no GPUs or internet required)
 
 You can see all the gory details in our [release changelogs](https://github.com/jozu-ai/kitops/releases).
 

--- a/docs/src/docs/next-steps.md
+++ b/docs/src/docs/next-steps.md
@@ -37,7 +37,7 @@ datasets:
 - description: Forum postings from photo sites
   name: training data
   path: ./data/forum-to-2023-train.csv
-  
+
 - name: validation data
   path: ./data/test.csv
 ```
@@ -174,7 +174,7 @@ The `unpack` command is part of the typical push and pull commands:
 * `pack` will pack up a set of assets into a ModelKit package.
 * `push` will push the whole ModelKit to a registry.
 * `pull` will pull the whole ModelKit from a registry.
-* `unpack` will extract all, or selected assets, from the ModelKit. 
+* `unpack` will extract all, or selected assets, from the ModelKit.
 
 ## Read the Kitfile or Manifest from a ModelKit
 

--- a/docs/src/docs/next-steps.md
+++ b/docs/src/docs/next-steps.md
@@ -81,7 +81,7 @@ docs:
     description: Information on how to use this model for inference
 
 datasets:
-  - description: Forum postings from sites like rangefinderforum, DPreview, PhotographyTalk, and r/AnalogCommunity
+  - description: Forum postings from sites like rangefinderforum, PhotographyTalk, and r/AnalogCommunity
     name: training data
     path: ./data/forum-to-2023-train.csv
   - description: validation data
@@ -144,9 +144,10 @@ First, you need to tag the image in your local registry with the remote registry
 kit pack . -t docker.io/jozubrad/film-slm:champion
 ```
 
-Second, you [kit push](./cli/cli-reference.md#kit-push) your local image to the remote registry:
+Second, you will need to login, then [kit push](./cli/cli-reference.md#kit-push) your local image to the remote registry:
 
 ```sh
+kit login docker.io
 kit push docker.io/jozubrad/film-slm:champion
 ```
 

--- a/docs/src/docs/quick-start.md
+++ b/docs/src/docs/quick-start.md
@@ -29,36 +29,43 @@ You'll see information about the version of Kit you're running. If you get an er
 
 ### 2/ Login to Your Registry
 
-You can use the [login command](./cli/cli-reference.md#kit-login) to authenticate with any container registry, but we'll use **GitHub Registry** throughout this guide.
+You can use the [login command](./cli/cli-reference.md#kit-login) to authenticate with any OCI v1.1-compatible container registry. Here we'll pull ModelKits from [Jozu Hub](https://jozu.ml/discover), but we'll use **GitHub Registry** to push (the Jozu Hub only supports pull, although push is being worked on now).
 
 ```sh
 kit login ghcr.io
 ```
 
-You'll see `Log in successful`. If you get an error it may be that you need an HTTP vs HTTPS (default) connection. Try the login command again but with `--plain-http`.
+After entering your username and password, you'll see `Log in successful`. If you get an error it may be that you need an HTTP vs HTTPS (default) connection. Try the login command again but with `--plain-http`.
 
 ### 3/ Get a Sample ModelKit
 
 Let's use the [unpack command](./cli/cli-reference.md#kit-unpack) to pull a sample ModelKit to our machine that we can play with. In this case we'll unpack the whole thing, but one of the great things about Kit is that you can also selectively unpack only the artifacts you need: just the model, the model and dataset, the code, the configuration...whatever you want. Check out the `unpack` [command reference](./cli/cli-reference.md#kit-unpack) for details.
 
-You can grab <a href="https://github.com/orgs/jozu-ai/packages"
+You can grab <a href="https://jozu.ml/discover"
   v-ga-track="{
     category: 'link',
     label: 'grab any of the ModelKits',
     location: 'docs/quick-start'
-  }">any of the ModelKits</a> from our site, but we've chosen a small language model example below.
+  }">any of the ModelKits</a> from the Jozu Hub, but we've chosen a fine-tuned model based on Llama3.
 
 ```sh
-kit unpack ghcr.io/jozu-ai/modelkit-examples/finetuning_slm:latest
+kit unpack jozu.ml/jozu/fine-tuning:tuned
 ```
 
-You'll see a set of messages as Kit unpacked the configuration, code, datasets, and serialized model. Now list the directory contents:
+You'll see a set of messages as Kit unpacks the configuration, code, datasets, and serialized model. Now list the directory contents:
 
 ```sh
 ls
 ```
 
-You'll see a single file (`Kitfile`) which is the manifest for our ModelKit, and a set of files or directories including adapters, a Jupyter notebook, and dataset.
+You'll see:
+* A Llama3 model
+* A LoRA adapter
+* A training dataset
+* A README file
+* A Kitfile
+
+The [Kitfile](./kitfile/kf-overview.md) is the manifest for our ModelKit, the serialized model, and a set of files or directories including the adapter, dataset, and docs. Every ModelKit has a Kitfile and you can use the info and inspect commands to view them from the CLI (there's more on this in our [Next Steps](next-steps.md) doc).
 
 ### 4/ Check the Local Repository
 
@@ -92,7 +99,7 @@ The new entry will be named based on whatever you used in your pack command.
 
 ### 6/ (Optional) Remove a ModelKit from a Local Repository
 
-Let's pretend that the `pack` command we ran in the previous step contained a typo in the ModelKit's repository name causing the word 'model' to be entered as 'modle'.The output from the `kit list` command would display the ModelKit as:
+Let's pretend that the `pack` command we ran in the previous step contained a typo in the ModelKit's repository name causing the word "model" to be entered as "modle". The output from the `kit list` command would display the ModelKit as:
 
 ```sh
 ghcr.io/jozubrad/mymodlekit:latest
@@ -118,7 +125,12 @@ kit push ghcr.io/jozubrad/mymodelkit:latest
 
 If you're using Kit with LLMs you can quickly run the model locally to speed integration, testing, or experimentation.
 
-Create a new directory for your LLM:
+<!-- The syntax below makes an Info callout box in Vitpress at compile time -->
+::: info
+If you're not interested in running the ModelKit locally you can jump to the [Next Steps](next-steps.md) where you'll learn how to sign ModelKits, write your own Kitfiles, and maintain your repository.
+:::
+
+To run the ModelKit locally, first create a new directory for your LLM:
 
 ```sh
 mkdir devmode


### PR DESCRIPTION
**This should not be merged until after the Jozu Hub is launched**

Updated docs to simplify pulling ModelKits by grabbing them from Jozu Hub.

Since we can only pull from Jozu Hub, not push, I left things like `kit login` and `kit push` pointing to `ghcr.io`. Once Jozu Hub can accept pushes we'll swap those over so new and existing users can see the ModelKits with more metadata and detail in the Hub.