### PR TITLE
Fixes 404's

### DIFF
--- a/docs/src/docs/cli/installation.md
+++ b/docs/src/docs/cli/installation.md
@@ -33,7 +33,7 @@ kit version
 
 This command should display the version number of the Kit CLI you have installed, indicating that the installation was successful.
 
-Now follow our [Quick Start](/docs/get-started.md) to learn how to pack and share your first ModelKit.
+Now follow our [Quick Start](../../get-started/) to learn how to pack and share your first ModelKit.
 
 **Need Help?** If something isn't working [get help on our Discord channel](https://discord.gg/Tapeh8agYy).
 
@@ -73,7 +73,7 @@ kit version
 
 This command should display the version number of the Kit CLI you have installed, indicating that the installation was successful.
 
-Now follow our [Quick Start](../get-started.md) to learn how to pack and share your first ModelKit.
+Now follow our [Quick Start](../../get-started/) to learn how to pack and share your first ModelKit.
 
 **Need Help?** If something isn't working [get help on our Discord channel](https://discord.gg/Tapeh8agYy).
 
@@ -122,7 +122,7 @@ kit version
 
 This command should display the version number of the Kit CLI you have installed, indicating that the installation was successful.
 
-Now follow our [Quick Start](../get-started.md) to learn how to pack and share your first ModelKit.
+Now follow our [Quick Start](../../get-started/) to learn how to pack and share your first ModelKit.
 
 **Need Help?** If something isn't working [get help on our Discord channel](https://discord.gg/Tapeh8agYy).
 
@@ -144,7 +144,7 @@ kit version
 
 This command should display the version number of the Kit CLI you have installed, indicating that the installation was successful.
 
-Now follow our [Quick Start](../get-started.md) to learn how to pack and share your first ModelKit.
+Now follow our [Quick Start](../../get-started/) to learn how to pack and share your first ModelKit.
 
 **Need Help?** If something isn't working [get help on our Discord channel](https://discord.gg/Tapeh8agYy).
 
@@ -203,7 +203,7 @@ kit version
 
 This command should display the version number of the Kit CLI you have installed, indicating that the installation was successful.
 
-Now follow our [Quick Start](../get-started.md) to learn how to pack and share your first ModelKit.
+Now follow our [Quick Start](../../get-started/) to learn how to pack and share your first ModelKit.
 
 **Need Help?** If something isn't working [get help on our Discord channel](https://discord.gg/Tapeh8agYy).
 
@@ -272,17 +272,17 @@ If the `KITOPS_HOME` is set in various places the order of precedence is:
 1. `--config` flag, if specified
 1. `$KITOPS_HOME` environment variable, if set
 1. A default OS-dependent value:
-    
+
     Linux: `$XDG_DATA_HOME/kitops`, falling back to `~/.local/share/kitops`
-    
+
     Windows: `%LOCALAPPDATA%\kitops`
-    
+
     Darwin: `~/Library/Caches/kitops`
 
 
 ## Follow the Quick Start
 
-Now that everything is set up you can follow our [Quick Start](../get-started.md) to learn how to pack and share your first ModelKit.
+Now that everything is set up you can follow our [Quick Start](../../get-started/) to learn how to pack and share your first ModelKit.
 
 ## Become a Design Partner
 

--- a/docs/src/docs/deploy.md
+++ b/docs/src/docs/deploy.md
@@ -17,7 +17,7 @@ The container is configurable via environment variables:
 
 `$MODELKIT_REF`: The ModelKit to pull (required).
 `$UNPACK_PATH`: Where to unpack the ModelKit (normally you’d want a `volumeMount` here). This is required and will default to `/home/user/modelkit`.
-`$UNPACK_FILTER`: Optional filter to limit what is unpacked (e.g., just the model, or model + code). The filter format is the same as the [--filter command line argument](../cli/cli-reference.md) for the Kit CLI.
+`$UNPACK_FILTER`: Optional filter to limit what is unpacked (e.g., just the model, or model + code). The filter format is the same as the [--filter command line argument](../cli/cli-reference/) for the Kit CLI.
 `$COSIGN_KEY`: Path to the key that should be used for verification, mounted inside the init container (e.g., from a Kubernetes secret).
 `$COSIGN_CERT_IDENTITY`: Signing identity for keyless signing.
 `$COSIGN_CERT_OIDC_ISSUER`: OIDC issuer for keyless signer identity.

--- a/docs/src/docs/deploy.md
+++ b/docs/src/docs/deploy.md
@@ -17,7 +17,7 @@ The container is configurable via environment variables:
 
 `$MODELKIT_REF`: The ModelKit to pull (required).
 `$UNPACK_PATH`: Where to unpack the ModelKit (normally you’d want a `volumeMount` here). This is required and will default to `/home/user/modelkit`.
-`$UNPACK_FILTER`: Optional filter to limit what is unpacked (e.g., just the model, or model + code). The filter format is the same as the [--filter command line argument](./cli/cli-reference.md) for the Kit CLI.
+`$UNPACK_FILTER`: Optional filter to limit what is unpacked (e.g., just the model, or model + code). The filter format is the same as the [--filter command line argument](../cli/cli-reference.md) for the Kit CLI.
 `$COSIGN_KEY`: Path to the key that should be used for verification, mounted inside the init container (e.g., from a Kubernetes secret).
 `$COSIGN_CERT_IDENTITY`: Signing identity for keyless signing.
 `$COSIGN_CERT_OIDC_ISSUER`: OIDC issuer for keyless signer identity.

