### PR TITLE
Normalize paths when deciding if files should be ignored

### DIFF
--- a/pkg/lib/filesystem/ignore.go
+++ b/pkg/lib/filesystem/ignore.go
@@ -78,6 +78,7 @@ func (pm *ignorePaths) Matches(path, layerPath string) (bool, error) {
 	// ignore file doesn't exclude the current path, check if it should be excluded
 	// since it's included in another layer
 	for _, layer := range pm.layers {
+		layer = cleanPath(layer)
 		if strings.HasPrefix(layerPath, layer) {
 			// ignore other layer paths if they are parents of the current layer's path,
 			// e.g. ignore ./main-dir when current layer is ./main-dir/sub-dir

--- a/testing/testdata/pack-unpack/test_path-formats.yaml
+++ b/testing/testdata/pack-unpack/test_path-formats.yaml
@@ -1,0 +1,24 @@
+description: Ensure various path formats are supported
+kitfile: |
+  manifestVersion: 1.0.0
+  package:
+    name: test-path-format
+  docs:
+    - path: my-file.txt
+    - path: ./my-file2.txt
+    - path: dir-one
+    - path: dir-two/
+    - path: ./dir-three
+    - path: ./dir-four/
+    - path: dir-five/my-file.txt
+    - path: ./dir-six/my-file.txt
+
+files:
+  - ./my-file.txt
+  - ./my-file2.txt
+  - ./dir-one/test-file
+  - ./dir-two/test-file
+  - ./dir-three/test-file
+  - ./dir-four/test-file
+  - ./dir-five/my-file.txt
+  - ./dir-six/my-file.txt


### PR DESCRIPTION
### Description
We need to normalize paths when computing ignores to ensure our current check succeeds in all cases. Currently, specifying a Kitfile such as
```yaml
manifestVersion: 1.0.0
model:
  path: my-model/  # Trailing slash on path for the my-model directory
```
results in the ignore check asking "does path `my-model` have prefix `my-model/`?", which fails. 

To make sure we handle `./my-model`, `my-model/` and `my-model` identically, we clean paths in the ignore checker to match how Kitfile paths are handled elsewhere

This PR also adds a functional test that would fail on the current main branch but is fixed by the PR.

### Linked issues
Closes #620 
