### PR TITLE
Fix some 404's and add a "new" sitemap

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -152,23 +152,8 @@ export default defineConfig({
     ])
   },
 
-  // Generate the sitemap.xml
-  transformHtml: (_, id, { pageData }) => {
-    if (!/[\\/]404\.html$/.test(id)) {
-      links.push({
-        url: pageData.relativePath.replace(/\/index\.md$/, '/').replace(/\.md$/, '.html'),
-        lastmod: pageData.lastUpdated,
-      })
-    }
-  },
-
-  buildEnd: async ({ outDir }) => {
-    const sitemap = new SitemapStream({ hostname: 'https://kitops.ml/' })
-    const writeStream = createWriteStream(resolve(outDir, 'sitemap.xml'))
-    sitemap.pipe(writeStream)
-    links.forEach((link) => sitemap.write(link))
-    sitemap.end()
-    await new Promise((r) => writeStream.on('finish', r))
+  sitemap: {
+    hostname: 'https://kitops.ml'
   },
 
   vite: {

--- a/docs/src/docs/cli/installation.md
+++ b/docs/src/docs/cli/installation.md
@@ -31,7 +31,7 @@ kit version
 
 This command should display the version number of the Kit CLI you have installed, indicating that the installation was successful.
 
-Now follow our [Quick Start](../get-started.md) to learn how to pack and share your first ModelKit.
+Now follow our [Quick Start](/docs/get-started.md) to learn how to pack and share your first ModelKit.
 
 **Need Help?** If something isn't working [get help on our Discord channel](https://discord.gg/Tapeh8agYy).
 

--- a/docs/src/docs/modelkit/intro.md
+++ b/docs/src/docs/modelkit/intro.md
@@ -4,9 +4,9 @@
 
 ModelKit revolutionizes the way AI/ML artifacts are shared and managed throughout the lifecycle of AI/ML projects. As an OCI-compliant packaging format, ModelKit encapsulates datasets, code, configurations, and models into a single, standardized unit. This approach not only streamlines the development process but also ensures broad compatibility and integration with a vast array of tools and platforms.
 
-[Get started with ModelKits](../get-started.md) in less than 15 minutes.
+[Get started with ModelKits](/docs/get-started.md) in less than 15 minutes.
 
-[See how security-conscious organization are using ModelKits](../use-cases.md) with their existing tools to develop AI/ML projects faster and safer than ever before.
+[See how security-conscious organization are using ModelKits](/docs/use-cases.md) with their existing tools to develop AI/ML projects faster and safer than ever before.
 
 ## Key Features of ModelKit:
 


### PR DESCRIPTION
Relates to #587.

This PR replaces the manually added `sitemap.xml` generation in the vitepress config, with the latest out-of-the-box solution.

It also fixes 3 broken links to prevent 404 failure from the google indexing.