### PR TITLE
Install git and git-lfs in default kitops images

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -21,9 +21,13 @@ ENV USER_ID=1001 \
     HOME=/home/user/
 
 RUN apk --no-cache upgrade && \
-    apk add --no-cache bash && \
+    apk add --no-cache bash git git-lfs && \
+    git-lfs install --system && \
     mkdir -p /home/user/ && \
     adduser -D $USER_NAME -h $HOME -u $USER_ID
+
+# Editor env var is required for kit import
+ENV EDITOR=vi
 
 USER ${USER_ID}
 

--- a/build/dockerfiles/release.Dockerfile
+++ b/build/dockerfiles/release.Dockerfile
@@ -34,9 +34,13 @@ ENV USER_ID=1001 \
     HOME=/home/user/
 
 RUN apk --no-cache upgrade && \
-    apk add --no-cache bash && \
+    apk add --no-cache git git-lfs && \
+    git-lfs install --system && \
     mkdir -p /home/user/ && \
     adduser -D $USER_NAME -h $HOME -u $USER_ID
+
+# Editor env var is required for kit import
+ENV EDITOR=vi
 
 COPY --from=kit-download /kit-cli-download/extracted/kit /usr/local/bin/kit
 COPY --from=kit-download /kit-cli-download/extracted/README.md /kit-cli-download/extracted/LICENSE /


### PR DESCRIPTION
### Description
Add git and git-lfs to kitops images to support https://github.com/jozu-ai/kitops/pull/684. This increases the image size from 36MB to 74MB.

### Linked issues
Related: #564 
