### PR TITLE
Updates to ModelKit format

### DIFF
--- a/pkg/artifact/kitfile.go
+++ b/pkg/artifact/kitfile.go
@@ -34,17 +34,18 @@ type (
 		Docs            []Docs    `json:"docs,omitempty" yaml:"docs,omitempty"`
 	}
 
-	Docs struct {
-		Path        string `json:"path" yaml:"path"`
-		Description string `json:"description" yaml:"description"`
-	}
-
 	Package struct {
 		Name        string   `json:"name,omitempty" yaml:"name,omitempty"`
 		Version     string   `json:"version,omitempty" yaml:"version,omitempty"`
 		Description string   `json:"description,omitempty" yaml:"description,omitempty"`
 		License     string   `json:"license,omitempty" yaml:"license,omitempty"`
 		Authors     []string `json:"authors,omitempty" yaml:"authors,omitempty,flow"`
+	}
+
+	Docs struct {
+		Path        string `json:"path" yaml:"path"`
+		Description string `json:"description" yaml:"description"`
+		*LayerInfo  `json:",inline" yaml:",inline"`
 	}
 
 	Model struct {
@@ -62,19 +63,22 @@ type (
 		//  * Numbers will be converted to decimal representations (0xFF -> 255, 1.2e+3 -> 1200)
 		//  * Maps will be sorted alphabetically by key
 		Parameters any `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+		*LayerInfo `json:",inline" yaml:",inline"`
 	}
 
 	ModelPart struct {
-		Name    string `json:"name,omitempty" yaml:"name,omitempty"`
-		Path    string `json:"path,omitempty" yaml:"path,omitempty"`
-		License string `json:"license,omitempty" yaml:"license,omitempty"`
-		Type    string `json:"type,omitempty" yaml:"type,omitempty"`
+		Name       string `json:"name,omitempty" yaml:"name,omitempty"`
+		Path       string `json:"path,omitempty" yaml:"path,omitempty"`
+		License    string `json:"license,omitempty" yaml:"license,omitempty"`
+		Type       string `json:"type,omitempty" yaml:"type,omitempty"`
+		*LayerInfo `json:",inline" yaml:",inline"`
 	}
 
 	Code struct {
 		Path        string `json:"path,omitempty" yaml:"path,omitempty"`
 		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		License     string `json:"license,omitempty" yaml:"license,omitempty"`
+		*LayerInfo  `json:",inline" yaml:",inline"`
 	}
 
 	DataSet struct {
@@ -90,6 +94,14 @@ type (
 		//  * Maps will be sorted alphabetically by key
 		//  * It's recommended to store metadata like preprocessing steps, formats, etc.
 		Parameters any `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+		*LayerInfo `json:",inline" yaml:",inline"`
+	}
+
+	LayerInfo struct {
+		// Digest for the layer corresponding to this element
+		Digest string `json:"digest,omitempty" yaml:"-"`
+		// Diff ID (uncompressed digest) for the layer corresponding to this element
+		DiffId string `json:"diffId,omitempty" yaml:"-"`
 	}
 )
 

