### PR TITLE
Add ability to automatically generate Kitfiles

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 
 	"kitops/pkg/cmd/dev"
 	"kitops/pkg/cmd/info"
+	kitinit "kitops/pkg/cmd/init"
 	"kitops/pkg/cmd/inspect"
 	"kitops/pkg/cmd/list"
 	"kitops/pkg/cmd/login"
@@ -149,6 +150,7 @@ func addSubcommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(logout.LogoutCommand())
 	rootCmd.AddCommand(version.VersionCommand())
 	rootCmd.AddCommand(dev.DevCommand())
+	rootCmd.AddCommand(kitinit.InitCommand())
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module kitops
 go 1.22.6
 
 require (
+	github.com/google/licensecheck v0.3.1
 	github.com/moby/patternmatcher v0.6.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lV
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/licensecheck v0.3.1 h1:QoxgoDkaeC4nFrtGN1jV7IPmDCHFNIVh54e5hSt6sPs=
+github.com/google/licensecheck v0.3.1/go.mod h1:ORkR35t/JjW+emNKtfJDII0zlciG9JgbT7SmsohlHmY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=

--- a/pkg/artifact/kitfile.go
+++ b/pkg/artifact/kitfile.go
@@ -44,7 +44,7 @@ type (
 
 	Docs struct {
 		Path        string `json:"path" yaml:"path"`
-		Description string `json:"description" yaml:"description"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		*LayerInfo  `json:",inline" yaml:",inline"`
 	}
 

--- a/pkg/cmd/init/cmd.go
+++ b/pkg/cmd/init/cmd.go
@@ -1,0 +1,98 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitinit
+
+import (
+	"context"
+	"fmt"
+	"kitops/pkg/lib/constants"
+	"kitops/pkg/lib/kitfile"
+	"kitops/pkg/output"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	shortDesc = `Generate a Kitfile for the contents of a directory`
+	longDesc  = `Examine the contents of a directory and attempt to generate a basic Kitfile
+based on common file formats. Any files whose type (i.e. model, dataset, etc.)
+cannot be determined will be included in a code layer.
+
+By default the command will prompt for input for a name and description for the Kitfile`
+	example = `# Generate a Kitfile for the current directory:
+kit init .
+
+# Generate a Kitfile for files in ./my-model, with name "mymodel" and a description:
+kit init ./my-model --name "mymodel" --desc "This is my model's description"`
+)
+
+type initOptions struct {
+	path       string
+	configHome string
+}
+
+func InitCommand() *cobra.Command {
+	opts := &initOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "init [flags] PATH",
+		Short:   shortDesc,
+		Long:    longDesc,
+		Example: example,
+		RunE:    runCommand(opts),
+		Args:    cobra.ExactArgs(1),
+	}
+
+	return cmd
+}
+
+func runCommand(opts *initOptions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := opts.complete(cmd.Context(), args); err != nil {
+			return output.Fatalf("Invalid arguments: %s", err)
+		}
+
+		kitfile, err := kitfile.GenerateKitfile(opts.path, nil)
+		if err != nil {
+			return output.Fatalf("Error generating Kitfile: %s", err)
+		}
+		bytes, err := kitfile.MarshalToYAML()
+		if err != nil {
+			return output.Fatalf("Error formatting Kitfile: %s", err)
+		}
+		kitfilePath := filepath.Join(opts.path, constants.DefaultKitfileName)
+		if err := os.WriteFile(kitfilePath, bytes, 0644); err != nil {
+			return output.Fatalf("Failed to write Kitfile: %s", err)
+		}
+		output.Infof("Generated Kitfile:\n\n%s", string(bytes))
+		output.Infof("Saved to path '%s'", kitfilePath)
+		return nil
+	}
+}
+
+func (opts *initOptions) complete(ctx context.Context, args []string) error {
+	configHome, ok := ctx.Value(constants.ConfigKey{}).(string)
+	if !ok {
+		return fmt.Errorf("default config path not set on command context")
+	}
+	opts.configHome = configHome
+	opts.path = args[0]
+
+	return nil
+}

--- a/pkg/cmd/login/cmd.go
+++ b/pkg/cmd/login/cmd.go
@@ -17,20 +17,18 @@
 package login
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"os"
 	"strings"
-	"syscall"
 
 	"kitops/pkg/cmd/options"
 	"kitops/pkg/lib/constants"
+	"kitops/pkg/lib/util"
 	"kitops/pkg/output"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
@@ -122,12 +120,12 @@ func (opts *loginOptions) complete(ctx context.Context, args []string) error {
 		// Prompt for password (and username, if necessary)
 		var err error
 		if username == "" {
-			username, err = promptForInput("Username: ", false)
+			username, err = util.PromptForInput("Username: ", false)
 			if err != nil {
 				return err
 			}
 		}
-		password, err = promptForInput("Password: ", true)
+		password, err = util.PromptForInput("Password: ", true)
 		if err != nil {
 			return err
 		}
@@ -158,25 +156,4 @@ func readPasswordFromStdin() (string, error) {
 		return "", fmt.Errorf("failed to read password from standard input")
 	}
 	return strings.TrimSpace(string(passwd)), err
-}
-
-func promptForInput(prompt string, isSensitive bool) (string, error) {
-	var bytes []byte
-	var err error
-	if !term.IsTerminal(int(syscall.Stdin)) {
-		return "", fmt.Errorf("attempting to read input from non-terminal")
-	}
-
-	fmt.Print(prompt)
-	if isSensitive {
-		bytes, err = term.ReadPassword(int(syscall.Stdin))
-		fmt.Print("\n")
-	} else {
-		reader := bufio.NewReader(os.Stdin)
-		bytes, err = reader.ReadBytes('\n')
-	}
-	if err != nil {
-		return "", fmt.Errorf("failed to read input: %w", err)
-	}
-	return strings.TrimSpace(string(bytes)), nil
 }

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -60,6 +60,15 @@ func DefaultKitfileNames() []string {
 	return []string{"Kitfile", "kitfile", ".kitfile"}
 }
 
+func IsDefaultKitfileName(filename string) bool {
+	for _, name := range DefaultKitfileNames() {
+		if name == filename {
+			return true
+		}
+	}
+	return false
+}
+
 // DefaultConfigPath returns the default configuration and cache directory for the CLI.
 // This is platform-dependent, using
 //   - $XDG_DATA_HOME/kitops on Linux, with fall back to $HOME/.local/share/kitops

--- a/pkg/lib/kitfile/generate.go
+++ b/pkg/lib/kitfile/generate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/fs"
 	"kitops/pkg/artifact"
+	"kitops/pkg/lib/constants"
 	"kitops/pkg/output"
 	"os"
 	"path/filepath"
@@ -91,6 +92,11 @@ func GenerateKitfile(baseDir string, packageOpt *artifact.Package) (*artifact.Ki
 	var detectedLicenseType string
 	for _, d := range ds {
 		filename := d.Name()
+		if constants.IsDefaultKitfileName(filename) {
+			// Skip Kitfile files (if present in the directory...). These won't be packed
+			// either way.
+			continue
+		}
 		if d.IsDir() {
 			dirModelFiles, err := addDirToKitfile(kitfile, filename, d)
 			if err != nil {

--- a/pkg/lib/kitfile/generate.go
+++ b/pkg/lib/kitfile/generate.go
@@ -96,7 +96,7 @@ func GenerateKitfile(baseDir string, packageOpt *artifact.Package) (*artifact.Ki
 				Description: "Readme file",
 			})
 			continue
-		} else if strings.ToLower(name) == "license" {
+		} else if strings.HasPrefix(strings.ToLower(name), "license") {
 			kitfile.Docs = append(kitfile.Docs, artifact.Docs{
 				Path:        name,
 				Description: "License file",

--- a/pkg/lib/kitfile/generate.go
+++ b/pkg/lib/kitfile/generate.go
@@ -101,7 +101,7 @@ func GenerateKitfile(baseDir string, packageOpt *artifact.Package) (*artifact.Ki
 			continue
 		}
 		if d.IsDir() {
-			dirModelFiles, err := addDirToKitfile(kitfile, filename, d)
+			dirModelFiles, err := addDirToKitfile(kitfile, baseDir, filename, d)
 			if err != nil {
 				output.Logf(output.LogLevelTrace, "Failed to determine type for directory %s: %s", filename, err)
 				unprocessedDirPaths = append(unprocessedDirPaths, filename)
@@ -199,7 +199,7 @@ func GenerateKitfile(baseDir string, packageOpt *artifact.Package) (*artifact.Ki
 	return kitfile, nil
 }
 
-func addDirToKitfile(kitfile *artifact.KitFile, dirPath string, d fs.DirEntry) (modelFiles []string, err error) {
+func addDirToKitfile(kitfile *artifact.KitFile, baseDir, dirPath string, d fs.DirEntry) (modelFiles []string, err error) {
 	switch d.Name() {
 	case "docs":
 		output.Logf(output.LogLevelTrace, "Directory %s interpreted as documentation", d.Name())
@@ -215,7 +215,7 @@ func addDirToKitfile(kitfile *artifact.KitFile, dirPath string, d fs.DirEntry) (
 		return nil, nil
 	}
 
-	entries, err := os.ReadDir(dirPath)
+	entries, err := os.ReadDir(filepath.Join(baseDir, dirPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read directory %s: %w", dirPath, err)
 	}
@@ -313,7 +313,7 @@ func addModelToKitfile(kitfile *artifact.KitFile, baseDir string, modelPaths []s
 	largestSize := int64(0)
 	averageSize := int64(0)
 	for _, modelFile := range modelPaths {
-		info, err := os.Stat(modelFile)
+		info, err := os.Stat(filepath.Join(baseDir, modelFile))
 		if err != nil {
 			return fmt.Errorf("failed to process file %s: %w", filepath.Join(baseDir, modelFile), err)
 		}

--- a/pkg/lib/kitfile/generate.go
+++ b/pkg/lib/kitfile/generate.go
@@ -1,0 +1,242 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitfile
+
+import (
+	"fmt"
+	"io/fs"
+	"kitops/pkg/artifact"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var modelWeightsSuffixes = []string{
+	".safetensors", ".pkl",
+	// Pytorch suffixes
+	".bin", ".pth", ".pt", ".mar", ".pt2", ".ptl",
+	// Tensorflow
+	".pb", ".ckpt", ".tflite", ".tfrecords",
+	// NumPy
+	".npy", ".npz",
+	// Keras and others
+	".keras", ".h5", ".caffemodel", ".pmml", ".coreml",
+	// Other suffixes
+	".gguf", ".ggml", ".ggmf", ".llamafile", ".onnx",
+}
+
+var docsSuffixes = []string{
+	".md", ".adoc", ".html", ".pdf",
+}
+
+var metadataSuffixes = []string{
+	".json", ".yaml", ".xml", ".csv", ".txt",
+}
+
+var datasetSuffixes = []string{
+	".tar", ".zip",
+}
+
+// Generate a basic Kitfile by looking at the contents of a directory. Parameter
+// packageOpt can be used to define metadata for the Kitfile (i.e. the package
+// section), which is left empty if the parameter is nil.
+func GenerateKitfile(baseDir string, packageOpt *artifact.Package) (*artifact.KitFile, error) {
+	kitfile := &artifact.KitFile{
+		ManifestVersion: "1.0.0",
+	}
+	if packageOpt != nil {
+		kitfile.Package = *packageOpt
+	}
+
+	ds, err := os.ReadDir(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("error reading directory: %w", err)
+	}
+	// We can make sure all files are included by including a layer with path '.'
+	// However, we only want to do this if it is necessary
+	includeCatchallSection := false
+	// Dirs we don't know how to handle automatically.
+	var unprocessedDirPaths []string
+	// Metadata files; we want these to be either model parts (if there is a model)
+	// or datasets
+	var metadataPaths []string
+	var modelFiles []fs.DirEntry
+	for _, d := range ds {
+		name := d.Name()
+		path := filepath.Join(baseDir, name)
+		if d.IsDir() {
+			err := addDirToKitfile(kitfile, path, d)
+			if err != nil {
+				unprocessedDirPaths = append(unprocessedDirPaths, path)
+			}
+			continue
+		}
+
+		// Check for "special" files (e.g. readme, license)
+		if strings.HasPrefix(strings.ToLower(path), "readme") {
+			kitfile.Docs = append(kitfile.Docs, artifact.Docs{
+				Path:        path,
+				Description: "Readme file",
+			})
+			continue
+		} else if strings.ToLower(path) == "license" {
+			kitfile.Docs = append(kitfile.Docs, artifact.Docs{
+				Path:        path,
+				Description: "License file",
+			})
+			// TODO: Determine license type automatically
+			continue
+		}
+
+		// Try to determine type based on file extension
+		// To support multi-part models, we need to collect all paths and decide
+		// which one is the model and which one(s) are parts
+		if anySuffix(name, modelWeightsSuffixes) {
+			modelFiles = append(modelFiles, d)
+			continue
+		}
+		// Metadata should be included in either Model or Datasets, depending on
+		// other contents
+		if anySuffix(name, metadataSuffixes) {
+			metadataPaths = append(metadataPaths, path)
+			continue
+		}
+		if anySuffix(name, docsSuffixes) {
+			kitfile.Docs = append(kitfile.Docs, artifact.Docs{Path: path})
+			continue
+		}
+		if anySuffix(name, datasetSuffixes) {
+			kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: path})
+			continue
+		}
+
+		// We don't know what this file is; we'll include it in a catch-all section
+		includeCatchallSection = true
+	}
+
+	if len(modelFiles) > 0 {
+		addModelToKitfile(kitfile, baseDir, modelFiles)
+		for _, metadataPath := range metadataPaths {
+			kitfile.Model.Parts = append(kitfile.Model.Parts, artifact.ModelPart{Path: metadataPath})
+		}
+	} else {
+		for _, metadataPath := range metadataPaths {
+			kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: metadataPath})
+		}
+	}
+
+	// Decide how to handle remaining paths. Either package them in one large code layer with basePath
+	// or as separate layers for each directory.
+	if includeCatchallSection || len(unprocessedDirPaths) > 5 {
+		// Overwrite any code layers we added before; this is cleaner than e.g. having a layer for '.' and a layer for 'src'
+		kitfile.Code = []artifact.Code{{Path: baseDir}}
+	} else {
+		for _, path := range unprocessedDirPaths {
+			kitfile.Code = append(kitfile.Code, artifact.Code{Path: path})
+		}
+	}
+
+	return kitfile, nil
+}
+
+func addDirToKitfile(kitfile *artifact.KitFile, path string, d fs.DirEntry) error {
+	// TODO: consider looking into directories to see if we can figure out what they store? Might work for datasets
+	switch d.Name() {
+	case "docs":
+		kitfile.Docs = append(kitfile.Docs, artifact.Docs{
+			Path: path,
+		})
+	case "src", "pkg", "lib", "build":
+		kitfile.Code = append(kitfile.Code, artifact.Code{
+			Path: path,
+		})
+	default:
+		return fmt.Errorf("could not determine data type for directory")
+	}
+	return nil
+}
+
+func addModelToKitfile(kitfile *artifact.KitFile, baseDir string, modelFiles []fs.DirEntry) error {
+	if len(modelFiles) == 0 {
+		return nil
+	}
+
+	if len(modelFiles) == 1 {
+		filename := modelFiles[0].Name()
+		kitfile.Model = &artifact.Model{
+			Path: filename,
+			Name: strings.TrimSuffix(filename, filepath.Ext(filename)),
+		}
+		return nil
+	}
+
+	// We'll handle two cases here: 1) the Model is split into multiple files (e.g. safetensors) or 2) there is a
+	// main model plus smaller adaptor(s)
+	largestFile := ""
+	largestSize := int64(0)
+	averageSize := int64(0)
+	for _, modelFile := range modelFiles {
+		info, err := modelFile.Info()
+		if err != nil {
+			return fmt.Errorf("failed to process file %s: %w", filepath.Join(baseDir, modelFile.Name()), err)
+		}
+		size := info.Size()
+		if size > largestSize {
+			largestSize = size
+			largestFile = modelFile.Name()
+		}
+		averageSize = averageSize + size
+	}
+	// Integer division is probably fine here; at most we're off by a byte.
+	averageSize = averageSize / int64(len(modelFiles))
+
+	// If the biggest file is 1.5x the average, make it the model and the rest parts; otherwise, add
+	// all parts in lexical order
+	if largestSize > averageSize+(averageSize/2) {
+		kitfile.Model = &artifact.Model{
+			Path: filepath.Join(baseDir, largestFile),
+		}
+		kitfile.Model.Name = strings.TrimSuffix(largestFile, filepath.Ext(largestFile))
+		for _, modelFile := range modelFiles {
+			if modelFile.Name() == largestFile {
+				continue
+			}
+			kitfile.Model.Parts = append(kitfile.Model.Parts, artifact.ModelPart{
+				Path: filepath.Join(baseDir, modelFile.Name()),
+			})
+		}
+	} else {
+		kitfile.Model = &artifact.Model{
+			Path: filepath.Join(baseDir, modelFiles[0].Name()),
+		}
+		for _, modelFile := range modelFiles[1:] {
+			kitfile.Model.Parts = append(kitfile.Model.Parts, artifact.ModelPart{
+				Path: filepath.Join(baseDir, modelFile.Name()),
+			})
+		}
+	}
+	return nil
+}
+
+func anySuffix(query string, suffixes []string) bool {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(query, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/lib/kitfile/generate.go
+++ b/pkg/lib/kitfile/generate.go
@@ -29,7 +29,7 @@ import (
 )
 
 var modelWeightsSuffixes = []string{
-	".safetensors", ".pkl",
+	".safetensors", ".pkl", ".joblib",
 	// Pytorch suffixes
 	".bin", ".pth", ".pt", ".mar", ".pt2", ".ptl",
 	// Tensorflow
@@ -47,11 +47,11 @@ var docsSuffixes = []string{
 }
 
 var metadataSuffixes = []string{
-	".json", ".yaml", ".xml", ".csv", ".txt",
+	".json", ".yaml", ".xml", ".txt",
 }
 
 var datasetSuffixes = []string{
-	".tar", ".zip",
+	".tar", ".zip", ".parquet", ".csv",
 }
 
 // Generate a basic Kitfile by looking at the contents of a directory. Parameter

--- a/pkg/lib/util/input.go
+++ b/pkg/lib/util/input.go
@@ -1,0 +1,50 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"golang.org/x/term"
+)
+
+// PromptForInput prints the provided prompt and reads a line of input from stdin.
+// If isSensitive is true, input is treated as a password (i.e. not printed)
+func PromptForInput(prompt string, isSensitive bool) (string, error) {
+	var bytes []byte
+	var err error
+	if !term.IsTerminal(int(syscall.Stdin)) {
+		return "", fmt.Errorf("attempting to read input from non-terminal")
+	}
+
+	fmt.Print(prompt)
+	if isSensitive {
+		bytes, err = term.ReadPassword(int(syscall.Stdin))
+		fmt.Print("\n")
+	} else {
+		reader := bufio.NewReader(os.Stdin)
+		bytes, err = reader.ReadBytes('\n')
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+	return strings.TrimSpace(string(bytes)), nil
+}


### PR DESCRIPTION
### Description
Add `kit init` command, that can be used to generate a basic Kitfile from the contents of a directory. It basically does this by looking at files and trying to guess what they might be, based on file extensions.

I've tested it against a few hand-written Kitfiles and (modulo user-provided metadata) it does an okay job :)

### Linked issues
Closes https://github.com/jozu-ai/kitops/issues/124
Related: https://github.com/jozu-ai/kitops/issues/564
