### PR TITLE
Enable unpack to filter for specific layers instead of all layers of a type

### DIFF
--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -41,13 +41,24 @@ filesystem. By default, it attempts to find the modelkit in local storage; if
 not found, it searches the remote registry and retrieves it. This process
 ensures that the necessary components are always available for unpacking,
 optimizing for efficiency by fetching only specified components from the
-remote registry when necessary`
+remote registry when necessary.
+
+The content that is unpacked can be limited via the --filter (-f) flag. For example,
+use
+    --filter=model
+to unpack only the model, or 
+    --filter=datasets:my-dataset
+to unpack only the dataset named 'my-dataset'. Filtering for specific code/datasets/docs
+will match on either name or the path of the field.`
 
 	example = `# Unpack all components of a modelkit to the current directory
 kit unpack myrepo/my-model:latest -d /path/to/unpacked
 
 # Unpack only the model and datasets of a modelkit to a specified directory
-kit unpack myrepo/my-model:latest --model --datasets -d /path/to/unpacked
+kit unpack myrepo/my-model:latest --filter=model,datasets -d /path/to/unpacked
+
+# Unpack only the dataset named "my-dataset" to the current directory
+kit unpack myrepo/my-model:latest --filter=datasets:my-dataset
 
 # Unpack a modelkit from a remote registry with overwrite enabled
 kit unpack registry.example.com/myrepo/my-model:latest -o -d /path/to/unpacked`
@@ -55,13 +66,17 @@ kit unpack registry.example.com/myrepo/my-model:latest -o -d /path/to/unpacked`
 
 type unpackOptions struct {
 	options.NetworkOptions
-	configHome string
-	unpackDir  string
-	unpackConf unpackConf
-	modelRef   *registry.Reference
-	overwrite  bool
+	configHome  string
+	unpackDir   string
+	filters     []string
+	filterConfs []filterConf
+	unpackConf  unpackConf
+	modelRef    *registry.Reference
+	overwrite   bool
 }
 
+// unpackConf configures which elements of the modelkit should be unpacked.
+// Deprecated: use filterConf instead, which supports advanced filtering
 type unpackConf struct {
 	unpackKitfile  bool
 	unpackModels   bool
@@ -85,13 +100,20 @@ func (opts *unpackOptions) complete(ctx context.Context, args []string) error {
 	}
 	opts.modelRef = modelRef
 
-	conf := opts.unpackConf
-	if !conf.unpackKitfile && !conf.unpackModels && !conf.unpackCode && !conf.unpackDatasets {
-		opts.unpackConf.unpackKitfile = true
-		opts.unpackConf.unpackModels = true
-		opts.unpackConf.unpackCode = true
-		opts.unpackConf.unpackDatasets = true
-		opts.unpackConf.unpackDocs = true
+	if len(opts.filters) > 0 {
+		for _, filter := range opts.filters {
+			filterConf, err := parseFilter(filter)
+			if err != nil {
+				return err
+			}
+			opts.filterConfs = append(opts.filterConfs, *filterConf)
+		}
+	} else {
+		// Deprecated, but handle original filtering flags as well for now
+		conf := opts.unpackConf
+		if conf.unpackKitfile || conf.unpackModels || conf.unpackCode || conf.unpackDatasets || conf.unpackDocs {
+			opts.filterConfs = filtersFromUnpackConf(conf)
+		}
 	}
 
 	absDir, err := filepath.Abs(opts.unpackDir)
@@ -122,11 +144,12 @@ func UnpackCommand() *cobra.Command {
 	cmd.Args = cobra.ExactArgs(1)
 	cmd.Flags().StringVarP(&opts.unpackDir, "dir", "d", "", "The target directory to unpack components into. This directory will be created if it does not exist")
 	cmd.Flags().BoolVarP(&opts.overwrite, "overwrite", "o", false, "Overwrites existing files and directories in the target unpack directory without prompting")
-	cmd.Flags().BoolVar(&opts.unpackConf.unpackKitfile, "kitfile", false, "Unpack only Kitfile")
-	cmd.Flags().BoolVar(&opts.unpackConf.unpackModels, "model", false, "Unpack only model")
-	cmd.Flags().BoolVar(&opts.unpackConf.unpackCode, "code", false, "Unpack only code")
-	cmd.Flags().BoolVar(&opts.unpackConf.unpackDatasets, "datasets", false, "Unpack only datasets")
-	cmd.Flags().BoolVar(&opts.unpackConf.unpackDocs, "docs", false, "Unpack only docs")
+	cmd.Flags().StringArrayVarP(&opts.filters, "filter", "f", []string{}, "Filter what is unpacked from the modelkit based on type and name. Can be specified multiple times")
+	cmd.Flags().BoolVar(&opts.unpackConf.unpackKitfile, "kitfile", false, "Unpack only Kitfile (deprecated: use --filter=kitfile)")
+	cmd.Flags().BoolVar(&opts.unpackConf.unpackModels, "model", false, "Unpack only model (deprecated: use --filter=model)")
+	cmd.Flags().BoolVar(&opts.unpackConf.unpackCode, "code", false, "Unpack only code (deprecated: use --filter=code)")
+	cmd.Flags().BoolVar(&opts.unpackConf.unpackDatasets, "datasets", false, "Unpack only datasets (deprecated: use --filter=datasets)")
+	cmd.Flags().BoolVar(&opts.unpackConf.unpackDocs, "docs", false, "Unpack only docs (deprecated: use --filter=docs)")
 	opts.AddNetworkFlags(cmd)
 	cmd.Flags().SortFlags = false
 

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -46,10 +46,20 @@ remote registry when necessary.
 The content that is unpacked can be limited via the --filter (-f) flag. For example,
 use
     --filter=model
-to unpack only the model, or 
+to unpack only the model, or
     --filter=datasets:my-dataset
-to unpack only the dataset named 'my-dataset'. Filtering for specific code/datasets/docs
-will match on either name or the path of the field.`
+to unpack only the dataset named 'my-dataset'.
+
+Valid filters have the format
+    <types>:<filters>
+where <types> is a comma-separated list of Kitfile fields (kitfile, model, datasets
+code, or docs) and <filters> is an optional comma-separated list of additional filters
+to apply, which are matched against the Kitfile to further restrict what is extracted.
+Additional filters match elements of the Kitfile on either the name (if present) or
+the path used.
+
+The filter field can be specified multiple times. A layer will be unpacked if it matches
+any of the specified filters`
 
 	example = `# Unpack all components of a modelkit to the current directory
 kit unpack myrepo/my-model:latest -d /path/to/unpacked
