### PR TITLE
Update to Go 1.22.6 and fix base image in init container Dockerfile

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:alpine AS builder
+FROM docker.io/library/golang:1.22.6-alpine AS builder
 
 RUN apk --no-cache upgrade && apk add --no-cache git
 ARG KIT_VERSION=next

--- a/build/dockerfiles/init/Dockerfile
+++ b/build/dockerfiles/init/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-platform digest for Cosign v2.4.0
 ARG COSIGN_DIGEST=sha256:9d50ceb15f023eda8f58032849eedc0216236d2e2f4cfe1cdf97c00ae7798cfe
-ARG KIT_BASE_IMAGE=ghcr.io/jozu-ai/kit:next
+ARG KIT_BASE_IMAGE=ghcr.io/jozu-ai/kitops:next
 
 FROM gcr.io/projectsigstore/cosign@$COSIGN_DIGEST AS cosign-install
 FROM $KIT_BASE_IMAGE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kitops
 
-go 1.21.6
+go 1.22.6
 
 require (
 	github.com/moby/patternmatcher v0.6.0


### PR DESCRIPTION
### Description
Update Go to 1.22(.6); fix default base image in init container's Dockerfile (repo is kitops, not kit)

### Linked issues
<!-- link any issues in this repository that are related to the PR; use "closes <issue>" or "fixes <issue>" to automatically link issues to this PR -->
