### PR TITLE
Change the version template for releases

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -50,7 +50,7 @@ jobs:
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.0.0
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 #v6.0.0
         with:
           version: latest
           distribution: goreleaser
@@ -92,7 +92,7 @@ jobs:
             go-version-file: 'go.mod'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.0.0
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 #v6.0.0
         with:
           version: latest
           distribution: goreleaser
@@ -120,7 +120,7 @@ jobs:
             go-version-file: 'go.mod'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.0.0
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 #v6.0.0
         with:
           version: latest
           distribution: goreleaser

--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 
 project_name: kitops
 
@@ -36,7 +36,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    rlcp: true
     files:
       - LICENSE
       - README.md
@@ -46,5 +45,5 @@ git:
     - "next"
 
 snapshot:
-  name_template: "{{ .Version }}-{{ .ShortCommit }}"
+  name_template: "{{ .Version }}"
 

--- a/.goreleaser.linux.yaml
+++ b/.goreleaser.linux.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 
 project_name: kitops
 
@@ -28,7 +28,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    rlcp: true
     files:
       - LICENSE
       - README.md
@@ -38,4 +37,4 @@ git:
     - "next"
 
 snapshot:
-  name_template: "{{ .Version }}-{{ .ShortCommit }}"
+  name_template: "{{ .Version }}"

--- a/.goreleaser.windows.yaml
+++ b/.goreleaser.windows.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 
 project_name: kitops
 
@@ -28,10 +28,9 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    rlcp: true
     files:
       - LICENSE
       - README.md
 
 snapshot:
-  name_template: "{{ .Version }}-{{ .ShortCommit }}"
+  name_template: "{{ .Version }}"


### PR DESCRIPTION
Removes the commit hash from version string. Upgrades goreleaser to v2

fixes #432 