### PR TITLE
Update documentation for Kit import

### DIFF
--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -80,7 +80,6 @@ Start development server (experimental) from a modelkit
 Start a development server for an unpacked modelkit, using a context directory
 that includes the model and a kitfile.
 
-
 ```
 kit dev start <directory> [flags]
 ```
@@ -147,9 +146,15 @@ Import a model from HuggingFace
 ### Synopsis
 
 Download a repository from HuggingFace and package it as a ModelKit.
-	
-The repository will be downloaded to a temporary directory and be packaged using a
-generated Kitfile.
+
+The repository can be specified either via a repository (e.g. myorg/myrepo) or
+with a full URL (https://huggingface.co/myorg/myrepo). The repository will be
+downloaded to a temporary directory and be packaged using a generated Kitfile.
+
+In interactive settings, this command will read the EDITOR environment variable
+to determine which editor should be used for editing the Kitfile.
+
+Note: importing repositories requires 'git' and 'git-lfs' to be installed.
 
 ```
 kit import [flags] REPOSITORY
@@ -158,11 +163,11 @@ kit import [flags] REPOSITORY
 ### Examples
 
 ```
-# Download repository myorg/myrepo and package it, using the default tag
+# Download repository myorg/myrepo and package it, using the default tag (myorg/myrepo:latest)
 kit import myorg/myrepo
 
-# Download repository and tag it 'myrepository:latest'
-kit import myorg/myrepo --tag myrepository:latest
+# Download repository and tag it 'myrepository:mytag'
+kit import myorg/myrepo --tag myrepository:mytag
 ```
 
 ### Options

--- a/pkg/cmd/kitimport/cmd.go
+++ b/pkg/cmd/kitimport/cmd.go
@@ -30,15 +30,21 @@ import (
 const (
 	shortDesc = `Import a model from HuggingFace`
 	longDesc  = `Download a repository from HuggingFace and package it as a ModelKit.
-	
-The repository will be downloaded to a temporary directory and be packaged using a
-generated Kitfile.`
 
-	example = `# Download repository myorg/myrepo and package it, using the default tag
+The repository can be specified either via a repository (e.g. myorg/myrepo) or
+with a full URL (https://huggingface.co/myorg/myrepo). The repository will be
+downloaded to a temporary directory and be packaged using a generated Kitfile.
+
+In interactive settings, this command will read the EDITOR environment variable
+to determine which editor should be used for editing the Kitfile.
+
+Note: importing repositories requires 'git' and 'git-lfs' to be installed.`
+
+	example = `# Download repository myorg/myrepo and package it, using the default tag (myorg/myrepo:latest)
 kit import myorg/myrepo
 
-# Download repository and tag it 'myrepository:latest'
-kit import myorg/myrepo --tag myrepository:latest`
+# Download repository and tag it 'myrepository:mytag'
+kit import myorg/myrepo --tag myrepository:mytag`
 )
 
 var repoToTagRegexp = regexp.MustCompile(`^.*?([0-9A-Za-z_-]+/[0-9A-Za-z_-]+)[^/]*$`)


### PR DESCRIPTION
### Description
Update docs for kit import:

* Clarify how repositories can be specified (org/repo or full URL)
* Add note about git and git-lfs requirement
* Add note about `$EDITOR` environment variable

This PR also updates the cli-reference doc (which normally only happens during a release) to pick up the changes sooner.

### Linked issues
Closes #710
Related to #708
