### PR TITLE
Add pykitops to the docs site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -107,6 +107,14 @@ export default defineConfig({
         ]
       },
       {
+        text: 'Python Library',
+        items: [
+          { text: 'Overview', link: '/docs/pykitops.html' },
+          { text: 'How-to Guides', link: '/docs/pykitops/how-to-guides.html' },
+          { text: 'Reference', link: '/docs/pykitops/reference.html' },
+        ]
+      },
+      {
         text: 'CLI',
         items: getSidebarItemsFromMdFiles('docs/cli', {
             replacements: {

--- a/docs/src/docs/pykitops.md
+++ b/docs/src/docs/pykitops.md
@@ -1,0 +1,5 @@
+# KitOps Python Library
+
+This site contains the project documentation for the PyKitOps SDK project - a python library for working with [KitOps' ModelKits](https://kitops.ml) in code. You can find [KitOps and ModelKit documentation](https://kitops.ml/docs/overview.html) on the KitOps site.
+
+<!--@include: pykitops/before-you-begin.md-->

--- a/docs/src/docs/pykitops/reference.md
+++ b/docs/src/docs/pykitops/reference.md
@@ -1,0 +1,11 @@
+<!--@include: ./reference/index.md-->
+
+<!--@include: ./reference/kit.md-->
+
+<!--@include: ./reference/kitfile.md-->
+
+<!--@include: ./reference/manager.md-->
+
+<!--@include: ./reference/reference.md-->
+
+<!--@include: ./reference/user.md-->


### PR DESCRIPTION
This PR adds the doc for pykitops in the docs' sidebar.

Note: This PR needs to be merged _after_ https://github.com/jozu-ai/pykitops/pull/18 as we are referencing those files.

Fixes https://github.com/jozu-ai/pykitops/issues/10