### PR TITLE
Add PR check step to verify all files in Vitepress @includes exist

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -80,6 +80,20 @@ jobs:
             exit 1
           fi
 
+      - name: Test Vitepress includes
+        shell: bash
+        run: |
+          grep -rnw '@include' --exclude-dir docs/node_modules docs | while read -r line; do
+            file="${line%%:*}"
+            include="${line##*@include: }"
+            include="${include%%-->}"
+            expected="$(dirname "$file")/$include"
+            if [ ! -f "$expected" ]; then
+              echo "Broken include in $file: path $expected does exist"
+              exit 1
+            fi
+          done
+
       - name: Check for trailing whitespace
         shell: bash
         run: |
@@ -89,6 +103,7 @@ jobs:
             echo "$files"
             exit 1
           fi
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:


### PR DESCRIPTION
### Description
Update PR check to attempt to check Vitepress @includes to avoid issues like https://github.com/jozu-ai/kitops/pull/409

With this step, PR check should fail with message
```
Broken include in docs/src/docs/kitfile/format.md: path docs/src/docs/kitfile/../../../../pkg/artifact/kit-file.md does refer to a file
```

### Linked issues
N/A