--- a/docs/src/docs/dev-mode.md
+++ b/docs/src/docs/dev-mode.md
@@ -16,7 +16,7 @@ Now unpack an LLM ModelKit - there are several on [Jozu Hub](https://jozu.ml/dis
 kit unpack jozu.ml/jozu/phi3:3.8b-mini-instruct-4k-q4_K_M
 ```
 
-Now start your LLM dev server locally using the [kit dev start command](./cli/cli-reference.md#kit-dev-start):
+Now start your LLM dev server locally using the [kit dev start command](../cli/cli-reference/#kit-dev-start):
 
 ```sh
 kit dev start .
@@ -24,7 +24,7 @@ kit dev start .
 
 In the command output you'll see a URL you can use to interact with the LLM (there's a command flag to always use the same port). You can control parameters of the model, change the prompt, or chat with the LLM.
 
-If you need to get logs use the [dev logs command](./cli/cli-reference.md#kit-dev-logs):
+If you need to get logs use the [dev logs command](../cli/cli-reference/#kit-dev-logs):
 
 ```sh
 kit dev logs

--- a/docs/src/docs/get-started.md
+++ b/docs/src/docs/get-started.md
@@ -12,24 +12,24 @@ In this guide, we'll use ModelKits and the kit CLI to easily:
 
 ## Before we start...
 
-1. Make sure you've got the [Kit CLI setup](./cli/installation.md).
+1. Make sure you've got the [Kit CLI setup](../cli/installation/).
 2. Create and navigate to a new folder on your filesystem - we suggest calling it `KitStart` but any name works.
 
 ## Learning to use the CLI
 
 ### 1/ Check your CLI Version
 
-Check that the Kit CLI is properly installed by using the [version command](./cli/cli-reference.md#kit-version).
+Check that the Kit CLI is properly installed by using the [version command](../cli/cli-reference/#kit-version).
 
 ```sh
 kit version
 ```
 
-You'll see information about the version of Kit you're running. If you get an error check to make sure you have [Kit installed and in your path](./cli/installation.md).
+You'll see information about the version of Kit you're running. If you get an error check to make sure you have [Kit installed and in your path](../cli/installation/).
 
 ### 2/ Login to Your Registry
 
-You can use the [login command](./cli/cli-reference.md#kit-login) to authenticate with any OCI v1.1-compatible container registry - local or remote (you can see our [list of compliant registries](./modelkit/compatibility.md)). In this guide, we'll use the [Jozu Hub](https://jozu.ml/) because it's free to sign-up and provides more detail on what's inside each ModelKit like whether it's signed or has provenance. You can substitute your own repository if preferred.
+You can use the [login command](../cli/cli-reference/#kit-login) to authenticate with any OCI v1.1-compatible container registry - local or remote (you can see our [list of compliant registries](../modelkit/compatibility/)). In this guide, we'll use the [Jozu Hub](https://jozu.ml/) because it's free to sign-up and provides more detail on what's inside each ModelKit like whether it's signed or has provenance. You can substitute your own repository if preferred.
 
 ```sh
 kit login jozu.ml
@@ -39,9 +39,9 @@ After entering your username and password, you'll see `Log in successful`. If yo
 
 ### 3/ Get a Sample ModelKit
 
-You can get started using one of our sample ModelKits (covered below), or you can [import a ModelKit from Hugging Face](./hf-import.md).
+You can get started using one of our sample ModelKits (covered below), or you can [import a ModelKit from Hugging Face](../hf-import/).
 
-Let's use the [unpack command](./cli/cli-reference.md#kit-unpack) to pull a [sample ModelKit from Jozu Hub](https://jozu.ml/organization/jozu-quickstarts) to our machine that we can play with. In this case, we'll unpack the whole thing, but one of the great things about Kit is that you can also selectively unpack only the artifacts you need: just the model, the model and dataset, the code, the configuration...whatever you want. Check out the `unpack` [command reference](./cli/cli-reference.md#kit-unpack) for details.
+Let's use the [unpack command](../cli/cli-reference/#kit-unpack) to pull a [sample ModelKit from Jozu Hub](https://jozu.ml/organization/jozu-quickstarts) to our machine that we can play with. In this case, we'll unpack the whole thing, but one of the great things about Kit is that you can also selectively unpack only the artifacts you need: just the model, the model and dataset, the code, the configuration...whatever you want. Check out the `unpack` [command reference](../cli/cli-reference/#kit-unpack) for details.
 
 If you have a model already on your machine you can use that instead.
 
@@ -71,11 +71,11 @@ tree
 └── training-data.txt* A Kitfile
 ```
 
-The [Kitfile](./kitfile/kf-overview.md) is the manifest for our ModelKit, the serialized model, and a set of files or directories including the adapter, dataset, and docs. Every ModelKit has a Kitfile and you can use the info and inspect commands to view them from the CLI (there's more on this in our [Next Steps](next-steps.md) doc).
+The [Kitfile](../kitfile/kf-overview/) is the manifest for our ModelKit, the serialized model, and a set of files or directories including the adapter, dataset, and docs. Every ModelKit has a Kitfile and you can use the info and inspect commands to view them from the CLI (there's more on this in our [Next Steps](../next-steps/) doc).
 
 ### 4/ Check the Local Repository
 
-Use the [list command](./cli/cli-reference.md#kit-list) to check what's in our local repository.
+Use the [list command](../cli/cli-reference/#kit-list) to check what's in our local repository.
 
 ```sh
 kit list
@@ -85,7 +85,7 @@ You'll see the column headings for an empty table with things like `REPOSITORY`,
 
 ### 5/ Pack the ModelKit
 
-Since our repository is empty we'll need to use the [pack command](./cli/cli-reference.md#kit-pack) to create our ModelKit. The ModelKit in your local registry will need to be named the same as your remote registry. The command will look like: `kit pack . -t [your registry address]/[your registry user or organization name]/[your repository name]:[your tag name]`
+Since our repository is empty we'll need to use the [pack command](../cli/cli-reference/#kit-pack) to create our ModelKit. The ModelKit in your local registry will need to be named the same as your remote registry. The command will look like: `kit pack . -t [your registry address]/[your registry user or organization name]/[your repository name]:[your tag name]`
 
 In our case, we are pushing a ModelKit tagged `latest` to:
 * The [Jozu Hub](https://jozu.ml/) registry
@@ -112,13 +112,13 @@ You should see an entry named based on whatever you used in your pack command.
 
 ### 6/ (Optional) Remove a ModelKit from a Local Repository
 
-If you have a typo when packing a ModelKit you can easily remove it from your repository and try again. The [Next Steps guide includes information on how to remove ModelKits](./next-steps.md#remove-command).
+If you have a typo when packing a ModelKit you can easily remove it from your repository and try again. The [Next Steps guide includes information on how to remove ModelKits](../next-steps/#remove-command).
 
 Once you've removed the mistaken ModelKit from the repository, you can repeat the `kit pack` command in the previous step, being sure to provide the correct organization and repository name for your ModelKit.
 
 ### 7/ Push the ModelKit to a Remote Repository
 
-The [push command](./cli/cli-reference.md#kit-push) will copy the newly built ModelKit from your local repository to the remote repository you logged into earlier. The naming of your ModelKit will need to be the same as what you see in your `kit list` command (REPOSITORY:TAG). You can even copy and paste it. In our case it looks like:
+The [push command](../cli/cli-reference/#kit-push) will copy the newly built ModelKit from your local repository to the remote repository you logged into earlier. The naming of your ModelKit will need to be the same as what you see in your `kit list` command (REPOSITORY:TAG). You can even copy and paste it. In our case it looks like:
 
 ```sh
 kit push jozu.ml/brad/quick-start:latest
@@ -130,7 +130,7 @@ Note that some registries, like Jozu Hub, don't automatically create a repositor
 
 You've learned how to unpack a ModelKit, pack one up, and push it. Anyone with access to your remote repository can now pull your new ModelKit and start playing with your model using the `kit pull` or `kit unpack` commands.
 
-If you'd like to learn more about using Kit, try our [Next Steps with Kit](./next-steps.md) document that covers:
+If you'd like to learn more about using Kit, try our [Next Steps with Kit](../next-steps/) document that covers:
 * Creating a container or Kubernetes deployment from a ModelKit
 * Signing your ModeKit
 * Making your own Kitfile
@@ -138,7 +138,7 @@ If you'd like to learn more about using Kit, try our [Next Steps with Kit](./nex
 * Tagging ModelKits
 * Keeping your registry tidy
 
-Or, if you want to run an LLM-based ModelKit locally try our [dev mode](./dev-mode.md).
+Or, if you want to run an LLM-based ModelKit locally try our [dev mode](../dev-mode/).
 
 Finally, if you're building workflows using Dagger you can use KitOps through our [Daggerverse modules](https://daggerverse.dev/mod/github.com/jozu-ai/daggerverse/kit). Or get the [GitHub Action for Kit](https://github.com/marketplace/actions/setup-kit-cli).
 

--- a/docs/src/docs/hf-import.md
+++ b/docs/src/docs/hf-import.md
@@ -10,13 +10,13 @@ Git LFS is required for importing from Hugging Face.
 To customize the editor used for editing the Kitfile during import, set the `EDITOR` environment variable
 :::
 
-You can read more about the `import` command in our [CLI reference](https://kitops.ml/docs/cli/cli-reference/#kit-import).
+You can read more about the `import` command in our [CLI reference](../cli/cli-reference/#kit-import).
 
 ## Importing a Hugging Face repository
 
 1. **Get the HF URL**: On the Hugging Face site, copy the URL from the repository you want to create a ModelKit from (e.g., https://huggingface.co/HuggingFaceTB/SmolLM-135M-Instruct). You can also customize the name or add a tag name if desired.
 
-1. **Kit import**: In a terminal window running Kit version 1.0.0 at least, type `kit import https://huggingface.co/HuggingFaceTB/SmolLM-135M-Instruct`. This will download and build a [Kitfile](./kitfile/kf-overview.md) based on the Hugging Face model and give you an opportunity to edit it before the ModelKit is packed.
+1. **Kit import**: In a terminal window running Kit version 1.0.0 at least, type `kit import https://huggingface.co/HuggingFaceTB/SmolLM-135M-Instruct`. This will download and build a [Kitfile](../kitfile/kf-overview/) based on the Hugging Face model and give you an opportunity to edit it before the ModelKit is packed.
 
 1. **Auto-generate the ModelKit**: Once the Kitfile is accepted a ModelKit will be built and saved to your local registry using the name you selected. If you didn't specify a tag name the ModelKit will be tagged `latest`.
 

--- a/docs/src/docs/modelkit/intro.md
+++ b/docs/src/docs/modelkit/intro.md
@@ -4,9 +4,9 @@
 
 ModelKit revolutionizes the way AI/ML artifacts are shared and managed throughout the lifecycle of AI/ML projects. As an OCI-compliant packaging format, ModelKit encapsulates datasets, code, configurations, and models into a single, standardized unit. This approach not only streamlines the development process but also ensures broad compatibility and integration with a vast array of tools and platforms.
 
-[Get started with ModelKits](/docs/get-started.md) in less than 15 minutes.
+[Get started with ModelKits](../get-started/) in less than 15 minutes.
 
-[See how security-conscious organization are using ModelKits](/docs/use-cases.md) with their existing tools to develop AI/ML projects faster and safer than ever before.
+[See how security-conscious organization are using ModelKits](../use-cases/) with their existing tools to develop AI/ML projects faster and safer than ever before.
 
 ## Key Features of ModelKit:
 

--- a/docs/src/docs/next-steps.md
+++ b/docs/src/docs/next-steps.md
@@ -10,11 +10,11 @@ In this guide you'll learn how to:
 
 ## Deploying a ModelKit
 
-You can create a container or Kubernetes deployment using a ModelKit. See our [deployment instructions](./deploy.md).
+You can create a container or Kubernetes deployment using a ModelKit. See our [deployment instructions](../deploy/).
 
 ## The Power of Unpack
 
-Models and their datasets can be very large and take a long time to push or pull, so Kit includes a unique and flexible [unpack command](./cli/cli-reference.md#kit-unpack) that allows you to pull only pieces of the ModelKit you need, saving time and storage space.
+Models and their datasets can be very large and take a long time to push or pull, so Kit includes a unique and flexible [unpack command](../cli/cli-reference/#kit-unpack) that allows you to pull only pieces of the ModelKit you need, saving time and storage space.
 
 Use the `--filter` or `-f` flag in the CLI to filter. For example, use `--filter=model` to unpack only the model, or `--filter=datasets:my-dataset` to unpack only the dataset named `my-dataset`.
 
@@ -54,7 +54,7 @@ kit unpack myrepo/my-model:latest
   --filter=datasets:evaluation
 ```
 
-Get more information on unpack and filtering in the [CLI reference docs](https://kitops.ml/docs/cli/cli-reference/#kit-unpack).
+Get more information on unpack and filtering in the [CLI reference docs](../cli/cli-reference/#kit-unpack).
 
 ## Signing your ModelKit
 
@@ -65,7 +65,7 @@ If you need a quick way to sign a ModelKit you can follow the same instructions 
 
 ## Using Kitfiles
 
-A Kitfile is the configuration document for your ModelKit. It's similar to a recipe or a `dockerfile` for a container. It's written in YAML so it's easy to read. 
+A Kitfile is the configuration document for your ModelKit. It's similar to a recipe or a `dockerfile` for a container. It's written in YAML so it's easy to read.
 
 There are three ways to create a Kitfile:
 
@@ -75,11 +75,11 @@ There are three ways to create a Kitfile:
 
 ### 1/ Import From Hugging Face
 
-If you are building a ModelKit from a Hugging Face repository you can use the [kit import](./hf-import.md) command and the Kitfile will be generated for you. However, it's still helpful to understand the Kitfile structure.
+If you are building a ModelKit from a Hugging Face repository you can use the [kit import](../hf-import/) command and the Kitfile will be generated for you. However, it's still helpful to understand the Kitfile structure.
 
 ### 2/ Generating a Kitfile From a Directory
 
-If you have your AI/ML project artifacts in a directory structure already then the easiest way to get started is with [kit init](https://kitops.ml/docs/cli/cli-reference/#kit-init). From the root of the directory with the AI/ML artifacts you wish to pack in the ModelKit run:
+If you have your AI/ML project artifacts in a directory structure already then the easiest way to get started is with [kit init](../cli/cli-reference/#kit-init). From the root of the directory with the AI/ML artifacts you wish to pack in the ModelKit run:
 
 ```sh
 kit init .
@@ -87,7 +87,7 @@ kit init .
 
 Once you have the generated Kitfile you can [pack the ModelKit](#using-the-kitfile-to-pack-a-modelkit), and push to a registry.
 
-You can learn more about the syntax, options, and flags in our [CLI docs](https://kitops.ml/docs/cli/cli-reference/#kit-init).
+You can learn more about the syntax, options, and flags in our [CLI docs](../cli/cli-reference/#kit-init).
 
 
 ### 3/ Writing Your Own Kitfile
@@ -102,7 +102,7 @@ There are five parts to a Kitfile:
 
 A Kitfile only needs the `package` section, plus one or more of the other sections.
 
-The `model` section can contain a single model, or you can create model dependencies with `model parts` which is covered in the [KitFile format documentation](https://kitops.ml/docs/kitfile/format.html#model).
+The `model` section can contain a single model, or you can create model dependencies with `model parts` which is covered in the [KitFile format documentation](../kitfile/format/#model).
 
 The `datasets`, `code`, and `docs` sections are lists, so each entry must start with a dash. The dash is required even if you are only packaging a single item of that type.
 
@@ -169,11 +169,11 @@ code:
     path: ./notebooks
 ```
 
-More information on Kitfiles can be found in the [Overview](./kitfile/kf-overview.md) and [Format](./kitfile/format.md) documentation.
+More information on Kitfiles can be found in the [Overview](../kitfile/kf-overview/) and [Format](../kitfile/format/) documentation.
 
 ### Using the Kitfile to Pack a ModelKit
 
-When you're done writing the Kitfile, name it `Kitfile` without an extension. Now you can use the [kit pack command](./cli/cli-reference.md#kit-pack) to build your ModelKit.
+When you're done writing the Kitfile, name it `Kitfile` without an extension. Now you can use the [kit pack command](../cli/cli-reference/#kit-pack) to build your ModelKit.
 
 To pack a ModelKit with a Kitfile in the current directory, name it "film-slm", attach the "champion" tag, and store it in the local registry:
 
@@ -202,7 +202,7 @@ First, you need to tag the image in your local registry with the remote registry
 kit pack . -t docker.io/jozubrad/film-slm:champion
 ```
 
-Second, you will need to login, then [kit push](./cli/cli-reference.md#kit-push) your local image to the remote registry:
+Second, you will need to login, then [kit push](../cli/cli-reference/#kit-push) your local image to the remote registry:
 
 ```sh
 kit login docker.io
@@ -211,7 +211,7 @@ kit push docker.io/jozubrad/film-slm:champion
 
 ## Read the Kitfile or Manifest from a ModelKit
 
-For any ModelKit in your local or remote registry you can use the [info command](./cli/cli-reference.md#kit-info) to easily read the Kitfile without pulling or unpacking it. This is a great way to understand what's in a ModelKit you might be interested in without needing to execute the more time-consuming unpack/pull commands.
+For any ModelKit in your local or remote registry you can use the [info command](../cli/cli-reference/#kit-info) to easily read the Kitfile without pulling or unpacking it. This is a great way to understand what's in a ModelKit you might be interested in without needing to execute the more time-consuming unpack/pull commands.
 
 ```sh
 kit info mymodel:challenger
@@ -242,7 +242,7 @@ datasets:
     description: UCF Video Dataset
 ```
 
-If you need more details, like the size, file format, or SHA digest of the contents, you can use [kit inspect](./cli/cli-reference.md#kit-inspect) to print the manifest to the terminal using the inspect command:
+If you need more details, like the size, file format, or SHA digest of the contents, you can use [kit inspect](../cli/cli-reference/#kit-inspect) to print the manifest to the terminal using the inspect command:
 
 ```sh
 kit inspect mymodel:challenger
@@ -276,7 +276,7 @@ kit inspect mymodel:challenger
 }
 ```
 
-`size` is shown in bytes. For more information on the manifest can be found in the [specification documentation](./modelkit/spec.md).
+`size` is shown in bytes. For more information on the manifest can be found in the [specification documentation](../modelkit/spec/).
 
 ## Tag ModelKits and Keep Your Registry Tidy
 
@@ -286,13 +286,13 @@ Tagging is a great way to version your ModelKits as they move through the develo
 
 However, after testing my latest model, if I find that its scores are much higher than the current champion model I may tag it `challenger` so everyone knows that this is likely to be the next model we deploy to production, replacing our current champion model.
 
-To do that I can create a new ModelKit and use the [tag command](./cli/cli-reference.md#kit-tag). For example to change from `latest` to `challenger`:
+To do that I can create a new ModelKit and use the [tag command](../cli/cli-reference/#kit-tag). For example to change from `latest` to `challenger`:
 
 ```sh
 kit tag mymodel:latest mymodel:challenger
 ```
 
-If you run [kit list](./cli/cli-reference.md#kit-list) you'll now see that you have two models in your local registry:
+If you run [kit list](../cli/cli-reference/#kit-list) you'll now see that you have two models in your local registry:
 
 ```sh
 kit list
@@ -328,7 +328,7 @@ mymodel     champion    Rajat        Finetuning_SLM   13.1 MiB   sha256:f268a74f
 
 Sometimes you want to remove a ModelKit that you've packed and stored in the repository. The `kit remove` command comes to the rescue.
 
-In this case, we no longer want the `challenger` ModelKit since it's a duplicate of the `champion` now. [Removing it](./cli/cli-reference.md#kit-remove) from our registry will keep things clean and clearer for other users:
+In this case, we no longer want the `challenger` ModelKit since it's a duplicate of the `champion` now. [Removing it](../cli/cli-reference/#kit-remove) from our registry will keep things clean and clearer for other users:
 
 ```sh
 kit remove mymodel:challenger
@@ -347,8 +347,8 @@ mymodel     latest      Rajat        Finetuning_SLM   13.1 MiB   sha256:f268a74f
 mymodel     champion    Rajat        Finetuning_SLM   13.1 MiB   sha256:f268a74ff85a00f2a68400dfc17b045bc7c1638da7f096c7ae400ad5bdfd520c
 ```
 
-You can learn more about all the Kit CLI commands from our [command reference doc](./cli/cli-reference.md).
+You can learn more about all the Kit CLI commands from our [command reference doc](../cli/cli-reference/).
 
-To learn about how to run an LLM locally using Kit, see our [Kit Dev](./dev-mode.md) documentation.
+To learn about how to run an LLM locally using Kit, see our [Kit Dev](../dev-mode/) documentation.
 
 Thanks for taking some time to play with Kit. We'd love to hear what you think. Feel free to drop us an [issue in our GitHub repository](https://github.com/jozu-ai/kitops/issues) or join [our Discord server](https://discord.gg/Tapeh8agYy).

--- a/docs/src/docs/overview.md
+++ b/docs/src/docs/overview.md
@@ -6,7 +6,7 @@ KitOps is an innovative open-source project designed to enhance collaboration am
 
 ### 🎁 ModelKit
 
-At the heart of KitOps is the ModelKit, an OCI-compliant packaging format that enables the seamless sharing of all necessary artifacts involved in the AI/ML model lifecycle. This includes datasets, code, doc, configurations, and the models themselves. By standardizing the way these components are packaged, ModelKit facilitates a more streamlined and collaborative development process that is compatible with nearly any tool. You can even [deploy ModelKits to containers or Kubernetes](./deploy.md).
+At the heart of KitOps is the ModelKit, an OCI-compliant packaging format that enables the seamless sharing of all necessary artifacts involved in the AI/ML model lifecycle. This includes datasets, code, doc, configurations, and the models themselves. By standardizing the way these components are packaged, ModelKit facilitates a more streamlined and collaborative development process that is compatible with nearly any tool. You can even [deploy ModelKits to containers or Kubernetes](../deploy/).
 
 ### 📄 Kitfile
 
@@ -20,7 +20,7 @@ Bringing everything together is the Kit Command Line Interface (CLI). The Kit CL
 
 KitOps is a key element in a platform engineering solution for AI/ML projects.
 
-[See how security-conscious organization are using ModelKits](./use-cases.md) with their existing tools to develop AI/ML projects faster and safer than ever before.
+[See how security-conscious organization are using ModelKits](../use-cases/) with their existing tools to develop AI/ML projects faster and safer than ever before.
 
 ## The Goal of KitOps
 
@@ -32,14 +32,14 @@ KitOps drives greater speed, security, and collaboration for teams working with 
 
 KitOps clears the path to use AI/ML with your existing tools and applications. No need to be an AI/ML expert, KitOps lets you concentrate on integrating AI/ML models into your applications, while Kit handles the packaging and sharing.
 
-[Get Started](./get-started.md).
+[Get Started](../get-started/).
 
 ### 👷 For DevOps teams
 
 ModelKits fit into your existing processes and the Kit CLI lets you pack or unpack ModelKit artifacts in the pipelines and automation you have proven over the last decade.
 
-[Build a better golden path for AI/ML projects](./use-cases.md).
-[Get Started](./get-started.md).
+[Build a better golden path for AI/ML projects](../use-cases/).
+[Get Started](../get-started/).
 
 
 ### 👩‍🔬 For data scientists
@@ -47,7 +47,7 @@ ModelKits fit into your existing processes and the Kit CLI lets you pack or unpa
 KitOps enables you to innovate in AI/ML without the usual infrastructure distractions. It simplifies dataset and model management and sharing, fostering closer collaboration with developers. With KitOps, you can spend more time experimenting and less time grappling with traditional software development tools.
 
 [See how to use KitOps with Jupyter Notebooks](https://www.youtube.com/watch?v=OQPp7QEvk7Q).
-[Get Started](./get-started.md).
+[Get Started](../get-started/).
 
 ## Benefits of KitOps
 
@@ -65,7 +65,7 @@ One of the core strengths of KitOps is its ability to keep data and code version
 
 ### 🚀 Deployment Ready
 
-Designed with a focus on deployment, ModelKits package assets in standard formats so you can depoly them as [containers or to Kubernetes](./deploy.md). They're also [compatible with nearly any tool](./modelkit/compatibility.md) - helping you get your model to production faster and more efficiently.
+Designed with a focus on deployment, ModelKits package assets in standard formats so you can deploy them as [containers or to Kubernetes](../deploy/). They're also [compatible with nearly any tool](../modelkit/compatibility/) - helping you get your model to production faster and more efficiently.
 
 ### 🏭 Standards-Based Approach
 

--- a/docs/src/docs/pykitops/index.md
+++ b/docs/src/docs/pykitops/index.md
@@ -4,10 +4,8 @@ This site contains the project documentation for the PyKitOps SDK project - a py
 
 The KitOps Python library is an open source project hosted on [GitHub](https://github.com/jozu-ai/pykitops/).
 
-You can find [KitOps and ModelKit documentation](https://kitops.ml/docs/overview.html) on the KitOps site.
-
 ## PyKitOps Documentation
 
-1. [Before You Begin](before-you-begin.md)
-2. [How-To Guides](how-to-guides.md)
-3. [API Reference](reference/index.md)
+1. [Before You Begin](./before-you-begin/)
+2. [How-To Guides](./how-to-guides/)
+3. [API Reference](./reference/index/)

--- a/docs/src/docs/use-cases.md
+++ b/docs/src/docs/use-cases.md
@@ -1,6 +1,6 @@
 # How KitOps Is Used 🛠️
 
-KitOps is the market's only open source, standards-based packaging and versioning system designed for AI/ML projects. Using the OCI standard allows KitOps to be painlessly adopted by any organization using containers and enterprise registries today (see a partial list of [compatible tools](./modelkit/compatibility.md)).
+KitOps is the market's only open source, standards-based packaging and versioning system designed for AI/ML projects. Using the OCI standard allows KitOps to be painlessly adopted by any organization using containers and enterprise registries today (see a partial list of [compatible tools](../modelkit/compatibility/)).
 
 Organizations around the world are using KitOps as a "gate" in the [handoff between development and production](#level-1-handoff-from-development-to-production-). This is often part of establishing golden paths and platform engineering around AI/ML projects.
 
@@ -10,7 +10,7 @@ Those who are concerned about end-to-end auditing of their model development - l
 
 ## Level 1: Handoff From Development to Production 🤝
 
-Organizations are having AI teams build a [ModelKit](./modelkit/intro.md) for each version of the AI project that is going to staging, user acceptance testing (UAT), or production.
+Organizations are having AI teams build a [ModelKit](../modelkit/intro/) for each version of the AI project that is going to staging, user acceptance testing (UAT), or production.
 
 KitOps is ideally suited to CI/CD pipelines (e.g., using KitOps in a GitHub Action, Dagger module, or other CI/CD pipeline flow) either triggered manually by the model development team when they're ready to send the model to production, or automatically when a model or its artifacts are updated in their respective repositories.
 
@@ -19,11 +19,11 @@ Security conscious organizations often can't allow internal teams to use any pub
 * They don't match the organization's security testing requirements
 * Their provenance isn't understood
 
-In these cases teams may use a pipeline (with [GitHub Actions](https://github.com/marketplace/actions/setup-kit-cli), [Dagger](https://daggerverse.dev/mod/github.com/jozu-ai/daggerverse/kit), or [another tool](./modelkit/compatibility.md)) to pull models or sample datasets from Hugging Face, run them through a battery of tests, then publish them in tamper-proof and signed ModelKits to their private container registry.
+In these cases teams may use a pipeline (with [GitHub Actions](https://github.com/marketplace/actions/setup-kit-cli), [Dagger](https://daggerverse.dev/mod/github.com/jozu-ai/daggerverse/kit), or [another tool](../modelkit/compatibility/)) to pull models or sample datasets from Hugging Face, run them through a battery of tests, then publish them in tamper-proof and signed ModelKits to their private container registry.
 
 This ensures that:
 * __Everyone has a library of safe, immutable, and signed ModelKits__ speeding development without compromising security
-* __[Safe models can be deployed](./deploy.md)__ for development or production use cases
+* __[Safe models can be deployed](../deploy/)__ for development or production use cases
 * __Operations teams have all the assets and information they need__ for testing, deploying, auditing, and managing AI/ML projects
 * __AI versioned packages are held in the same enterprise registry__ as other production assets like containers making them easier to find, secure, and audit
 * __Compliance teams have a catalogue of versioned models__ that can be used for [EU AI Act](https://artificialintelligenceact.eu/) or other regulatory reporting
@@ -32,8 +32,8 @@ This ensures that:
 **Get Started:**
 * [Kit Dagger Modules](https://daggerverse.dev/mod/github.com/jozu-ai/daggerverse/kit): Kit Dagger modules make it easy to pack and selectively unpack ModelKits to speed pipelines.
 * [Kit GitHub Action](https://github.com/marketplace/actions/setup-kit-cli): Our Kit GitHub Action is used to build hundreds of ModelKits every day as part of pipelines.
-* [Learn to pack and unpack ModelKits](./get-started.md)
-* [Create containers or Kubernetes deployments directly from ModelKits](./deploy.md)
+* [Learn to pack and unpack ModelKits](../get-started/)
+* [Create containers or Kubernetes deployments directly from ModelKits](../deploy/)
 
 This is where most organizations start their usage of KitOps, but once they start most continue on...
 
@@ -54,7 +54,7 @@ This ensures that:
 * Data and AI teams who don't work closely together can share artifacts even if they're using different development tools
 * Development artifacts can't be accidentally or maliciously tampered with
 
-This can be a lightweight process automated with ModelKit packing via the Kit [CLI](./cli/cli-reference.md).
+This can be a lightweight process automated with ModelKit packing via the Kit [CLI](../cli/cli-reference/).
 
 The beauty of KitOps' ModelKits is their flexibility and the fact that they fit into the already standard tools and processes that organizations have built around OCI artifacts and registries.
 

--- a/docs/src/docs/versus.md
+++ b/docs/src/docs/versus.md
@@ -17,15 +17,15 @@ Let's look at each option in a little more depth.
 
 First off, it's important to understand that KitOps and its ModelKits don't replace the need for MLOps training and experimentation tools like Weights & Biases, MLFlow, or others.
 
-However, [ModelKits](./modelkit/intro.md) are more secure and flexible way to package, version, and share AI project assets outside of the data science team who use MLOps tools everyday.
+However, [ModelKits](../modelkit/intro/) are more secure and flexible way to package, version, and share AI project assets outside of the data science team who use MLOps tools everyday.
 
 Unlike MLOps tools, KitOps:
 
-* Can be stored in the [container registry](https://kitops.ml/docs/modelkit/compatibility.html#compliant-oci-registries) every team already uses
+* Can be stored in the [container registry](https://kitops.ml/docs/modelkit/compatibility/#compliant-oci-registries) every team already uses
 * Fits naturally (and without any changes) into organizations' existing deployment, security, and compliance processes
-* Can already be [used with *every* software, DevOps, and data science tool](./modelkit/compatibility.md)
+* Can already be [used with *every* software, DevOps, and data science tool](../modelkit/compatibility/)
 * Is available as free open source, and openly governed so it protects users and organizations from vendor lock-in
-* Is [simple enough](./get-started.md) for anyone to use, not just data science teams
+* Is [simple enough](../get-started/) for anyone to use, not just data science teams
 * Is based on standards like OCI, that are vendor agnostic
 * Built by a community with decades of production operations and compliance experience
 
@@ -33,7 +33,7 @@ Unlike MLOps tools, KitOps:
 
 As with MLOps tools, Kit isn't designed to replace the other tools you already use and love. Jupyter notebooks, git, and containers all have their strengths and can be used for housing part of an AI project.
 
-However, [ModelKits](./modelkit/intro.md) are a better way to package, version, and share *all* the assets for an AI project in one trackable place, for use by the data science team, software engineering, and infrastructure teams. This includes:
+However, [ModelKits](../modelkit/intro/) are a better way to package, version, and share *all* the assets for an AI project in one trackable place, for use by the data science team, software engineering, and infrastructure teams. This includes:
 
 * Codebases
 * Serialized models
@@ -58,7 +58,7 @@ Additionally, while you can run a model in a notebook, the model isn't durably s
 
 #### ModelKits & Jupyter Notebooks
 
-We suggest continuing to use notebooks, but include a [Kitfile](./kitfile/kf-overview.md) in each, and at the end of the notebook execute a `kit pack` command to save the [serialized model, dataset, and code](./cli/cli-reference.html#kit-pack) from the notebook into a ModelKit for versioning, centralized tracking, and sharing. This allows the data science team to continue to use Jupyter Notebooks, but allows software engineering, product management, and infrastructure teams to easily run, track, and use the models outside of notebooks.
+We suggest continuing to use notebooks, but include a [Kitfile](../kitfile/kf-overview/) in each, and at the end of the notebook execute a `kit pack` command to save the [serialized model, dataset, and code](../cli/cli-reference/#kit-pack) from the notebook into a ModelKit for versioning, centralized tracking, and sharing. This allows the data science team to continue to use Jupyter Notebooks, but allows software engineering, product management, and infrastructure teams to easily run, track, and use the models outside of notebooks.
 
 ### Containers
 
@@ -66,7 +66,7 @@ We love containers - they're great for running and deploying models. But they're
 
 #### ModelKits & Containers
 
-We suggest having data science and production operations teams discuss how a model will be deployed (in a container, as a side-car, etc...) early in the development cycle. If a container is going to be used, you can [include a dockerfile or container in a ModelKit](./kitfile/kf-overview.html#kitfile-structure) so that a model can be easily run locally or pushed through a standard deployment pipeline when needed.
+We suggest having data science and production operations teams discuss how a model will be deployed (in a container, as a side-car, etc...) early in the development cycle. If a container is going to be used, you can [include a dockerfile or container in a ModelKit](../kitfile/kf-overview/#kitfile-structure) so that a model can be easily run locally or pushed through a standard deployment pipeline when needed.
 
 ### Git
 
@@ -74,7 +74,7 @@ Git is excellent at managing software projects that consist of a large number of
 
 #### ModelKits & Git
 
-Code related to model development is often easier to store in ModelKits where it is always in-sync with the Jupyter Notebook, serialized model, and datasets used during development. Larger codebases and code related to application integrations are best kept in git, but is often helpful to also package into the ModelKit ([a codebase can be stored in a ModelKit](./kitfile/format.html#code) so that anyone can see the state of the code at the point that the project's ModelKit was versioned).
+Code related to model development is often easier to store in ModelKits where it is always in-sync with the Jupyter Notebook, serialized model, and datasets used during development. Larger codebases and code related to application integrations are best kept in git, but is often helpful to also package into the ModelKit ([a codebase can be stored in a ModelKit](../kitfile/format/#code) so that anyone can see the state of the code at the point that the project's ModelKit was versioned).
 
 ### Dataset Storage
 
@@ -84,4 +84,4 @@ It's easy to end up with near-duplicate datasets in different locations, making 
 
 #### ModelKits & Dataset Storage
 
-Keeping datasets in versioned ModelKits ensures that it's always clear which data and state, was used with a specific version of the model. It avoids the risk of accidental data contamination and ensures you can always trace the [model/data lineage](./modelkit/spec.md#terminology-and-structure). A library of ModelKits for an AI project acts as a kind of audit record, allowing you to diff package contents to see when something changed and who made the change.
+Keeping datasets in versioned ModelKits ensures that it's always clear which data and state, was used with a specific version of the model. It avoids the risk of accidental data contamination and ensures you can always trace the [model/data lineage](../modelkit/spec/#terminology-and-structure). A library of ModelKits for an AI project acts as a kind of audit record, allowing you to diff package contents to see when something changed and who made the change.

--- a/docs/src/docs/why-kitops.md
+++ b/docs/src/docs/why-kitops.md
@@ -4,10 +4,10 @@ KitOps is the market's only open source, standards-based packaging and versionin
 
 KitOps has been downloaded over 20,000 times in just the last three months. Users often use it as a:
 
-* [Secure and immutable packaging and versioning standard](./modelkit/intro.md) that is [compatible with their existing container registry](https://kitops.ml/docs/modelkit/compatibility.html#compliant-oci-registries)
-* Point-of-control between development and production to [enforce consistency in packaging and documentation](./kitfile/kf-overview.md)
+* [Secure and immutable packaging and versioning standard](../modelkit/intro/) that is [compatible with their existing container registry](../modelkit/compatibility/#compliant-oci-registries)
+* Point-of-control between development and production to [enforce consistency in packaging and documentation](../kitfile/kf-overview/)
 * Catalogue of meaningful AI/ML project versions for regulatory compliance or change tracking
-* Mechanism to simplify and unify the [creation of containers or Kubernetes deployment YAML](./deploy.md)
+* Mechanism to simplify and unify the [creation of containers or Kubernetes deployment YAML](../deploy/)
 
 > [!NOTE]
 > The goal of KitOps is to be a library of versioned packages for your AI project, stored in an enterprise registry you already use.

--- a/docs/src/docs/why-kitops.md
+++ b/docs/src/docs/why-kitops.md
@@ -45,12 +45,12 @@ Kit's ModelKits are the better solution:
 * Remove tampering risks by using an immutable package
 * Reduce risks by including the provenance of the model and datasets
 
-Use `kit pack` to package up your Jupyter notebook, serialized model, and datasets (based on a [Kitfile](./kitfile/kf-overview.md)).
+Use `kit pack` to package up your Jupyter notebook, serialized model, and datasets (based on a [Kitfile](../kitfile/kf-overview/)).
 
 Then `kit push` it to any OCI-compliant registry, even a private one.
 
 Most people won't need everything, so just `kit unpack` only the layers you need (e.g., only model and datasets, or only code and docs) from the remote registry. Or, if you need everything then a `kit pull` will grab everything.
 
-Finally [package it all up as a container or Kubernetes deployment](./deploy.md).
+Finally [package it all up as a container or Kubernetes deployment](../deploy/).
 
-Check out our [getting started doc](./get-started.md), see the power and flexibility of our [CLI commands](./cli/cli-reference.md), or learn more about packaging your AI/ML project with [ModelKits](./modelkit/intro.md) and even making them [deployable](./deploy.md).
+Check out our [getting started doc](../get-started/), see the power and flexibility of our [CLI commands](../cli/cli-reference/), or learn more about packaging your AI/ML project with [ModelKits](../modelkit/intro/) and even making them [deployable](../deploy/).


### PR DESCRIPTION
Because of the `trailing slash` change in url's, some relative .md references are being treated as "folder/file" instead of just "file" (eg. `/docs/get-started/` would append anything to `/docs/get-started/foo` because of the trailing slash).