### PR TITLE
Add Model format field to Kitfile

### DIFF
--- a/pkg/artifact/kitfile.go
+++ b/pkg/artifact/kitfile.go
@@ -52,6 +52,7 @@ type (
 		Path        string      `json:"path,omitempty" yaml:"path,omitempty"`
 		License     string      `json:"license,omitempty" yaml:"license,omitempty"`
 		Framework   string      `json:"framework,omitempty" yaml:"framework,omitempty"`
+		Format      string      `json:"format,omitempty" yaml:"format,omitempty"`
 		Version     string      `json:"version,omitempty" yaml:"version,omitempty"`
 		Description string      `json:"description,omitempty" yaml:"description,omitempty"`
 		Parts       []ModelPart `json:"parts,omitempty" yaml:"parts,omitempty"`


### PR DESCRIPTION
### Description
To make runtime usage simpler, add Kitfile field .model.format. This can be set to store the model's data format (e.g. safetensors, gguf, onnx, etc.).

This information can be used by runtimes to determine how to consume the model (e.g. if the runtime can handle .gguf files)

### Linked issues
No issue at the moment
