### PR TITLE
fixup: use brackets on documentation

### DIFF
--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -662,9 +662,9 @@ to unpack only the model, or
 to unpack only the dataset named 'my-dataset'.
 
 Valid filters have the format
-    <types>:<filters>
-where <types> is a comma-separated list of Kitfile fields (kitfile, model, datasets
-code, or docs) and <filters> is an optional comma-separated list of additional filters
+    [types]:[filters]
+where [types] is a comma-separated list of Kitfile fields (kitfile, model, datasets
+code, or docs) and [filters] is an optional comma-separated list of additional filters
 to apply, which are matched against the Kitfile to further restrict what is extracted.
 Additional filters match elements of the Kitfile on either the name (if present) or
 the path used.

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -51,9 +51,9 @@ to unpack only the model, or
 to unpack only the dataset named 'my-dataset'.
 
 Valid filters have the format
-    <types>:<filters>
-where <types> is a comma-separated list of Kitfile fields (kitfile, model, datasets
-code, or docs) and <filters> is an optional comma-separated list of additional filters
+    [types]:[filters]
+where [types] is a comma-separated list of Kitfile fields (kitfile, model, datasets
+code, or docs) and [filters] is an optional comma-separated list of additional filters
 to apply, which are matched against the Kitfile to further restrict what is extracted.
 Additional filters match elements of the Kitfile on either the name (if present) or
 the path used.


### PR DESCRIPTION
The `<` and `>` is causing the documentation build to fail. The rest of the documents seems to use `[` and `]` for similar purposes this PR switches to usage for the remaining ones. 