### PR TITLE
Add `--file` flag to kit import to allow using existing Kitfiles

### DIFF
--- a/pkg/cmd/kitimport/cmd.go
+++ b/pkg/cmd/kitimport/cmd.go
@@ -44,16 +44,20 @@ Note: importing repositories requires 'git' and 'git-lfs' to be installed.`
 kit import myorg/myrepo
 
 # Download repository and tag it 'myrepository:mytag'
-kit import myorg/myrepo --tag myrepository:mytag`
+kit import myorg/myrepo --tag myrepository:mytag
+
+# Download repository and pack it using an existing Kitfile
+kit import myorg/myrepo --file ./path/to/Kitfile`
 )
 
 var repoToTagRegexp = regexp.MustCompile(`^.*?([0-9A-Za-z_-]+/[0-9A-Za-z_-]+)[^/]*$`)
 
 type importOptions struct {
-	repo       string
-	configHome string
-	tag        string
-	token      string
+	configHome  string
+	repo        string
+	tag         string
+	token       string
+	kitfilePath string
 }
 
 func ImportCommand() *cobra.Command {
@@ -70,6 +74,7 @@ func ImportCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.token, "token", "", "Token to use for authenticating with repository")
 	cmd.Flags().StringVarP(&opts.tag, "tag", "t", "", "Tag for the ModelKit (default is '[repository]:latest')")
+	cmd.Flags().StringVarP(&opts.kitfilePath, "file", "f", "", "Path to Kitfile to use for packing")
 	cmd.Flags().SortFlags = false
 	return cmd
 }

--- a/pkg/cmd/kitimport/cmd.go
+++ b/pkg/cmd/kitimport/cmd.go
@@ -74,7 +74,7 @@ func ImportCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.token, "token", "", "Token to use for authenticating with repository")
 	cmd.Flags().StringVarP(&opts.tag, "tag", "t", "", "Tag for the ModelKit (default is '[repository]:latest')")
-	cmd.Flags().StringVarP(&opts.kitfilePath, "file", "f", "", "Path to Kitfile to use for packing")
+	cmd.Flags().StringVarP(&opts.kitfilePath, "file", "f", "", "Path to Kitfile to use for packing (use '-' to read from standard input)")
 	cmd.Flags().SortFlags = false
 	return cmd
 }

--- a/pkg/cmd/kitimport/kitimport.go
+++ b/pkg/cmd/kitimport/kitimport.go
@@ -70,9 +70,16 @@ func doImport(ctx context.Context, opts *importOptions) error {
 		return err
 	}
 
-	// Check on the off-chance a Kitfile already exists
 	var kitfile *artifact.KitFile
-	if opts.kitfilePath != "" {
+	if opts.kitfilePath == "-" {
+		kitfile = &artifact.KitFile{}
+		if err := kitfile.LoadModel(os.Stdin); err != nil {
+			return fmt.Errorf("failed to read Kitfile from input: %w", err)
+		}
+		if err := kfutils.ValidateKitfile(kitfile); err != nil {
+			return err
+		}
+	} else if opts.kitfilePath != "" {
 		kf, err := readExistingKitfile(opts.kitfilePath)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Description
Add flag `--file` (`-f`) to kit import, with the same semantics as for kit push:

* `--file <path>` to use an existing Kitfile for the imported repository
* `--file -` to use a Kitfile from standard input (e.g. piped in) 

### Linked issues
N/A