### PR TITLE
Fixed TAG_NAME environment variable assignment

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -277,7 +277,7 @@ jobs:
 
       - name: Create and save homebrew-metadata.txt
         env:
-          TAG_NAME: ${{ inputs.release_tag}}
+          TAG_NAME: ${{ inputs.release_tag || github.ref_name}}
           REPO: ${{ github.repository }}
         run: |
           shopt -s failglob


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/jozu-ai/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/jozu-ai/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description
I corrected a problem in which the environment variable $TAG_NAME was being set within the Platform Release GitHub workflow.
