### PR TITLE
Fix garbage collection for pulled modelkits

### DIFF
--- a/pkg/lib/repo/local/pull.go
+++ b/pkg/lib/repo/local/pull.go
@@ -93,6 +93,11 @@ func (l *localRepo) PullModel(ctx context.Context, src oras.ReadOnlyTarget, ref 
 	if err := l.localIndex.addManifest(desc); err != nil {
 		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to add manifest to index: %w", err)
 	}
+	// This is a workaround to add the manifest to the main index as well; this is necessary for garbage collection to work
+	if err := l.Store.Tag(ctx, desc, desc.Digest.String()); err != nil {
+		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to add manifest to shared index: %w", err)
+	}
+
 	if !util.ReferenceIsDigest(ref.Reference) {
 		if err := l.localIndex.tag(desc, ref.Reference); err != nil {
 			return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to save tag: %w", err)


### PR DESCRIPTION
### Description
When we pull a modelkit from a remote, we need to ensure its manifest descriptor is added to both the local index and the shared (non-scoped) index. Otherwise, garbage collection will fail -- `kit remove <modelkit>` will remove the manifest from the index and it won't appear in `kit list`, but the blobs referenced by the manifest will not be cleaned up there is no manifest to delete in the shared OCI index.

Calling delete on a non-existent manifest in the store will not trigger an error, so this issue was a little hard to notice.

### Linked issues
N/A
