### PR TITLE
More 404 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![Official Website](<https://img.shields.io/badge/-Visit%20the%20Official%20Website%20%E2%86%92-rgb(255,175,82)?style=for-the-badge>)](https://kitops.ml?utm_source=github&utm_medium=kitops-readme)
 
-[![Use Cases](<https://img.shields.io/badge/-KitOps%20Quick%20Start%20%E2%86%92-rgb(122,140,225)?style=for-the-badge>)](https://kitops.ml/docs/get-started.html?utm_source=github&utm_medium=kitops-readme)
+[![Use Cases](<https://img.shields.io/badge/-KitOps%20Quick%20Start%20%E2%86%92-rgb(122,140,225)?style=for-the-badge>)](https://kitops.ml/docs/get-started/?utm_source=github&utm_medium=kitops-readme)
 
 ### What is KitOps?
 
@@ -36,7 +36,7 @@ For our friends in the EU - ModelKits are the perfect way to create a library of
 
 ### 😍 What's New? ✨
 
-* 🚢 Create a **[runnable container from a ModelKit](https://tinyurl.com/5b76p5u3)** with one command! Read [KitOps deploy docs](https://kitops.ml/docs/deploy.html) for details.
+* 🚢 Create a **[runnable container from a ModelKit](https://tinyurl.com/5b76p5u3)** with one command! Read [KitOps deploy docs](https://kitops.ml/docs/deploy/) for details.
 * 🥂 Get the most out of KitOps' ModelKits by using them with the **[Jozu Hub](https://jozu.ml/)** repository. Or, continue using ModelKits with your existing OCI registry (even on-premises and air-gapped).
 * 🛠️ Use KitOps with Dagger pipelines using our modules from the [Daggerverse](https://daggerverse.dev/mod/github.com/jozu-ai/daggerverse/kit).
 * ⛑️ [KitOps works great with Red Hat](https://developers.redhat.com/articles/2024/09/16/enhance-llms-instructlab-kitops) InstructLab and Quay.io products.
@@ -44,19 +44,19 @@ For our friends in the EU - ModelKits are the perfect way to create a library of
 
 ### Features
 
-* 🎁 **[Unified packaging](https://kitops.ml/docs/modelkit/intro.html):** A ModelKit package includes models, datasets, configurations, and code. Add as much or as little as your project needs.
-* 🏭 **[Versioning](https://kitops.ml/docs/cli/cli-reference.html#kit-tag):** Each ModelKit is tagged so everyone knows which dataset and model work together.
-* 🔒 **[Tamper-proofing](https://kitops.ml/docs/modelkit/spec.html):** Each ModelKit package includes an SHA digest for itself, and every artifact it holds.
-* 🤩 **[Selective-unpacking](https://kitops.ml/docs/cli/cli-reference.html#kit-unpack):** Unpack only what you need from a ModelKit with the `kit unpack --filter` command - just the model, just the dataset and code, or any other combination.
+* 🎁 **[Unified packaging](https://kitops.ml/docs/modelkit/intro/):** A ModelKit package includes models, datasets, configurations, and code. Add as much or as little as your project needs.
+* 🏭 **[Versioning](https://kitops.ml/docs/cli/cli-reference/#kit-tag):** Each ModelKit is tagged so everyone knows which dataset and model work together.
+* 🔒 **[Tamper-proofing](https://kitops.ml/docs/modelkit/spec/):** Each ModelKit package includes an SHA digest for itself, and every artifact it holds.
+* 🤩 **[Selective-unpacking](https://kitops.ml/docs/cli/cli-reference/#kit-unpack):** Unpack only what you need from a ModelKit with the `kit unpack --filter` command - just the model, just the dataset and code, or any other combination.
 * 🤖 **[Automation](https://github.com/marketplace/actions/setup-kit-cli):** Pack or unpack a ModelKit locally or as part of your CI/CD workflow for testing, integration, or deployment (e.g. [GitHub Actions](https://github.com/marketplace/actions/setup-kit-cli) or [Dagger](https://daggerverse.dev/mod/github.com/jozu-ai/daggerverse/kit).
-* 🐳 **[Deploy containers](https://kitops.ml/docs/deploy.html):** Generate a basic or custom docker container from any ModelKit.
-* 🚢 **[Kubernetes-ready](https://kitops.ml/docs/deploy.html):** Generate a Kubernetes / KServe deployment config from any ModelKit.
+* 🐳 **[Deploy containers](https://kitops.ml/docs/deploy/):** Generate a basic or custom docker container from any ModelKit.
+* 🚢 **[Kubernetes-ready](https://kitops.ml/docs/deploy/):** Generate a Kubernetes / KServe deployment config from any ModelKit.
 * 🪛 **[LLM fine-tuning](https://dev.to/kitops/fine-tune-your-first-large-language-model-llm-with-lora-llamacpp-and-kitops-in-5-easy-steps-1g7f):** Use KitOps to fine-tune a large language model using LoRA.
 * 🎯 **[RAG pipelines](https://www.codeproject.com/Articles/5384392/A-Step-by-Step-Guide-to-Building-and-Distributing):** Create a RAG pipeline for tailoring an LLM with KitOps.
-* 📝 **[Artifact signing](https://kitops.ml/docs/next-steps.html):** ModelKits and their assets can be signed so you can be confident of their provenance.
-* 🌈 **[Standards-based](https://kitops.ml/docs/modelkit/compatibility.html):** Store ModelKits in any OCI 1.1-compliant container or artifact registry.
-* 🥧 **[Simple syntax](https://kitops.ml/docs/kitfile/kf-overview.html):** Kitfiles are easy to write and read, using a familiar YAML syntax.
-* 🩰 **[Flexible](https://kitops.ml/docs/kitfile/format.html#model):** Reference base models using `model parts`, or store key-value pairs (or any YAML-compatible JSON data) in your Kitfile - use it to keep features, hyperparameters, links to MLOps tool experiments, or validation output.
+* 📝 **[Artifact signing](https://kitops.ml/docs/next-steps/):** ModelKits and their assets can be signed so you can be confident of their provenance.
+* 🌈 **[Standards-based](https://kitops.ml/docs/modelkit/compatibility/):** Store ModelKits in any OCI 1.1-compliant container or artifact registry.
+* 🥧 **[Simple syntax](https://kitops.ml/docs/kitfile/kf-overview/):** Kitfiles are easy to write and read, using a familiar YAML syntax.
+* 🩰 **[Flexible](https://kitops.ml/docs/kitfile/format/#model):** Reference base models using `model parts`, or store key-value pairs (or any YAML-compatible JSON data) in your Kitfile - use it to keep features, hyperparameters, links to MLOps tool experiments, or validation output.
 * 🏃‍♂️‍➡️ **[Run locally](./docs/src/docs/dev-mode.md):** Kit's Dev Mode lets you run an LLM locally, configure it, and prompt/chat with it instantly.
 * 🤗 **Universal:** ModelKits can be used with any AI, ML, or LLM project - even multi-modal models.
 
@@ -66,19 +66,19 @@ There's a video of KitOps in action on the [KitOps site](https://kitops.ml/).
 
 ## 🚀 Try KitOps in under 15 Minutes
 
-1. [Install the CLI](https://kitops.ml/docs/cli/installation.html) for your platform.
-2. Follow the [Getting Started](https://kitops.ml/docs/get-started.html) docs to learn to pack, unpack, and share a ModelKit.
+1. [Install the CLI](https://kitops.ml/docs/cli/installation/) for your platform.
+2. Follow the [Getting Started](https://kitops.ml/docs/get-started/) docs to learn to pack, unpack, and share a ModelKit.
 3. Test drive one of our [ModelKit Quick Starts](https://jozu.ml/organization/jozu-quickstarts) that includes everything you need to run your model including a codebase, dataset, documentation, and of course the model.
 
-For those who prefer to build from the source, follow [these steps](https://kitops.ml/docs/cli/installation.html#🛠️-install-from-source) to get the latest version from our repository.
+For those who prefer to build from the source, follow [these steps](https://kitops.ml/docs/cli/installation/#🛠️-install-from-source) to get the latest version from our repository.
 
 ## What is in the box?
 
-**[ModelKit](https://kitops.ml/docs/modelkit/intro.html):** At the heart of KitOps is the ModelKit, an OCI-compliant packaging format for sharing all AI project artifacts: datasets, code, configurations, and models. By standardizing the way these components are packaged, versioned, and shared, ModelKits facilitate a more streamlined and collaborative development process that is compatible with any MLOps or DevOps tool.
+**[ModelKit](https://kitops.ml/docs/modelkit/intro/):** At the heart of KitOps is the ModelKit, an OCI-compliant packaging format for sharing all AI project artifacts: datasets, code, configurations, and models. By standardizing the way these components are packaged, versioned, and shared, ModelKits facilitate a more streamlined and collaborative development process that is compatible with any MLOps or DevOps tool.
 
-**[Kitfile](https://kitops.ml/docs/kitfile/kf-overview.html):** A ModelKit is defined by a Kitfile - your AI/ML project's blueprint. It uses YAML to describe where to find each of the artifacts that will be packaged into the ModelKit. The Kitfile outlines what each part of the project is.
+**[Kitfile](https://kitops.ml/docs/kitfile/kf-overview/):** A ModelKit is defined by a Kitfile - your AI/ML project's blueprint. It uses YAML to describe where to find each of the artifacts that will be packaged into the ModelKit. The Kitfile outlines what each part of the project is.
 
-**[Kit CLI](https://kitops.ml/docs/cli/cli-reference.html):** The Kit CLI not only enables users to create, manage, run, and deploy ModelKits -- it lets you pull only the pieces you need. Just need the serialized model for deployment? Use `unpack --model`, or maybe you just want the training datasets? `unpack --datasets`.
+**[Kit CLI](https://kitops.ml/docs/cli/cli-reference/):** The Kit CLI not only enables users to create, manage, run, and deploy ModelKits -- it lets you pull only the pieces you need. Just need the serialized model for deployment? Use `unpack --model`, or maybe you just want the training datasets? `unpack --datasets`.
 
 ## Need Help?
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ See the full changelog from [0.4](https://github.com/jozu-ai/kitops/releases/tag
 * Demo: using [ModelKits with Jupyter Notebooks](https://youtu.be/OQPp7QEvk7Q?feature=shared)
 * Add [Windows & Linux for `kit dev`](https://github.com/jozu-ai/kitops/releases/tag/v0.4.0) command
 * [Add `--filter` option](https://github.com/jozu-ai/kitops/releases/tag/v0.4.0) to `kit info` command
-* Deploy [ModelKits as containers](https://kitops.ml/docs/deploy.html)
+* Deploy [ModelKits as containers](https://kitops.ml/docs/deploy/)
 * [Added parameters field](https://github.com/jozu-ai/kitops/pull/514) to datasets and code
 * [Enhanced proxy](https://github.com/jozu-ai/kitops/pull/512) support
 
@@ -41,7 +41,7 @@ Users want to be able to deploy their models through existing CI/CD/CT pipelines
 
 Users want to be able to get the Kit CLI from locations like Brew, Choco, and Conda.
 
-* [Install with Brew](https://kitops.ml/docs/cli/installation.html)
+* [Install with Brew](https://kitops.ml/docs/cli/installation/)
 * Use KitOps with our Python SDK
 * Add support for Choco
 * Add support for Conda

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,7 +3,7 @@
 Welcome to our project! We use GitHub for tracking bugs and feature requests.
 
 If you need other types of help try:
-* View our [product documentation](https://kitops.ml/docs/overview.html)
+* View our [product documentation](https://kitops.ml/docs/overview/)
 * Join the [KitOps Discord](https://discord.gg/Tapeh8agYy)
 * Join our [public office hours meeting](./GOVERNANCE.md)
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -61,7 +61,7 @@ export default defineConfig({
 
     // Top navigation
     nav: [
-      { text: 'Get Started', activeMatch: '^/#getstarted', link: '/docs/get-started.html' },
+      { text: 'Get Started', activeMatch: '^/#getstarted', link: '/docs/get-started/' },
       { text: 'How does it work?', activeMatch: `^/#howdoesitwork`, link: '/#howdoesitwork' },
       { text: 'Docs', activeMatch: `^/docs`, link: '/docs/overview' },
       { text: 'Blog', activeMatch: `^/blog`, link: '/blog' },

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 
 # KitOps Documentation
 
-This is the documentation for [KitsOps](https://kitops.ml). You can read the docs at https://kitops.ml/docs/overview.html.
+This is the documentation for [KitsOps](https://kitops.ml). You can read the docs at https://kitops.ml/docs/overview/.
 
 ## Table of Contents
 

--- a/docs/src/docs/modelkit/intro.md
+++ b/docs/src/docs/modelkit/intro.md
@@ -4,9 +4,9 @@
 
 ModelKit revolutionizes the way AI/ML artifacts are shared and managed throughout the lifecycle of AI/ML projects. As an OCI-compliant packaging format, ModelKit encapsulates datasets, code, configurations, and models into a single, standardized unit. This approach not only streamlines the development process but also ensures broad compatibility and integration with a vast array of tools and platforms.
 
-[Get started with ModelKits](../get-started/) in less than 15 minutes.
+[Get started with ModelKits](../../get-started/) in less than 15 minutes.
 
-[See how security-conscious organization are using ModelKits](../use-cases/) with their existing tools to develop AI/ML projects faster and safer than ever before.
+[See how security-conscious organization are using ModelKits](../../use-cases/) with their existing tools to develop AI/ML projects faster and safer than ever before.
 
 ## Key Features of ModelKit:
 

--- a/docs/src/docs/pykitops/before-you-begin.md
+++ b/docs/src/docs/pykitops/before-you-begin.md
@@ -23,7 +23,7 @@ To determine if the Kit CLI is installed in your environment:
     Go version: go1.22.6
     ```
 
-If you don't have the Kit CLI installed, follow the [Kit Installation Instructions](https://kitops.ml/docs/cli/installation.html).
+If you don't have the Kit CLI installed, follow the [Kit Installation Instructions](https://kitops.ml/docs/cli/installation/).
 
 ### 2/ Prepare Your Registry
 

--- a/docs/src/docs/why-kitops.md
+++ b/docs/src/docs/why-kitops.md
@@ -1,6 +1,6 @@
 # Why Use KitOps?
 
-KitOps is the market's only open source, standards-based packaging and versioning system designed for AI/ML projects. Using the OCI standard allows KitOps to be painlessly adopted by any organization using containers and enterprise registries today (see a partial list of [compatible tools](./modelkit/compatibility.md)).
+KitOps is the market's only open source, standards-based packaging and versioning system designed for AI/ML projects. Using the OCI standard allows KitOps to be painlessly adopted by any organization using containers and enterprise registries today (see a partial list of [compatible tools](../modelkit/compatibility/)).
 
 KitOps has been downloaded over 20,000 times in just the last three months. Users often use it as a:
 


### PR DESCRIPTION
More 404 fixes.

Note: Some documents like CONTRIBUTING.md and CODE-OF-CONDUCT.md are git repository files that have links each other but that link is not compatible with our `kitops.ml` with-trailing-slash approach, so they will cause some 404 unless we duplicate them and use the proper url in the kitops site.