### PR TITLE
Enable building containerized Kit CLI and init container

### DIFF
--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+    paths-ignore: docs/
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -1,0 +1,61 @@
+name: Next CLI container build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  INIT_IMAGE_NAME: ${{ github.repository }}-init
+  NEXT_TAG: next
+
+permissions:
+  packages: write
+
+jobs:
+  docker-image-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf    # v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db  # v3.6.1
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567         # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Build and push base Kit container
+        id: build-kit-container
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85    # v6.7.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          context: .
+          file: build/dockerfiles/Dockerfile
+          build-args: |
+            KIT_VERSION=${{ github.ref_name }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.NEXT_TAG }}
+
+      - name: Build and push Kit init container
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85    # v6.7.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          context: build/dockerfiles/init
+          file: build/dockerfiles/init/Dockerfile
+          build-args: |
+            KIT_BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-kit-container.outputs.digest }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}:${{ env.NEXT_TAG }}

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -13,6 +13,9 @@ env:
   NEXT_TAG: next
 
 permissions:
+  id-token: write
+  contents: read
+  attestations: write
   packages: write
 
 jobs:
@@ -49,6 +52,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.NEXT_TAG }}
 
       - name: Build and push Kit init container
+        id: build-kit-init-container
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85    # v6.7.0
         with:
           platforms: linux/amd64,linux/arm64
@@ -59,3 +63,17 @@ jobs:
             KIT_BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-kit-container.outputs.digest }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}:${{ env.NEXT_TAG }}
+
+      # - name: Generate artifact attestation for base container
+      #   uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1   # v1.4.2
+      #   with:
+      #     subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      #     subject-digest: ${{ steps.build-kit-container.outputs.digest }}
+      #     push-to-registry: true
+
+      # - name: Generate artifact attestation for base container
+      #   uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1   # v1.4.2
+      #   with:
+      #     subject-name: ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}
+      #     subject-digest: ${{ steps.build-kit-init-container.outputs.digest }}
+      #     push-to-registry: true

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -50,6 +50,10 @@ jobs:
             KIT_VERSION=${{ github.ref_name }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.NEXT_TAG }}
+          annotations: |
+            index:org.opencontainers.image.description=Kit CLI container built from source
+            index:org.opencontainers.image.source=https://github.com/jozu-ai/kitops
+            index:org.opencontainers.image.licenses=Apache-2.0
 
       - name: Build and push Kit init container
         id: build-kit-init-container
@@ -63,6 +67,10 @@ jobs:
             KIT_BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-kit-container.outputs.digest }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}:${{ env.NEXT_TAG }}
+          annotations: |
+            index:org.opencontainers.image.description=Kit CLI init container
+            index:org.opencontainers.image.source=https://github.com/jozu-ai/kitops
+            index:org.opencontainers.image.licenses=Apache-2.0
 
       # - name: Generate artifact attestation for base container
       #   uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1   # v1.4.2

--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -25,6 +25,8 @@ permissions:
   contents: write
   pull-requests: write
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-macos:
@@ -254,6 +256,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
 
       - name: Build and push Kit init container
+        id: build-kit-init-container
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85    # v6.7.0
         with:
           platforms: linux/amd64,linux/arm64
