### PR TITLE
Make release container job depend on release job in actions

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -331,6 +331,7 @@ jobs:
 
   docker-image-build:
     runs-on: ubuntu-latest
+    needs: [release]
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf    # v3.2.0


### PR DESCRIPTION
### Description
Since we changed the release container build job to pull artifacts from GitHub releases, we need to wait for the job that creates the release to complete before attempting to build the container.

### Linked issues
N/A; should address the failed container build step for the v0.3.4 release in future releases.