@@ -59,6 +69,12 @@ kit unpack myrepo/my-model:latest --filter=model,datasets -d /path/to/unpacked
 
 # Unpack only the dataset named "my-dataset" to the current directory
 kit unpack myrepo/my-model:latest --filter=datasets:my-dataset
+
+# Unpack only the docs layer with path "./README.md" to the current directory
+kit unpack myrepo/my-model:latest --filter=docs:./README.md
+
+# Unpack the model and the dataset named "validation"
+kit unpack myrepo/my-model:latest --filter=model --filter=datasets:validation
 
 # Unpack a modelkit from a remote registry with overwrite enabled
 kit unpack registry.example.com/myrepo/my-model:latest -o -d /path/to/unpacked`

--- a/pkg/cmd/unpack/filter.go
+++ b/pkg/cmd/unpack/filter.go
@@ -1,0 +1,173 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package unpack
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"kitops/pkg/artifact"
+	"kitops/pkg/lib/constants"
+)
+
+type filterConf struct {
+	baseTypes []string
+	filters   []string
+}
+
+func (fc *filterConf) matches(baseType, field string) bool {
+	return fc.matchesBaseType(baseType) && fc.matchesField(field)
+}
+
+func (fc *filterConf) matchesBaseType(baseType string) bool {
+	for _, t := range fc.baseTypes {
+		if t == baseType {
+			return true
+		}
+	}
+	return false
+}
+
+func (fc *filterConf) matchesField(field string) bool {
+	if len(fc.filters) == 0 {
+		// By default everything matches
+		return true
+	}
+	for _, filter := range fc.filters {
+		if filter == field {
+			return true
+		}
+	}
+	return false
+}
+
+func parseFilter(filter string) (*filterConf, error) {
+	typesAndIds := strings.Split(filter, ":")
+
+	if len(typesAndIds) > 2 {
+		return nil, fmt.Errorf("invalid filter: should be in format <type1>,<type2>[:<filter1>,<filter2>]")
+	}
+
+	conf := &filterConf{}
+
+	for _, filterType := range strings.Split(typesAndIds[0], ",") {
+		baseType, err := filterToMediaBaseType(filterType)
+		if err != nil {
+			return nil, err
+		}
+		conf.baseTypes = append(conf.baseTypes, baseType)
+	}
+
+	// Check for additional filtering based on name/path
+	if len(typesAndIds) == 1 {
+		return conf, nil
+	}
+
+	filters := strings.Split(typesAndIds[1], ",")
+	conf.filters = filters
+	return conf, nil
+}
+
+// shouldUnpackLayer determines if we should unpack a layer in a Kitfile by matching
+// fields against the filters. Matching is done against path and name (if present).
+// If filters is empty, we assume everything should be unpacked
+func shouldUnpackLayer(layer any, filters []filterConf) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	// The type switch below checks for concrete (non-pointer) types. We need to use
+	// reflect to dereference the pointer and get a new interface{} (any) type.
+	if val := reflect.ValueOf(layer); val.Kind() == reflect.Ptr {
+		layer = val.Elem().Interface()
+	}
+
+	switch l := layer.(type) {
+	case artifact.KitFile:
+		for _, filter := range filters {
+			for _, baseType := range filter.baseTypes {
+				if baseType == constants.ConfigType {
+					return true
+				}
+			}
+		}
+		return false
+	case artifact.Model:
+		return matchesFilters(l.Name, constants.ModelType, filters) || matchesFilters(l.Path, constants.ModelType, filters)
+	case artifact.ModelPart:
+		return matchesFilters(l.Name, constants.ModelPartType, filters) || matchesFilters(l.Path, constants.ModelPartType, filters)
+	case artifact.Docs:
+		// Docs does not have an ID/name field so we can only match on path
+		return matchesFilters(l.Path, constants.DocsType, filters)
+	case artifact.DataSet:
+		return matchesFilters(l.Name, constants.DatasetType, filters) || matchesFilters(l.Path, constants.DatasetType, filters)
+	case artifact.Code:
+		// Code does not have a ID/name field so we can only match on path
+		return matchesFilters(l.Path, constants.CodeType, filters)
+	default:
+		return false
+	}
+}
+
+func matchesFilters(field string, baseType string, filterConfs []filterConf) bool {
+	// Treat modelparts as covered by the 'model' filter
+	if baseType == constants.ModelPartType {
+		baseType = constants.ModelType
+	}
+	for _, filterConf := range filterConfs {
+		if filterConf.matches(baseType, field) {
+			return true
+		}
+	}
+	return false
+}
+
+// filtersFromUnpackConf converts a (deprecated) unpackConf to a set of filters to enable supporting the old flags
+func filtersFromUnpackConf(conf unpackConf) []filterConf {
+	filter := filterConf{}
+
+	if conf.unpackKitfile {
+		filter.baseTypes = append(filter.baseTypes, constants.ConfigType)
+	}
+	if conf.unpackModels {
+		filter.baseTypes = append(filter.baseTypes, constants.ModelType)
+	}
+	if conf.unpackDocs {
+		filter.baseTypes = append(filter.baseTypes, constants.DocsType)
+	}
+	if conf.unpackDatasets {
+		filter.baseTypes = append(filter.baseTypes, constants.DatasetType)
+	}
+	if conf.unpackCode {
+		filter.baseTypes = append(filter.baseTypes, constants.CodeType)
+	}
+	return []filterConf{filter}
+}
+
+func filterToMediaBaseType(filterType string) (string, error) {
+	switch filterType {
+	case "kitfile":
+		return constants.ConfigType, nil
+	case "datasets":
+		// annoyingly, the mediatype is dataset, but for the filter we want the plural
+		return constants.DatasetType, nil
+	case constants.ModelType, constants.CodeType, constants.DocsType:
+		return filterType, nil
+	default:
+		return "", fmt.Errorf("invalid filter type %s (must be one of 'kitfile', 'model', 'datasets', 'code', or 'docs')", filterType)
+	}
+}

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -170,9 +170,12 @@ func unpackParent(ctx context.Context, ref string, optsIn *unpackOptions, visite
 	opts := *optsIn
 	opts.modelRef = parentRef
 	// Unpack only model, ignore code/datasets
-	opts.unpackConf.unpackKitfile = false
-	opts.unpackConf.unpackCode = false
-	opts.unpackConf.unpackDatasets = false
+	modelFilter, err := parseFilter("model")
+	if err != nil {
+		// Shouldn't happen, ever
+		return fmt.Errorf("failed to parse filter for parent modelkit: %w", err)
+	}
+	opts.filterConfs = []filterConf{*modelFilter}
 
 	return runUnpackRecursive(ctx, &opts, append(visitedRefs, ref))
 }

--- a/pkg/lib/constants/mediaType.go
+++ b/pkg/lib/constants/mediaType.go
@@ -88,7 +88,7 @@ func IsValidCompression(compression string) error {
 	case NoneCompression, GzipCompression, GzipFastestCompression:
 		return nil
 	default:
-		return fmt.Errorf("Invalid option for --compression flag: must be one of 'none', 'gzip', or 'gzip-fastest'")
+		return fmt.Errorf("invalid compression type: must be one of 'none', 'gzip', or 'gzip-fastest'")
 	}
 }
 


### PR DESCRIPTION
### Description
This PR adds a flag `--filter` (`-f` for short) that can be used to filter which parts of a Kitfile are unpacked in a `kit unpack` operation. In general, the flag takes the format 
```
<types>:<filters>
```
where `<types>` is a comma-separate list of sections in the kitfile to unpack (e.g. `model,datasets,kitfile`), and `<filters>` is an optional comma-separated list of filters to apply to those types. To unpack only models and datasets, you would use the command
```
kit unpack <model> --filter=model,datasets
```
To unpack only the `training-data` dataset, you would use
```
kit unpack <model> --filter=datasets:training-data
```

Matching for `<filters>` is done based on name (e.g. dataset/modelpart name) or on path (since not all fields have an ID and names are optional). Currently, matching on paths is exact and not anything fancy.

The old flags (`--model`, `--datasets`, etc.) are still present for compatibility and marked as deprecated (for removal in a few releases). They currently are converted to basic filters to work within the new system.

### Linked issues
Closes https://github.com/jozu-ai/kitops/issues/391