@@ -265,3 +268,17 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}:${{ github.ref_name }}
+
+      - name: Generate artifact attestation for base container
+        uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1   # v1.4.2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-kit-container.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for base container
+        uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1   # v1.4.2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}
+          subject-digest: ${{ steps.build-kit-init-container.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -16,9 +16,16 @@ on:
     tags:
       - 'v*'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  INIT_IMAGE_NAME: ${{ github.repository }}-init
+
 permissions:
   contents: write
   pull-requests: write
+  packages: write
+
 jobs:
   build-macos:
     runs-on: macos-latest
@@ -127,6 +134,7 @@ jobs:
           args: release --clean --snapshot --config ./.goreleaser.linux.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # v4.3.6
         with:
@@ -135,6 +143,7 @@ jobs:
             retention-days: 7
             path: |
               ./dist/*.tar.gz
+
   # Creates a release with the artifacts from the previous steps.
   # workflow_dispatch triggered versions will be draft releases.
   # CLI docs are not updated for workflow_dispatch triggered versions.
@@ -209,3 +218,50 @@ jobs:
           git push origin "${PR_BRANCH}"
           gh pr create --fill --base main --head "${PR_BRANCH}"
           git checkout "${CURRENT_BRANCH}"
+
+
+  docker-image-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf    # v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db  # v3.6.1
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567         # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Build and push base Kit container
+        id: build-kit-container
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85    # v6.7.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          context: build/dockerfiles
+          file: build/dockerfiles/release.Dockerfile
+          build-args: |
+            KIT_VERSION=${{ github.ref_name }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+
+      - name: Build and push Kit init container
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85    # v6.7.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          context: build/dockerfiles/init
+          file: build/dockerfiles/init/Dockerfile
+          build-args: |
+            KIT_BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-kit-container.outputs.digest }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}:${{ github.ref_name }}

--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -254,6 +254,10 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          annotations: |
+            index:org.opencontainers.image.description=Official release Kit CLI container
+            index:org.opencontainers.image.source=https://github.com/jozu-ai/kitops
+            index:org.opencontainers.image.licenses=Apache-2.0
 
       - name: Build and push Kit init container
         id: build-kit-init-container
@@ -268,6 +272,10 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.INIT_IMAGE_NAME }}:${{ github.ref_name }}
+          annotations: |
+            index:org.opencontainers.image.description=Kit CLI init container
+            index:org.opencontainers.image.source=https://github.com/jozu-ai/kitops
+            index:org.opencontainers.image.licenses=Apache-2.0
 
       - name: Generate artifact attestation for base container
         uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1   # v1.4.2

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/golang:alpine AS builder
 
 RUN apk --no-cache upgrade && apk add --no-cache git
-ARG version=next
+ARG KIT_VERSION=next
 
 WORKDIR /build
 
@@ -13,7 +13,7 @@ COPY . .
 RUN \
     CGO_ENABLED=0 go build \
     -o kit \
-    -ldflags="-s -w -X kitops/pkg/lib/constants.Version=${version} -X kitops/pkg/lib/constants.GitCommit=$(git rev-parse --short HEAD) -X kitops/pkg/lib/constants.BuildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    -ldflags="-s -w -X kitops/pkg/lib/constants.Version=${KIT_VERSION} -X kitops/pkg/lib/constants.GitCommit=$(git rev-parse --short HEAD) -X kitops/pkg/lib/constants.BuildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
 FROM docker.io/library/alpine
 ENV USER_ID=1001 \

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -30,3 +30,7 @@ USER ${USER_ID}
 COPY --from=builder /build/kit /usr/local/bin/kit
 
 ENTRYPOINT ["kit"]
+
+LABEL org.opencontainers.image.description="Kit CLI container built from source"
+LABEL org.opencontainers.image.source="https://github.com/jozu-ai/kitops"
+LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -2,7 +2,6 @@ FROM docker.io/library/golang:alpine AS builder
 
 RUN apk --no-cache upgrade && apk add --no-cache git
 ARG version=next
-ARG gitCommit=<unknown>
 
 WORKDIR /build
 
@@ -14,7 +13,7 @@ COPY . .
 RUN \
     CGO_ENABLED=0 go build \
     -o kit \
-    -ldflags="-s -w -X kitops/pkg/lib/constants.Version=${version} -X kitops/pkg/lib/constants.GitCommit=$gitCommit -X kitops/pkg/lib/constants.BuildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    -ldflags="-s -w -X kitops/pkg/lib/constants.Version=${version} -X kitops/pkg/lib/constants.GitCommit=$(git rev-parse --short HEAD) -X kitops/pkg/lib/constants.BuildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
 FROM docker.io/library/alpine
 ENV USER_ID=1001 \
@@ -29,6 +28,5 @@ RUN apk --no-cache upgrade && \
 USER ${USER_ID}
 
 COPY --from=builder /build/kit /usr/local/bin/kit
-COPY build/dockerfiles/KServe/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["kit"]

--- a/build/dockerfiles/KServe/Dockerfile
+++ b/build/dockerfiles/KServe/Dockerfile
@@ -4,3 +4,7 @@ FROM $KIT_BASE_IMAGE
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+LABEL org.opencontainers.image.description="KitOps KServe container"
+LABEL org.opencontainers.image.source="https://github.com/jozu-ai/kitops"
+LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/build/dockerfiles/KServe/Dockerfile
+++ b/build/dockerfiles/KServe/Dockerfile
@@ -1,0 +1,6 @@
+ARG KIT_BASE_IMAGE=ghcr.io/jozu-ai/kit:next
+FROM $KIT_BASE_IMAGE
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/dockerfiles/KServe/README.md
+++ b/build/dockerfiles/KServe/README.md
@@ -3,13 +3,15 @@
 The Dockerfile in this directory is used to build an image that can run as a ClusterStorageContainer for [KServe](https://kserve.github.io/website/master/).
 
 ## Building
-To build the image, `docker` is required. From the root of this repository, set the `$KIT_KSERVE_IMAGE` to the image tag you want to build and run
+To build the image, `docker` or `podman` is required. From the root of this repository, set the `$KIT_KSERVE_IMAGE` to the image tag you want to build and run
 ```bash
-docker build . \
-  -f build/dockerfiles/KServe/kserve.Dockerfile \
-  -t $KIT_KSERVE_IMAGE \
-  --build-arg version="next" \
-  --build-arg gitCommit=$(git rev-parse HEAD)
+docker build -t $KIT_KSERVE_IMAGE .
+```
+
+By default, the image will be built using `ghcr.io/jozu-ai/kit:next` as a base. This can be overridden (to build using a specific version of Kit, for example) by using the build arg `KIT_BASE_IMAGE`:
+```shell
+# Build the image based on Kit v0.3.2 instead of 'next'
+docker build -t kit-init-container:latest --build-arg KIT_BASE_IMAGE=ghcr.io/jozu-ai/kit:v0.3.2 .
 ```
 
 ## Installing

--- a/build/dockerfiles/README.md
+++ b/build/dockerfiles/README.md
@@ -1,0 +1,11 @@
+# Containerized Kit CLI
+
+The Dockerfile in this directory can be used for building a containerized version of the Kit CLI. To build this image manually, run the following command from the root of this repository:
+```bash
+docker build -t kit-cli:latest -f build/dockerfiles/Dockerfile .
+```
+
+The default entrypoint for this image is invoking the `kit` CLI, allowing for quickly running Kit commands without needing to install the CLI:
+```
+docker run --rm ghcr.io/jozu-ai/kit:latest version
+```

--- a/build/dockerfiles/README.md
+++ b/build/dockerfiles/README.md
@@ -1,11 +1,26 @@
 # Containerized Kit CLI
 
-The Dockerfile in this directory can be used for building a containerized version of the Kit CLI. To build this image manually, run the following command from the root of this repository:
-```bash
-docker build -t kit-cli:latest -f build/dockerfiles/Dockerfile .
-```
-
-The default entrypoint for this image is invoking the `kit` CLI, allowing for quickly running Kit commands without needing to install the CLI:
+The Dockerfiles in this directory can be used for building a containerized version of the Kit CLI. The default entrypoint
+for these image is invoking the `kit` CLI, allowing for quickly running Kit commands without needing to install the CLI:
 ```
 docker run --rm ghcr.io/jozu-ai/kit:latest version
 ```
+
+## Release build
+The dockerfile named `release.Dockerfile` will build a container that includes a specified release of the Kit CLI, downloaded
+from GitHub releases. To build this container to include Kit version `vX.Y.Z`, use the following command
+```bash
+docker build -t kit-cli:my-tag -f build/dockerfiles/release.Dockerfile --build-arg KIT_VERSION=vX.Y.Z .
+```
+Note, the `KIT_VERSION` build arg is required.
+
+
+## Offline build
+The dockerfile named `Dockerfile` will build a container by compiling the Kit CLI from local sources. To build this image
+manually, run the following command from the root of this repository:
+
+```bash
+docker build -t kit-cli:next -f build/dockerfiles/Dockerfile .
+```
+By default, this container will set the Kit CLI version inside the container to `next`. To override this, you can specify
+the build arg `KIT_VERSION`.

--- a/build/dockerfiles/init/Dockerfile
+++ b/build/dockerfiles/init/Dockerfile
@@ -1,6 +1,11 @@
+# Multi-platform digest for Cosign v2.4.0
+ARG COSIGN_DIGEST=sha256:9d50ceb15f023eda8f58032849eedc0216236d2e2f4cfe1cdf97c00ae7798cfe
 ARG KIT_BASE_IMAGE=ghcr.io/jozu-ai/kit:next
+
+FROM gcr.io/projectsigstore/cosign@$COSIGN_DIGEST AS cosign-install
 FROM $KIT_BASE_IMAGE
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --from=cosign-install /ko-app/cosign /usr/local/bin/cosign
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/dockerfiles/init/Dockerfile
+++ b/build/dockerfiles/init/Dockerfile
@@ -9,3 +9,7 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --from=cosign-install /ko-app/cosign /usr/local/bin/cosign
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+LABEL org.opencontainers.image.description="Kit CLI init container"
+LABEL org.opencontainers.image.source="https://github.com/jozu-ai/kitops"
+LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/build/dockerfiles/init/Dockerfile
+++ b/build/dockerfiles/init/Dockerfile
@@ -1,0 +1,6 @@
+ARG KIT_BASE_IMAGE=ghcr.io/jozu-ai/kit:next
+FROM $KIT_BASE_IMAGE
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/dockerfiles/init/README.md
+++ b/build/dockerfiles/init/README.md
@@ -1,0 +1,74 @@
+# Kit CLI init container
+This image is designed to be used as an init container on platforms such as Kubernetes and supports
+
+* Unpacking a ModelKit to a specific path within the container
+* Verifying a ModelKit's signature before unpacking via cosign
+
+This image is configured through setting environment variables:
+
+* The environment variable `$MODELKIT_REF` is required and should contain the name of the modelkit to unpack
+* Environment variables `$UNPACK_PATH` and `$UNPACK_FILTER` are optional configure how the ModelKit is unpacked:
+  * `$UNPACK_PATH` can be used to unpack the ModelKit to a specific directory within the container (default is `/home/user/modelkit`)
+  * `$UNPACK_FILTER` can be used to configure which parts of the modelkit are unpacked (the default is to unpack only the model)
+
+  For the expected format for these environment variables matches the usage of the `--dir` and `--filter` flags on `kit unpack`, respectively.
+
+In addition, this image can be used to verify the signature on a ModelKit in a registry:
+
+* To verify a ModelKit via a key, set the `$COSIGN_KEY` environment variable:
+  * The value of `$COSIGN_KEY` can be a path to a key mounted inside the container, a URL to the key, or a KMS URI
+* To verify the ModelKit using cosign's keyless verification, set the `$COSIGN_CERT_IDENTITY` and `$COSIGN_CERT_OIDC_ISSUER` environment variables:
+  * `$COSIGN_CERT_IDENTITY` should contain the identity of the expected signer within the OIDC issuer
+  * `$COSIGN_CERT_OIDC_ISSUER` should contain the URL to the expected OIDC issuer used to sign the modelkit (e.g. `https://github.com/login/oauth`)
+
+  For additional documentation how verifying ModelKit signatures works, see the [`cosign` documentation](https://docs.sigstore.dev/verifying/verify/)
+
+## Example
+
+Below is a minimal example of using this image to download a modelkit named `ghcr.io/jozu-ai/my-modelkit:latest` to a container
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-modelkit-pod
+spec:
+  initContainers:
+  - name: kitops-init
+    image: ghcr.io/jozu-ai/kitops-init-container:latest
+    env:
+      - name: MODELKIT_REF
+        value: "ghcr.io/jozu-ai/my-modelkit:latest"
+      - name: UNPACK_PATH
+        value: /tmp/my-modelkit
+      - name: COSIGN_CERT_IDENTITY
+        value: kitops@jozu.com
+      - name: COSIGN_CERT_OIDC_ISSUER
+        value: https://github.com/login/oauth
+    volumeMounts:
+      - name: modelkit-storage
+        mountPath: /tmp/my-modelkit
+  containers:
+  - name: main-container
+    image: alpine:latest
+    volumeMounts:
+      - name: modelkit-storage
+        mountPath: /my-modelkit
+    command: ["tail"]
+    args: ["-f", "/dev/null"]
+  volumes:
+  - name: modelkit-storage
+    emptyDir: {}
+```
+
+## Building the image
+Building the image requires docker or podman. To build the image, run the following command in this directory:
+```shell
+docker build -t kit-init-container:latest .
+```
+
+By default, the image will be built using `ghcr.io/jozu-ai/kit:next` as a base. This can be overridden (to build using a specific version of Kit, for example) by using the build arg `KIT_BASE_IMAGE`:
+```shell
+# Build the image based on Kit v0.3.2 instead of 'next'
+docker build -t kit-init-container:latest --build-arg KIT_BASE_IMAGE=ghcr.io/jozu-ai/kit:v0.3.2 .
+```

--- a/build/dockerfiles/init/entrypoint.sh
+++ b/build/dockerfiles/init/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+UNPACK_PATH=${UNPACK_PATH:-/home/user/modelkit/}
+UNPACK_FILTER=${UNPACK_FILTER:-model}
+if [ -z "$MODELKIT_REF" ]; then
+  echo "Environment variable \$MODELKIT_REF is required"
+  exit 1
+fi
+
+echo "Binary version info:"
+kit version
+
+echo "Unpacking modelkit $MODELKIT_REF to $UNPACK_PATH with filter $UNPACK_FILTER"
+kit unpack "$MODELKIT_REF" --dir "$UNPACK_PATH" --filter="$UNPACK_FILTER"

--- a/build/dockerfiles/init/entrypoint.sh
+++ b/build/dockerfiles/init/entrypoint.sh
@@ -2,11 +2,30 @@
 
 set -e
 
+# Kit configuration via env vars:
+#   - UNPACK_PATH   : Where to unpack the modelkit (default: /home/user/modelkit)
+#   - UNPACK_FILTER : What to unpack from the modelkit (default: model)
+#   - MODELKIT_REF  : The modelkit to unpack -- required!
 UNPACK_PATH=${UNPACK_PATH:-/home/user/modelkit/}
 UNPACK_FILTER=${UNPACK_FILTER:-model}
 if [ -z "$MODELKIT_REF" ]; then
   echo "Environment variable \$MODELKIT_REF is required"
   exit 1
+fi
+
+# Variables for verifying signature via cosign. Can specify either a key to use for
+# verifying or an identity and oidc issuer for keyless verification
+if [ -n "$COSIGN_KEY" ]; then
+  echo "Verifying signature for modelkit $MODELKIT_REF via key"
+  cosign verify --key "$COSIGN_KEY" "$MODELKIT_REF"
+elif [ -n "$COSIGN_CERT_IDENTITY" ] && [ -n "$COSIGN_CERT_OIDC_ISSUER" ]; then
+  echo "Verifying signature for modelkit $MODELKIT_REF"
+  cosign verify \
+    --certificate-identity=${COSIGN_CERT_IDENTITY} \
+    --certificate-oidc-issuer=${COSIGN_CERT_OIDC_ISSUER} \
+    "$MODELKIT_REF"
+else
+  echo "Signature verification is disabled"
 fi
 
 echo "Binary version info:"

--- a/build/dockerfiles/release.Dockerfile
+++ b/build/dockerfiles/release.Dockerfile
@@ -44,3 +44,7 @@ COPY --from=kit-download /kit-cli-download/extracted/README.md /kit-cli-download
 USER ${USER_ID}
 
 ENTRYPOINT ["kit"]
+
+LABEL org.opencontainers.image.description="Official release Kit CLI container"
+LABEL org.opencontainers.image.source="https://github.com/jozu-ai/kitops"
+LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/build/dockerfiles/release.Dockerfile
+++ b/build/dockerfiles/release.Dockerfile
@@ -1,0 +1,46 @@
+FROM docker.io/library/alpine AS kit-download
+ARG KIT_VERSION
+
+RUN apk --no-cache upgrade && \
+    apk add --no-cache bash curl
+
+WORKDIR /kit-cli-download
+
+RUN <<EOF
+  set -e
+
+  [ -n "$KIT_VERSION" ] || { echo "Build arg 'KIT_VERSION' is required"; exit 1; }
+
+  export ARCH="$(uname -m | sed 's|aarch64|arm64|g')"
+
+  echo "Downloading CLI and checksums"
+  curl -fsSL \
+    -o kit.tar.gz "https://github.com/jozu-ai/kitops/releases/download/$KIT_VERSION/kitops-linux-$ARCH.tar.gz" \
+    -o checksums.txt "https://github.com/jozu-ai/kitops/releases/download/$KIT_VERSION/kitops_${KIT_VERSION}_checksums.txt" \
+
+  echo "Checking SHA256 checksum"
+  CHECKSUM=$(cat checksums.txt | grep "kitops-linux-$ARCH.tar.gz" | cut -f 1 -d ' ')
+  echo "$CHECKSUM kit.tar.gz" | sha256sum -c
+
+  echo "Extracting Kit CLI to $(pwd)/extracted/"
+  mkdir -p ./extracted
+  tar -xzvf kit.tar.gz -C ./extracted/
+EOF
+
+FROM docker.io/library/alpine
+
+ENV USER_ID=1001 \
+    USER_NAME=kit \
+    HOME=/home/user/
+
+RUN apk --no-cache upgrade && \
+    apk add --no-cache bash && \
+    mkdir -p /home/user/ && \
+    adduser -D $USER_NAME -h $HOME -u $USER_ID
+
+COPY --from=kit-download /kit-cli-download/extracted/kit /usr/local/bin/kit
+COPY --from=kit-download /kit-cli-download/extracted/README.md /kit-cli-download/extracted/LICENSE /
+
+USER ${USER_ID}
+
+ENTRYPOINT ["kit"]


### PR DESCRIPTION

### Description
Add a Dockerfile that just builds the Kit CLI and includes it in a container. While this container can be used to quickly run Kit commands, e.g.

```shell
docker run -it --rm kitimage:latest unpack mymodel -d /home/user/test
```

it is also used as a base image for other images:
* The KServe Dockerfile is largely unchanged and kept in case someone wants to use it
* An additional Kubernetes-style init container is added and makes it easier to run Kit in an init container to unpack a modelkit to some path in a volume. This container also supports verifying signatures using cosign.

### Still TODO:
* Decide which repo to store these images in
* Add CI configurations to build versioned images on release and `next` images for each commit
* Figure out better base images for containers than just alpine.

### Linked issues
Closes #369 