--- a/pkg/cmd/unpack/unpack.go
+++ b/pkg/cmd/unpack/unpack.go
@@ -246,7 +246,7 @@ func extractTar(tr *tar.Reader, dir string, overwrite bool, logger *output.Progr
 		if err != nil {
 			return err
 		}
-		outPath := filepath.Join(dir, header.Name)
+		outPath := header.Name
 		// Check if the outPath is within the target directory
 		_, _, err = filesystem.VerifySubpath(dir, outPath)
 		if err != nil {
@@ -259,7 +259,6 @@ func extractTar(tr *tar.Reader, dir string, overwrite bool, logger *output.Progr
 				if !fi.IsDir() {
 					return fmt.Errorf("path '%s' already exists and is not a directory", outPath)
 				}
-				logger.Debugf("Path %s already exists", outPath)
 			} else {
 				logger.Debugf("Creating directory %s", outPath)
 				if err := os.MkdirAll(outPath, header.FileInfo().Mode()); err != nil {

--- a/pkg/lib/kitfile/local-storage.go
+++ b/pkg/lib/kitfile/local-storage.go
@@ -42,11 +42,12 @@ import (
 // modelkits that include paths that leave the base context directory, allowing only subdirectories of the root
 // context to be included in the modelkit.
 func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact.KitFile, ignore filesystem.IgnorePaths, compression string) (*ocispec.Descriptor, error) {
-	configDesc, err := saveConfig(ctx, localRepo, kitfile)
+	layerDescs, err := saveKitfileLayers(ctx, localRepo, kitfile, ignore, compression)
 	if err != nil {
 		return nil, err
 	}
-	layerDescs, err := saveKitfileLayers(ctx, localRepo, kitfile, ignore, compression)
+
+	configDesc, err := saveConfig(ctx, localRepo, kitfile)
 	if err != nil {
 		return nil, err
 	}
@@ -97,68 +98,73 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 				BaseType:    constants.ModelType,
 				Compression: compression,
 			}
-			layer, err := saveContentLayer(ctx, localRepo, kitfile.Model.Path, mediaType, ignore)
+			layer, layerInfo, err := saveContentLayer(ctx, localRepo, kitfile.Model.Path, mediaType, ignore)
 			if err != nil {
 				return nil, err
 			}
 			layers = append(layers, layer)
+			kitfile.Model.LayerInfo = layerInfo
 		}
-		for _, part := range kitfile.Model.Parts {
+		for idx, part := range kitfile.Model.Parts {
 			mediaType := constants.MediaType{
 				BaseType:    constants.ModelPartType,
 				Compression: compression,
 			}
-			layer, err := saveContentLayer(ctx, localRepo, part.Path, mediaType, ignore)
+			layer, layerInfo, err := saveContentLayer(ctx, localRepo, part.Path, mediaType, ignore)
 			if err != nil {
 				return nil, err
 			}
 			layers = append(layers, layer)
+			kitfile.Model.Parts[idx].LayerInfo = layerInfo
 		}
 	}
-	for _, code := range kitfile.Code {
+	for idx, code := range kitfile.Code {
 		mediaType := constants.MediaType{
 			BaseType:    constants.CodeType,
 			Compression: compression,
 		}
-		layer, err := saveContentLayer(ctx, localRepo, code.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, localRepo, code.Path, mediaType, ignore)
 		if err != nil {
 			return nil, err
 		}
 		layers = append(layers, layer)
+		kitfile.Code[idx].LayerInfo = layerInfo
 	}
-	for _, dataset := range kitfile.DataSets {
+	for idx, dataset := range kitfile.DataSets {
 		mediaType := constants.MediaType{
 			BaseType:    constants.DatasetType,
 			Compression: compression,
 		}
-		layer, err := saveContentLayer(ctx, localRepo, dataset.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, localRepo, dataset.Path, mediaType, ignore)
 		if err != nil {
 			return nil, err
 		}
 		layers = append(layers, layer)
+		kitfile.DataSets[idx].LayerInfo = layerInfo
 	}
-	for _, docs := range kitfile.Docs {
+	for idx, docs := range kitfile.Docs {
 		mediaType := constants.MediaType{
 			BaseType:    constants.DocsType,
 			Compression: compression,
 		}
-		layer, err := saveContentLayer(ctx, localRepo, docs.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, localRepo, docs.Path, mediaType, ignore)
 		if err != nil {
 			return nil, err
 		}
 		layers = append(layers, layer)
+		kitfile.Docs[idx].LayerInfo = layerInfo
 	}
 
 	return layers, nil
 }
 
-func saveContentLayer(ctx context.Context, localRepo local.LocalRepo, path string, mediaType constants.MediaType, ignore filesystem.IgnorePaths) (ocispec.Descriptor, error) {
+func saveContentLayer(ctx context.Context, localRepo local.LocalRepo, path string, mediaType constants.MediaType, ignore filesystem.IgnorePaths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
 	// We want to store a gzipped tar file in store, but to do so we need a descriptor, so we have to compress
 	// to a temporary file. Ideally, we'd also add this to the internal store by moving the file to avoid
 	// copying if possible.
-	tempPath, desc, err := compressLayer(path, mediaType, ignore)
+	tempPath, desc, info, err := compressLayer(path, mediaType, ignore)
 	if err != nil {
-		return ocispec.DescriptorEmptyJSON, err
+		return ocispec.DescriptorEmptyJSON, nil, err
 	}
 	defer func() {
 		if err := os.Remove(tempPath); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -167,10 +173,10 @@ func saveContentLayer(ctx context.Context, localRepo local.LocalRepo, path strin
 	}()
 
 	if exists, err := localRepo.Exists(ctx, desc); err != nil {
-		return ocispec.DescriptorEmptyJSON, err
+		return ocispec.DescriptorEmptyJSON, nil, err
 	} else if exists {
 		output.Infof("Already saved %s layer: %s", mediaType.BaseType, desc.Digest)
-		return desc, nil
+		return desc, info, nil
 	}
 
 	// Workaround to avoid copying a potentially very large file: move it to the expected path
@@ -182,25 +188,25 @@ func saveContentLayer(ctx context.Context, localRepo local.LocalRepo, path strin
 		output.Debugf("Failed to move temp file into storage (will copy instead): %s", err)
 		file, err := os.Open(tempPath)
 		if err != nil {
-			return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to open temporary file: %w", err)
+			return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("failed to open temporary file: %w", err)
 		}
 		defer file.Close()
 		if err := localRepo.Push(ctx, desc, file); err != nil {
-			return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to add layer to storage: %w", err)
+			return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("failed to add layer to storage: %w", err)
 		}
 	}
 
 	// Verify blob is in store now
 	exists, err := localRepo.Exists(ctx, desc)
 	if err != nil {
-		return ocispec.DescriptorEmptyJSON, err
+		return ocispec.DescriptorEmptyJSON, nil, err
 	}
 	if !exists {
-		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to move layer to storage: file is not stored")
+		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("failed to move layer to storage: file is not stored")
 	}
 
 	output.Infof("Saved %s layer: %s", mediaType.BaseType, desc.Digest)
-	return desc, nil
+	return desc, nil, nil
 }
 
 func saveModelManifest(ctx context.Context, store oras.Target, manifest ocispec.Manifest) (*ocispec.Descriptor, error) {

--- a/pkg/lib/kitfile/local-storage.go
+++ b/pkg/lib/kitfile/local-storage.go
@@ -206,7 +206,7 @@ func saveContentLayer(ctx context.Context, localRepo local.LocalRepo, path strin
 	}
 
 	output.Infof("Saved %s layer: %s", mediaType.BaseType, desc.Digest)
-	return desc, nil, nil
+	return desc, info, nil
 }
 
 func saveModelManifest(ctx context.Context, store oras.Target, manifest ocispec.Manifest) (*ocispec.Descriptor, error) {

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -188,7 +188,7 @@ func (t *ProgressTar) Close() error {
 }
 
 func TarProgress(total int64, tw *tar.Writer) (*ProgressTar, *ProgressLogger) {
-	if !progressEnabled {
+	if !progressEnabled || total == 0 {
 		return &ProgressTar{tw: tw}, &ProgressLogger{stdout}
 	}
 


### PR DESCRIPTION
### Description
This PR implements the updates discussed in #489:

* We've added fields to the ModelKit manifest's config to store layer digests and diff IDs, so that we can match Kitfile fields to layers more easily (rather than relying on order)
* We're now packing tar layers slightly differently -- instead of packing the contents of a layer's path, we pack full directory structure from the pack context. In short, if you extract the tarballs for all layers in a manifest, you should get back the original file structure

This change is backwards compatible with ModelKits packed prior to this change -- they can still be unpacked, etc. This change does, however, break reproducible digests for older ModelKits (packing the same data with Kit prior to this change will result in a ModelKit with a different digest due to the changes to tar files and the config). Within Kit versions, digests are still reproducible.  

### Linked issues
Closes #489 
