### PR TITLE
quick start updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fjozu-ai%2Fkitops&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)
 
 [![Official Website](<https://img.shields.io/badge/-Visit%20the%20Official%20Website%20%E2%86%92-rgb(255,175,82)?style=for-the-badge>)](https://kitops.ml?utm_source=github&utm_medium=kitops-readme)
-[![Use Cases](<https://img.shields.io/badge/-KitOps%20Quick%20Start%20%E2%86%92-rgb(122,140,225)?style=for-the-badge>)](https://kitops.ml/docs/quick-start.html?utm_source=github&utm_medium=kitops-readme)
+<!-- [![Use Cases](<https://img.shields.io/badge/-KitOps%20Quick%20Start%20%E2%86%92-rgb(122,140,225)?style=for-the-badge>)](https://kitops.ml/docs/get-started.html?utm_source=github&utm_medium=kitops-readme)-->
 
 ### What is KitOps?
 
@@ -61,13 +61,11 @@ There's a video of KitOps in action on the [KitOps site](https://kitops.ml/).
 
 **[Kit CLI](./docs/src/docs/cli/cli-reference.md):** The Kit CLI not only enables users to create, manage, run, and deploy ModelKits -- it lets you pull only the pieces you need. Just need the serialized model for deployment? Use `unpack --model`, or maybe you just want the training datasets? `unpack --datasets`.
 
-You can pull pre-built ModelKits from [Jozu Hub](https://jozu.ml/discover).
-
 ## 🚀 Try KitOps in under 15 Minutes
 
 1. [Install the CLI](./docs/src/docs/cli/installation.md) for your platform.
-2. Follow the [ Quick Start](https://kitops.ml/docs/quick-start.html) to learn to pack, unpack, and share a ModelKit.
-3. Test out one of our ModelKit Quick Starts which include everything thing you need to run your model including a codebase, dataset, documentation, and of course the model.
+2. Follow the [Getting Started](./docs/src/docs/get-started.md) docs to learn to pack, unpack, and share a ModelKit.
+3. Test drive one of our [ModelKit Quick Starts](https://jozu.ml/organization/jozu-quickstarts) that include everything thing you need to run your model including a codebase, dataset, documentation, and of course the model.
 
 - [Meta LLama 3.1](https://jozu.ml/repository/jozu/llama3.1-8b)
 - [Google Gemma](https://jozu.ml/repository/jozu/gemma-7b)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -49,7 +49,7 @@ export default defineConfig({
 
     // Top navigation
     nav: [
-      { text: 'Get Started?', activeMatch: '^/#getstarted', link: '/docs/quick-start.html' },
+      { text: 'Get Started?', activeMatch: '^/#getstarted', link: '/docs/get-started.html' },
       { text: 'How does it work?', activeMatch: `^/#howdoesitwork`, link: '/#howdoesitwork' },
       { text: 'Docs', activeMatch: `^/docs`, link: '/docs/overview' },
       { text: 'Blog', activeMatch: `^/blog`, link: '/blog' },
@@ -61,7 +61,7 @@ export default defineConfig({
         text: 'Getting started',
         items: [
           { text: 'Overview', link: '/docs/overview' },
-          { text: 'Quick Start', link: '/docs/quick-start' },
+          { text: 'Get Started', link: '/docs/get-started' },
           { text: 'Next Steps', link: '/docs/next-steps' },
           { text: 'Kit Dev', link: '/docs/dev-mode' },
           { text: 'Why KitOps?', link: '/docs/why-kitops' },
@@ -74,7 +74,7 @@ export default defineConfig({
         items: [
           { text: 'Overview', link: '/docs/modelkit/intro' },
           { text: 'Specification', link: '/docs/modelkit/spec' },
-          { text: 'Pre-built ModelKits', link: '/docs/modelkit/prebuilt-modelkits' },
+          { text: 'ModelKit Quick Starts', link: 'https://jozu.ml/organization/jozu-quickstarts' },
           { text: 'Compatibility', link: '/docs/modelkit/compatibility' },
         ]
       },

--- a/docs/discord-tracking.md
+++ b/docs/discord-tracking.md
@@ -10,4 +10,4 @@ Because our allegedly permanent discord links have needed to be refreshed a coup
 * ./docs/.vitepress/theme/components/Footer.vue
 * ./docs/.vitepress/theme/components/Home.vue
 * ./docs/src/docs/next-steps.md
-* ./docs/src/docs/quick-start.md
+* ./docs/src/docs/get-started.md

--- a/docs/src/docs/get-started.md
+++ b/docs/src/docs/get-started.md
@@ -2,7 +2,7 @@
 import vGaTrack from '@theme/directives/ga'
 </script>
 
-# KitOps Quick Start
+# KitOps Getting Started
 
 In this guide, we'll use ModelKits and the kit CLI to easily:
 * Package up a model, notebook, and datasets into a single ModelKit you can share through your existing tools
@@ -28,7 +28,7 @@ You'll see information about the version of Kit you're running. If you get an er
 
 ### 2/ Login to Your Registry
 
-You can use the [login command](./cli/cli-reference.md#kit-login) to authenticate with any OCI v1.1-compatible container registry - local or remote. In this guide we'll use the [Jozu Hub](https://jozu.ml/) because it's free to sign-up and provides more detail on what's inside each ModelKit and whether it's signed or has provenance. You can substitute your own repository if preferred.
+You can use the [login command](./cli/cli-reference.md#kit-login) to authenticate with any OCI v1.1-compatible container registry - local or remote (you can see our [list of compliant registries](./modelkit/compatibility.md)). In this guide we'll use the [Jozu Hub](https://jozu.ml/) because it's free to sign-up and provides more detail on what's inside each ModelKit like whether it's signed or has provenance. You can substitute your own repository if preferred.
 
 ```sh
 kit login jozu.ml
@@ -44,7 +44,7 @@ You can grab <a href="https://jozu.ml/discover"
   v-ga-track="{
     category: 'link',
     label: 'grab any of the ModelKits',
-    location: 'docs/quick-start'
+    location: 'docs/get-started'
   }">any of the ModelKits</a> from the Jozu Hub, but we've chosen a fine-tuned model based on Llama3.
 
 The unpack command will unpack the ModelKit contents to the current directory by default. If you want it unpacked to a specific directory use the `-d /path/to/unpacked`.
@@ -80,15 +80,22 @@ You'll see the column headings for an empty table with things like `REPOSITORY`,
 
 ### 5/ Pack the ModelKit
 
-Since our repository is empty we'll need use the [pack command](./cli/cli-reference.md#kit-pack) to create our ModelKit. The ModelKit in your local registry will need to be named the same as your remote registry. So the command will look like: `kit pack . -t [your registry address]/[your repository name]/mymodelkit:latest`
+Since our repository is empty we'll need use the [pack command](./cli/cli-reference.md#kit-pack) to create our ModelKit. The ModelKit in your local registry will need to be named the same as your remote registry. The command will look like: `kit pack . -t [your registry address]/[your registry user or organization name]/[your repository name]:[your tag name]`
 
-In my case I am pushing to the `brad` repository on [Jozu Hub](https://jozu.ml/). You'll need to substitute the name of your own repository:
+In our case we are pushing a ModelKit tagged `latest` to:
+* The [Jozu Hub](https://jozu.ml/) registry
+* The `brad` user organization
+* The `quick-start` repository
+
+As a result, the command will look like:
 
 ```sh
 kit pack . -t jozu.ml/brad/quick-start:latest
 ```
 
-You'll see a set of `Saved ...` messages as each piece of the ModelKit is saved to the local repository.
+You may need to substitute your own registry, user, repository, or tag names.
+
+Once complete, you'll see a set of `Saved ...` messages as each piece of the ModelKit is saved to the local repository.
 
 Check your local registry again:
 
@@ -102,21 +109,21 @@ You should see an entry named based on whatever you used in your pack command.
 
 If you have a typo when packing a ModelKit you can easily remove it from your repository and try again. The [Next Steps guide includes information on how to remove ModelKits](./next-steps.md#remove-command).
 
-Once you've removed the mistaken ModelKit from the repository, you can repeat the `kit pack` command in the previous step, being sure to provide the correct repository name for your ModelKit.
+Once you've removed the mistaken ModelKit from the repository, you can repeat the `kit pack` command in the previous step, being sure to provide the correct organization and repository name for your ModelKit.
 
 ### 7/ Push the ModelKit to a Remote Repository
 
-The [push command](./cli/cli-reference.md#kit-push) will copy the newly built ModelKit from your local repository to the remote repository you logged into earlier. The naming of your ModelKit will need to be the same as what you see in your `kit list` command (REPOSITORY:TAG). You can even copy and paste it. In my case it looks like:
+The [push command](./cli/cli-reference.md#kit-push) will copy the newly built ModelKit from your local repository to the remote repository you logged into earlier. The naming of your ModelKit will need to be the same as what you see in your `kit list` command (REPOSITORY:TAG). You can even copy and paste it. In our case it looks like:
 
 ```sh
 kit push jozu.ml/brad/quick-start:latest
 ```
 
-Note that some registries, like Jozu Hub, don't automatically create a repository. If you receive an error from your `push` command, make sure you have created the repository in your target registry.
+Note that some registries, like Jozu Hub, don't automatically create a repository. If you receive an error from your `push` command, make sure you have created the repository in your target registry and that you have push rights to the repository.
 
 ### Congratulations
 
-You've learned how to unpack a ModelKit, pack one up, push it, and run an LLM locally. Anyone with access to your remote repository can now pull your new ModelKit and start playing with your model using the `kit pull` or `kit unpack` commands.
+You've learned how to unpack a ModelKit, pack one up, and push it. Anyone with access to your remote repository can now pull your new ModelKit and start playing with your model using the `kit pull` or `kit unpack` commands.
 
 If you'd like to learn more about using Kit, try our [Next Steps with Kit](./next-steps.md) document that covers:
 * Signing your ModeKit
@@ -124,5 +131,7 @@ If you'd like to learn more about using Kit, try our [Next Steps with Kit](./nex
 * The power of `unpack`
 * Tagging ModelKits
 * Keeping your registry tidy
+
+Or, if you want to run an LLM-based ModelKit locally try our [dev mode](./dev-mode.md)
 
 Thanks for taking some time to play with Kit. We'd love to hear what you think. Feel free to drop us an [issue in our GitHub repository](https://github.com/jozu-ai/kitops/issues) or join [our Discord server](https://discord.gg/3eDb4yAN).

--- a/docs/src/docs/modelkit/compatibility.md
+++ b/docs/src/docs/modelkit/compatibility.md
@@ -4,11 +4,24 @@ ModelKit packages can be pushed to any OCI 1.1-compliant registry, whether in th
 
 ModelKits themselves use standards like JSON, YAML, and TAR files so whatever MLOps or DevOps tools you're using...they'll work with ModelKits.
 
-A few examples in alphabetical order:
+## Compliant OCI Registries
+
+* Amazon Elastic Container Registry (ECR)
+* Azure Container Registry
+* Docker Hub
+* GitHub Packages Container Registry
+* GitLab Container Registry
+* Google Artifact Registry
+* Harbor
+* IBM Cloud Container Registry
+* JFrog Artifactory
+* Red Hat Quay.io
+
+## Other Compatible Tools
+
 * Amazon SageMaker
 * Amazon Elastic Kubernetes Service (EKS)
 * Amazon Elastic Compute Cloud (EC2)
-* Amazon Elastic Container Registry (ECR)
 * Amazon Fargate
 * Amazon Lambda
 * Amazon S3
@@ -16,15 +29,12 @@ A few examples in alphabetical order:
 * Azure ML
 * Azure Kubernetes Service (AKS)
 * Azure Cloud
-* Azure Container Registry
 * Circle CI
 * Clear ML
 * Comet ML
 * Databricks
 * DataRobot
 * Domino
-* Docker
-* Docker Hub
 * DvC
 * Git
 * Git LFS
@@ -33,12 +43,9 @@ A few examples in alphabetical order:
 * Google Vertex
 * Google Kubernetes Service (GKS)
 * Google Container Platform (GCP)
-* Google Artifact Registry
 * Hugging Face
 * IBM Cloud
-* IBM Cloud Container Registry
 * Jenkins CI/CD
-* JFrog Artifactory
 * Jupyter notebooks
 * Kubernetes
 * Kserve
@@ -53,7 +60,6 @@ A few examples in alphabetical order:
 * Red Hat InstructLab
 * Red Hat OpenShift
 * Red Hat OpenShift AI
-* Red Hat Quay.io
 * Seldon
 * Sonatype Nexus
 * Tensorflow Hub

--- a/docs/src/docs/modelkit/intro.md
+++ b/docs/src/docs/modelkit/intro.md
@@ -4,7 +4,7 @@
 
 ModelKit revolutionizes the way AI/ML artifacts are shared and managed throughout the lifecycle of AI/ML projects. As an OCI-compliant packaging format, ModelKit encapsulates datasets, code, configurations, and models into a single, standardized unit. This approach not only streamlines the development process but also ensures broad compatibility and integration with a vast array of tools and platforms.
 
-Start with a [pre-built ModelKit](./prebuilt-modelkits.md), see the [ModelKit spec](./spec.md), or look over the [tool compatibility list](./compatibility.md).
+<!-- Start with a [ModelKit Quick Start](TBD), -->See the [ModelKit spec](./spec.md), or look over the [tool compatibility list](./compatibility.md).
 
 ## Key Features of ModelKit:
 

--- a/docs/src/docs/next-steps.md
+++ b/docs/src/docs/next-steps.md
@@ -7,15 +7,11 @@ In this guide you'll learn how to:
 * Read the Kitfile or manifest from a ModelKit
 * Tag ModelKits and keep your registry tidy
 
-::: info
-If you're interested in running an LLM locally using Kit, you can jump to the [Kit Dev](./dev-mode.md) documentation.
-:::
-
 ## Signing your ModelKit
 
-Because ModelKits are OCI artifacts, they can be signed like any other OCI artifact (you may already sign your containers, for example).
+Because ModelKits are OCI 1.1 artifacts, they can be signed like any other OCI artifact (you may already sign your containers, for example).
 
-If you need a quick way to sign a ModelKit you can follow the same instructions as for a container, using something like [Cosign](https://docs.sigstore.dev/signing/quickstart).
+If you need a quick way to sign a ModelKit you can follow the same instructions as for a container, using a tool like [Cosign](https://docs.sigstore.dev/cosign/signing/signing_with_containers/).
 
 
 ## Making your own Kitfile
@@ -30,7 +26,7 @@ A Kitfile is the configuration document for your ModelKit. It's written in YAML 
 
 A Kitfile only needs the `package` section, plus one or more of the other sections.
 
-The `model` section can only contain a single model (you can chain models by using multiple ModelKits).
+The `model` section can contain a single model, or you can create model dependencies with `model parts` which is covered in the [KitFile format documentation](https://kitops.ml/docs/kitfile/format.html#model).
 
 The `datasets`, `code`, and `docs` sections are lists, so each entry must start with a dash. The dash is required even if you are only packaging a single item of that type.
 

--- a/docs/src/docs/why-kitops.md
+++ b/docs/src/docs/why-kitops.md
@@ -46,4 +46,4 @@ Then `kit push` it to any OCI-compliant registry, even a private one.
 
 Most people won't need everything, so just `kit unpack` from the remote registry to get just the model, only the datasets, or just the notebook. Or, if you need everything then a `kit pull` will grab everything.
 
-Check out our [quick start](./quick-start.md), see the power and flexibility of our [CLI commands](./cli/cli-reference.md), or learn more about packaging your AI/ML project with [ModelKits](./modelkit/intro.md).
+Check out our [getting started doc](./get-started.md), see the power and flexibility of our [CLI commands](./cli/cli-reference.md), or learn more about packaging your AI/ML project with [ModelKits](./modelkit/intro.md).


### PR DESCRIPTION
* Updated all reference to Quick Start ModelKits to point to the `jozu-quickstart` organization page on Jozu Hub
* Changed `quick-start.md` to `get-started.md` to avoid confusion with Quick Start ModelKits
* Separated the list of compatible OCI registries from other tools in `compatibility.md`
* Fixed mistaken references to `dev mode` in getting started and next steps docs
* Updated all other impacted pages to address the above changes
