### PR TITLE
Improve the email field validation in the home page

### DIFF
--- a/docs/.vitepress/theme/components/Home.vue
+++ b/docs/.vitepress/theme/components/Home.vue
@@ -125,7 +125,7 @@ const subscribeToNewsletter = async () => {
           :disabled="isBusy"
           id="email"
           type="email"
-          pattern="^[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*@[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*$"
+          pattern="^[a-zA-Z0-9]+(?:[._+-][a-zA-Z0-9]+)*@[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$"
           name="email"
           placeholder="you@example.com"
           class="input"

--- a/docs/.vitepress/theme/components/Home.vue
+++ b/docs/.vitepress/theme/components/Home.vue
@@ -125,6 +125,7 @@ const subscribeToNewsletter = async () => {
           :disabled="isBusy"
           id="email"
           type="email"
+          pattern="^[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*@[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*$"
           name="email"
           placeholder="you@example.com"
           class="input"


### PR DESCRIPTION
This PR uses a custom (better?) regexp pattern to validate emails in the newsletter subscription form.