### PR TITLE
Use loops instead of sendgrid for the newsletter modal

### DIFF
--- a/docs/.vitepress/theme/components/Home.vue
+++ b/docs/.vitepress/theme/components/Home.vue
@@ -10,7 +10,7 @@ const ONE_DAY_MS = 1000 * 60 * 60 * 24
 const isSubscribed = localStorage.getItem('subscribed')
 // get the last time we showed the modal, or 1 day ago if it's not set yet
 const newsletterLastOpenedAt = localStorage.getItem('newsletter-last-opened') || (new Date().getTime()) - ONE_DAY_MS
-const newsletterLastOpenDiff = new Date().getTime() - new Date(newsletterLastOpenedAt).getTime()
+const newsletterLastOpenDiff = new Date().getTime() - new Date(Number(newsletterLastOpenedAt)).getTime()
 
 const isNewsletterVisible = ref(false)
 

--- a/docs/.vitepress/theme/components/NewsletterModal.vue
+++ b/docs/.vitepress/theme/components/NewsletterModal.vue
@@ -21,12 +21,14 @@ onBeforeUnmount(() => {
 })
 
 const onSubmit = () => {
-  const LIST_ID = '115e5954-d2cc-4e97-b0dd-e6561d59e660'
+  const LIST_ID = 'cm19ng3g101z90ll73b380b5s'
   isBusy.value = true
 
-  const request = axios.put('https://sendgrid-proxy.gorkem.workers.dev/v3/marketing/contacts', {
-    list_ids: [ LIST_ID ],
-    contacts: [ { email: email.value }  ]
+  const request = axios.put('https://sendgrid-proxy.gorkem.workers.dev/v1/contacts/update', {
+    email: email.value,
+    mailingLists: {
+      [LIST_ID]: true
+    }
   })
 
   request


### PR DESCRIPTION
This PR uses `loops` instead of `sendgrid` for marketing lists and contacts.