### PR TITLE
Remove the autofocus from the new newsletter input

### DIFF
--- a/docs/.vitepress/theme/components/Home.vue
+++ b/docs/.vitepress/theme/components/Home.vue
@@ -141,7 +141,6 @@ const subscribeToNewsletter = async () => {
           placeholder="you@example.com"
           class="input"
           v-model="email"
-          autofocus
           style="border: 1px solid var(--color-off-white)" />
 
         <input


### PR DESCRIPTION
This PR removes the `autofocus` prop from the newsletter input to avoid the scrollbar jumping to that field onload.