### PR TITLE
Allow specifying a separate target reference to push in `kit push`

### DIFF
--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -33,16 +33,19 @@ import (
 
 const (
 	shortDesc = `Upload a modelkit to a specified registry`
-	longDesc  = `This command pushes modelkits to a remote registry.
+	longDesc  = `This command pushes modelkits from local storage to a remote registry.
 
-The modelkits should be tagged with the target registry and repository before
-they can be pushed`
+If specified without a destination, the ModelKit must be tagged locally before
+pushing.`
 
-	example = `# Push the latest modelkits to a remote registry
-kit push registry.example.com/my-model:latest
+	example = `# Push the ModelKit tagged 'latest' to a remote registry
+kit push registry.example.com/my-org/my-model:latest
 
-# Push a specific version of a modelkits using a tag:
-kit push registry.example.com/my-model:1.0.0`
+# Push a ModelKit to a remote registry by digest
+kit push registry.example.com/my-org/my-model@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+
+# Push local modelkit 'mymodel:1.0.0' to a remote registry
+kit push mymodel:1.0.0 registry.example.com/my-org/my-model:latest`
 )
 
 type pushOptions struct {
@@ -94,7 +97,7 @@ func (opts *pushOptions) complete(ctx context.Context, args []string) error {
 func PushCommand() *cobra.Command {
 	opts := &pushOptions{}
 	cmd := &cobra.Command{
-		Use:     "push [flags] registry/repository[:tag|@digest] [registry/repository[:tag|@digest]]",
+		Use:     "push [flags] SOURCE [DESTINATION]",
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: example,

--- a/pkg/cmd/push/push.go
+++ b/pkg/cmd/push/push.go
@@ -30,10 +30,11 @@ import (
 
 func PushModel(ctx context.Context, localRepo local.LocalRepo, repo registry.Repository, opts *pushOptions) (ocispec.Descriptor, error) {
 	trackedRepo, logger := output.WrapTarget(repo)
-	ref := opts.modelRef.Reference
+	srcTag := opts.srcModelRef.Reference
+	destTag := opts.destModelRef.Reference
 	copyOpts := oras.CopyOptions{}
 	copyOpts.Concurrency = opts.Concurrency
-	desc, err := oras.Copy(ctx, localRepo, ref, trackedRepo, ref, copyOpts)
+	desc, err := oras.Copy(ctx, localRepo, srcTag, trackedRepo, destTag, copyOpts)
 	if err != nil {
 		return ocispec.DescriptorEmptyJSON, fmt.Errorf("failed to copy to remote: %w", err)
 	}


### PR DESCRIPTION
### Description
Allow specifying a separate push target, so that you don't _have_ to tag ModelKits locally before pushing (similar to what podman--but not docker--does).

* Push locally-tagged image to remote (same as what we currently do): 
  ```
  kit push registry.example.com/myorg/mymodel:mytag
  ```
* Push a local image to the same remote without tagging first
  ```
  kit push localmodel:latest registry.example.com/myorg/mymodel:mytag
  ```

### Linked issues
I didn't create an issue for this one yet, but I figured it'd be useful while working on https://github.com/jozu-ai/kitops/pull/684, which by default tags according to the HF repo
