### PR TITLE
Fix bug where we warn of empty layers when progress bars are disabled

### DIFF
--- a/pkg/lib/kitfile/layer.go
+++ b/pkg/lib/kitfile/layer.go
@@ -227,11 +227,6 @@ func writeFileToTar(file string, fi os.FileInfo, ptw *output.ProgressTar, plog *
 }
 
 func getTotalSize(basePath string, ignore filesystem.IgnorePaths) (int64, error) {
-	if !output.ProgressEnabled() {
-		// Won't use this information anyways, save the work.
-		return 0, nil
-	}
-
 	pathInfo, err := os.Stat(basePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
### Description
When packing a ModelKit, we precompute the total size of files in each layer so that we can show a progress bar for the pack process. However, we assume we don't need this size when progress bars are disabled and simply return a size of 0.

Since the computed size is also used in printing a warning about empty layers, this leads to us printing a warning that layers are empty when progress bars are disabled.

This PR re-enables computing total size when progress bars are disabled so that the warning is still useful.

### Linked issues
N/A
