### PR TITLE
Update HF import documentation for v1.1

### DIFF
--- a/docs/src/docs/hf-import.md
+++ b/docs/src/docs/hf-import.md
@@ -2,10 +2,6 @@
 
 You can automatically generate a ModelKit from a Hugging Face repository using the `kit import` command. This speeds and simplifies the job of getting started with ModelKits.
 
-::: warning
-Git LFS is required for importing from Hugging Face.
-:::
-
 ::: tip
 To customize the editor used for editing the Kitfile during import, set the `EDITOR` environment variable
 :::
@@ -17,6 +13,10 @@ You can read more about the `import` command in our [CLI reference](../cli/cli-r
 1. **Get the HF URL**: On the Hugging Face site, copy the URL from the repository you want to create a ModelKit from (e.g., https://huggingface.co/HuggingFaceTB/SmolLM-135M-Instruct). You can also customize the name or add a tag name if desired.
 
 1. **Kit import**: In a terminal window running Kit version 1.0.0 at least, type `kit import https://huggingface.co/HuggingFaceTB/SmolLM-135M-Instruct`. This will download and build a [Kitfile](../kitfile/kf-overview/) based on the Hugging Face model and give you an opportunity to edit it before the ModelKit is packed.
+
+::: tip
+If you have a [Huggingface Access Token](https://huggingface.co/docs/hub/security-tokens) you can specify it using the `--token` flag for `kit import`.
+:::
 
 1. **Auto-generate the ModelKit**: Once the Kitfile is accepted a ModelKit will be built and saved to your local registry using the name you selected. If you didn't specify a tag name the ModelKit will be tagged `latest`.
 


### PR DESCRIPTION
### Description
Drop the Git LFS requirement from the HF import document, as it is no longer required as of v1.1. Also, add a tip about using access tokens with import, as it's required for some models.

This PR should not be merged until the next release, as the changes depend on https://github.com/jozu-ai/kitops/pull/742

### Linked issues
N/A