### PR TITLE
Fixups for `kit import`

### DIFF
--- a/pkg/lib/git/clone.go
+++ b/pkg/lib/git/clone.go
@@ -48,6 +48,7 @@ func CloneRepository(repo, dest, token string) error {
 	} else {
 		// This is a workaround to disable interactive password prompts
 		cloneEnv = append(cloneEnv, "GIT_ASKPASS=true")
+		cloneEnv = append(cloneEnv, "GIT_TERMINAL_PROMPT=0")
 	}
 
 	// Clone without LFS enabled to get metadata about repo first


### PR DESCRIPTION
### Description
Fix a couple of minor bugs in `kit import`, mostly impacting Windows:

* Cleaning up the temporary directory we use for storing files before they're packed fails because it's our current working directory
* Users still see a password prompt for repositories requiring a token, since windows does not have a `true` binary

### Linked issues
N/A
