### PR TITLE
Show update notifications when a new version of kit is available

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,8 +75,6 @@ func RunCommand() *cobra.Command {
 				output.SetProgressBars("none")
 			}
 
-			update.CheckForUpdate()
-
 			configHome, err := getConfigHome(opts)
 			if err != nil {
 				output.Errorf("Failed to read base config directory")
@@ -86,6 +84,9 @@ func RunCommand() *cobra.Command {
 			}
 			ctx := context.WithValue(cmd.Context(), constants.ConfigKey{}, configHome)
 			cmd.SetContext(ctx)
+
+			update.CheckForUpdate(configHome)
+
 			// At this point, we've parsed the command tree and args; the CLI is being correctly
 			// so we don't want to print usage. Each subcommand should print its error message before
 			// returning

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"kitops/pkg/cmd/version"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/repo/local"
+	"kitops/pkg/lib/update"
 	"kitops/pkg/output"
 
 	"github.com/spf13/cobra"
@@ -73,6 +74,8 @@ func RunCommand() *cobra.Command {
 				output.SetLogLevel(output.LogLevelTrace)
 				output.SetProgressBars("none")
 			}
+
+			update.CheckForUpdate()
 
 			configHome, err := getConfigHome(opts)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	github.com/vbauerster/mpb/v8 v8.7.3
+	golang.org/x/mod v0.19.0
 	golang.org/x/sync v0.7.0
 	golang.org/x/sys v0.22.0
 	golang.org/x/term v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vbauerster/mpb/v8 v8.7.3 h1:n/mKPBav4FFWp5fH4U0lPpXfiOmCEgl5Yx/NM3tKJA0=
 github.com/vbauerster/mpb/v8 v8.7.3/go.mod h1:9nFlNpDGVoTmQ4QvNjSLtwLmAFjwmq0XaAF26toHGNM=
+golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
+golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -34,14 +34,15 @@ const (
 	IgnoreFileName = ".kitignore"
 
 	// Constants for the directory structure of kit's cached images and credentials
-	// Modelkits are stored in <configpath>/kitops/storage/ and
-	// credentials are stored in <configpath>/kitops/credentials.json
-	DefaultConfigSubdir = "kitops"
-	StorageSubpath      = "storage"
-	CredentialsSubpath  = "credentials.json"
-	HarnessSubpath      = "harness"
-	HarnessProcessFile  = "process.pid"
-	HarnessLogFile      = "harness.log"
+	// Modelkits are stored in $KITOPS_HOME/storage/ and
+	// credentials are stored in $KITOPS_HOME/credentials.json
+	DefaultConfigSubdir               = "kitops"
+	StorageSubpath                    = "storage"
+	CredentialsSubpath                = "credentials.json"
+	HarnessSubpath                    = "harness"
+	HarnessProcessFile                = "process.pid"
+	HarnessLogFile                    = "harness.log"
+	UpdateNotificationsConfigFilename = "disable-update-notifications"
 
 	// Kitops-specific annotations for modelkit artifacts
 	CliVersionAnnotation = "ml.kitops.modelkit.cli-version"

--- a/pkg/lib/update/update.go
+++ b/pkg/lib/update/update.go
@@ -1,0 +1,89 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"kitops/pkg/lib/constants"
+	"kitops/pkg/output"
+
+	"golang.org/x/mod/semver"
+)
+
+const releaseUrl = "https://api.github.com/repos/jozu-ai/kitops/releases/latest"
+
+// Regexp for a semver version -- taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+// We've added an optional 'v' to the start (e.g. v1.2.3) since using a 'v' prefix is common (and used, in our case)
+// Capture groups are:
+//
+//	[1] - Major version
+//	[2] - Minor version
+//	[3] - Bugfix/z-stream version
+//	[4] - Pre-release identifiers (1.2.3-<info>), if present
+//	[5] - Build metadata (1.2.3+<metadata>), if present
+var versionTagRegexp = regexp.MustCompile(`^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+type ghReleaseInfo struct {
+	TagName    string `json:"tag_name"`
+	Prerelease bool   `json:"prerelease"`
+	Draft      bool   `json:"draft"`
+	Url        string `json:"html_url"`
+}
+
+func CheckForUpdate() {
+	// If this isn't a release version of kit, don't nag the user unnecessarily
+	if constants.Version == "unknown" || !versionTagRegexp.MatchString(constants.Version) {
+		return
+	}
+
+	resp, err := http.Get(releaseUrl)
+	if err != nil {
+		output.Debugf("Failed to check for updates: %s", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		output.Debugf("Failed to read GitHub response body: %s", err)
+		return
+	}
+	info := &ghReleaseInfo{}
+	if err := json.Unmarshal(respBody, info); err != nil {
+		output.Debugf("Failed to parse GitHub response body: %s", err)
+		return
+	}
+	if info.Prerelease || info.Draft {
+		// This isn't a full release; for now just don't notify users, even if there is a newer full release we don't know about
+		return
+	}
+
+	// The Go semver package requires versions start with a 'v' (contrary to the spec)
+	currentVersion := fmt.Sprintf("v%s", strings.TrimPrefix(constants.Version, "v"))
+	latestVersion := fmt.Sprintf("v%s", strings.TrimPrefix(info.TagName, "v"))
+	if semver.Compare(currentVersion, latestVersion) < 0 {
+		output.Infof("Note: A new version of Kit is available! You are using Kit %s. The latest version is %s.", currentVersion, latestVersion)
+		output.Infof("      To see a list of changes, visit %s", info.Url)
+		output.Infof("") // Add a newline to not confuse it with regular output
+	}
+}

--- a/pkg/lib/update/update.go
+++ b/pkg/lib/update/update.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/output"
@@ -64,7 +65,10 @@ func CheckForUpdate(configHome string) {
 		return
 	}
 
-	resp, err := http.Get(releaseUrl)
+	client := &http.Client{
+		Timeout: 1 * time.Second,
+	}
+	resp, err := client.Get(releaseUrl)
 	if err != nil {
 		output.Debugf("Failed to check for updates: %s", err)
 		return


### PR DESCRIPTION
### Description
Show an update notification in the CLI if a newer version is available on GitHub:

```
Note: A new version of Kit is available! You are using Kit v0.2.2. The latest version is v0.3.0.
      To see a list of changes, visit https://github.com/jozu-ai/kitops/releases/tag/v0.3.0
      To disable this notification, use 'kit version --show-update-notifications=false'
```

Notifications can be disabled by running `kit version --show-update-notifications=false` (use `=true` to re-enable). 

Errors in checking for an update are delegated to debug-level logs and not shown to the user by default. 

To test this PR, you will need to build kit with at least `-ldflags="-s -w -X kitops/pkg/lib/constants.Version=${version}"`

Note: I had to put the enable/disable flag under the version subcommand, as trying to include it in the root command would either not run it or would break the default help text.

### Linked issues
Closes #365 
