### PR TITLE
Ensure we don't store duplicate manifests in the index

### DIFF
--- a/pkg/lib/repo/local/repository.go
+++ b/pkg/lib/repo/local/repository.go
@@ -87,6 +87,16 @@ func (li *localIndex) save() error {
 		return nil
 	}
 
+	seenDigests := map[digest.Digest]bool{}
+	var uniqueManifests []ocispec.Descriptor
+	for _, desc := range li.Manifests {
+		if !seenDigests[desc.Digest] {
+			uniqueManifests = append(uniqueManifests, desc)
+		}
+		seenDigests[desc.Digest] = true
+	}
+	li.Manifests = uniqueManifests
+
 	indexJson, err := json.Marshal(li.Index)
 	if err != nil {
 		return fmt.Errorf("failed to marshal index: %w", err)

--- a/pkg/lib/repo/local/repository.go
+++ b/pkg/lib/repo/local/repository.go
@@ -61,7 +61,9 @@ func newLocalIndex(storagePath, repoName string) (*localIndex, error) {
 func (li *localIndex) addManifest(manifestDesc ocispec.Descriptor) error {
 	curTag := manifestDesc.Annotations[ocispec.AnnotationRefName]
 	delete(manifestDesc.Annotations, ocispec.AnnotationRefName)
-	li.Manifests = append(li.Manifests, manifestDesc)
+	if !li.exists(manifestDesc) {
+		li.Manifests = append(li.Manifests, manifestDesc)
+	}
 	if err := li.save(); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
Avoid accidentally adding the same manifest multiple times to the local storage index. Previously, the addManifest method would not check if the manifest was already saved, leading to duplicated entries.

### Reproducer
`kit pull` the same ModelKit multiple times (previously, would result in multiple identical lines in `kit list`)

### Linked issues
closes #730 
