### PR TITLE
Move to using cache directory in KITOPS_HOME instead of the system temp dir

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"kitops/pkg/cmd/diff"
 	"kitops/pkg/cmd/info"
 	"kitops/pkg/cmd/inspect"
+	"kitops/pkg/cmd/kitcache"
 	"kitops/pkg/cmd/kitimport"
 	"kitops/pkg/cmd/kitinit"
 	"kitops/pkg/cmd/list"
@@ -157,6 +158,7 @@ func addSubcommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(kitinit.InitCommand())
 	rootCmd.AddCommand(diff.DiffCommand())
 	rootCmd.AddCommand(kitimport.ImportCommand())
+	rootCmd.AddCommand(kitcache.CacheCommand())
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ import (
 	"kitops/pkg/cmd/unpack"
 	"kitops/pkg/cmd/version"
 	"kitops/pkg/lib/constants"
+	"kitops/pkg/lib/filesystem/cache"
 	"kitops/pkg/lib/repo/local"
 	"kitops/pkg/lib/update"
 	"kitops/pkg/output"
@@ -99,6 +100,7 @@ func RunCommand() *cobra.Command {
 				return errors.New("exit")
 			}
 			ctx := context.WithValue(cmd.Context(), constants.ConfigKey{}, configHome)
+			cache.SetCacheHome(constants.CachePath(configHome))
 			cmd.SetContext(ctx)
 
 			update.CheckForUpdate(configHome)

--- a/pkg/cmd/kitcache/cmd.go
+++ b/pkg/cmd/kitcache/cmd.go
@@ -1,0 +1,100 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitcache
+
+import (
+	"fmt"
+	"io"
+	fscache "kitops/pkg/lib/filesystem/cache"
+	"kitops/pkg/output"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func CacheCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: `Manage temporary files cached by Kit`,
+		Long: `Manage files stored in the temporary KitOps cache dir ($KITOPS_HOME/cache)
+
+Normally, this directory is empty, but may contain leftover files from resumable
+downloads or files that were not cleaned up due to the command being cancelled.`,
+		Example: `# Get information about size of cached files
+kit cache info
+
+# Clear files in cache
+kit cache clear
+		`,
+	}
+	cmd.AddCommand(cacheInfoCommand())
+	cmd.AddCommand(cacheClearCommand())
+
+	return cmd
+}
+
+func cacheInfoCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "info",
+		Short: `Get information about cache disk usage`,
+		Long:  `Print the total size of temporary files in the cache directory.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			totalSize, stats, err := fscache.StatCache()
+			if err != nil {
+				return output.Fatalln(err)
+			}
+			if totalSize == 0 {
+				output.Infof("Cache is currently empty")
+				return nil
+			}
+			printCacheInfo(cmd.OutOrStdout(), totalSize, stats)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func cacheClearCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: `Clear temporary cache storage`,
+		Long:  `Clear temporary files from cache storage.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := fscache.ClearCache(); err != nil {
+				return output.Fatalln(err)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func printCacheInfo(w io.Writer, totalSize int64, subpaths map[string]int64) {
+	var subpathNames []string
+	for s := range subpaths {
+		subpathNames = append(subpathNames, s)
+	}
+	sort.Strings(subpathNames)
+	fmt.Fprintf(w, "Total size of cache directory: %s\n", output.FormatBytes(totalSize))
+	fmt.Fprintln(w, "Cache contents:")
+	tw := tabwriter.NewWriter(w, 0, 2, 4, ' ', 0)
+	for _, subpath := range subpathNames {
+		fmt.Fprintf(tw, "  ./%s\t%s\n", subpath, output.FormatBytes(subpaths[subpath]))
+	}
+	tw.Flush()
+}

--- a/pkg/cmd/kitimport/gitimport.go
+++ b/pkg/cmd/kitimport/gitimport.go
@@ -36,7 +36,7 @@ import (
 )
 
 func importUsingGit(ctx context.Context, opts *importOptions) error {
-	tmpDir, cleanupTmp, err := cache.MkCacheDir("import_git", "")
+	tmpDir, cleanupTmp, err := cache.MkCacheDir(cache.CacheImportSubdir, "")
 	if err != nil {
 		return err
 	}
@@ -109,6 +109,11 @@ func importUsingGit(ctx context.Context, opts *importOptions) error {
 		return fmt.Errorf("failed to pack ModelKit: %w", err)
 	}
 	output.Infof("Model is packed as %s", opts.tag)
+
+	if err := cache.CleanCacheDir(cache.CacheImportSubdir); err != nil {
+		output.Logf(output.LogLevelWarn, "Failed to clean cache directory: %s", err)
+	}
+
 	return nil
 }
 

--- a/pkg/cmd/kitimport/gitimport.go
+++ b/pkg/cmd/kitimport/gitimport.go
@@ -27,6 +27,7 @@ import (
 	"kitops/pkg/artifact"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/filesystem"
+	"kitops/pkg/lib/filesystem/cache"
 	"kitops/pkg/lib/git"
 	kfutils "kitops/pkg/lib/kitfile"
 	kfgen "kitops/pkg/lib/kitfile/generate"
@@ -35,16 +36,14 @@ import (
 )
 
 func importUsingGit(ctx context.Context, opts *importOptions) error {
-	tmpDir, err := os.MkdirTemp("", "kitops_import_tmp")
+	tmpDir, cleanupTmp, err := cache.MkCacheDir("import_git", "")
 	if err != nil {
-		return fmt.Errorf("failed to create temporary directory: %w", err)
+		return err
 	}
 	doCleanup := true
 	defer func() {
 		if doCleanup {
-			if err := os.RemoveAll(tmpDir); err != nil {
-				output.Logf(output.LogLevelWarn, "Failed to remove temporary directory %s: %s", tmpDir, err)
-			}
+			cleanupTmp()
 		}
 	}()
 

--- a/pkg/cmd/kitimport/hfimport.go
+++ b/pkg/cmd/kitimport/hfimport.go
@@ -42,7 +42,7 @@ func importUsingHF(ctx context.Context, opts *importOptions) error {
 		return fmt.Errorf("could not process URL %s: %w", opts.repo, err)
 	}
 
-	tmpDir, cleanupTmp, err := cache.MkCacheDir("import_hf", "")
+	tmpDir, cleanupTmp, err := cache.MkCacheDir("import", "")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -115,6 +115,11 @@ func importUsingHF(ctx context.Context, opts *importOptions) error {
 		return fmt.Errorf("failed to pack ModelKit: %w", err)
 	}
 	output.Infof("Model is packed as %s", opts.tag)
+
+	if err := cache.CleanCacheDir(cache.CacheImportSubdir); err != nil {
+		output.Logf(output.LogLevelWarn, "Failed to clean cache directory: %s", err)
+	}
+
 	return nil
 }
 

--- a/pkg/cmd/kitimport/hfimport.go
+++ b/pkg/cmd/kitimport/hfimport.go
@@ -26,6 +26,7 @@ import (
 	"kitops/pkg/artifact"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/filesystem"
+	"kitops/pkg/lib/filesystem/cache"
 	"kitops/pkg/lib/hf"
 	kfutils "kitops/pkg/lib/kitfile"
 	kfgen "kitops/pkg/lib/kitfile/generate"
@@ -41,16 +42,14 @@ func importUsingHF(ctx context.Context, opts *importOptions) error {
 		return fmt.Errorf("could not process URL %s: %w", opts.repo, err)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "kitops_import_tmp")
+	tmpDir, cleanupTmp, err := cache.MkCacheDir("import_hf", "")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 	doCleanup := true
 	defer func() {
 		if doCleanup {
-			if err := os.RemoveAll(tmpDir); err != nil {
-				output.Logf(output.LogLevelWarn, "Failed to remove temporary directory %s: %s", tmpDir, err)
-			}
+			cleanupTmp()
 		}
 	}()
 

--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -38,6 +38,7 @@ const (
 	// credentials are stored in $KITOPS_HOME/credentials.json
 	DefaultConfigSubdir               = "kitops"
 	StorageSubpath                    = "storage"
+	CacheSubpath                      = "cache"
 	CredentialsSubpath                = "credentials.json"
 	HarnessSubpath                    = "harness"
 	HarnessProcessFile                = "process.pid"
@@ -123,6 +124,10 @@ func HarnessPath(configBase string) string {
 
 func CredentialsPath(configBase string) string {
 	return filepath.Join(configBase, CredentialsSubpath)
+}
+
+func CachePath(configBase string) string {
+	return filepath.Join(configBase, CacheSubpath)
 }
 
 // IndexJsonPath is a wrapper for getting the index.json path for a local OCI index,

--- a/pkg/lib/filesystem/cache/cache.go
+++ b/pkg/lib/filesystem/cache/cache.go
@@ -1,0 +1,88 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"kitops/pkg/output"
+	"os"
+	"path/filepath"
+)
+
+var cacheHomeDir = os.TempDir()
+
+func SetCacheHome(cacheHome string) {
+	cacheHomeDir = cacheHome
+}
+
+func cacheHome() string {
+	return cacheHomeDir
+}
+
+// MkCacheDir creates a directory within configHome to be used for temporary storage and returns a function that can
+// be called to remove it once it is no longer needed. If cacheKey is not empty, the cache directory will be
+// deterministic and can be used to resume operations. Otherwise the directory will be generated with a random,
+// non-colliding name.
+func MkCacheDir(subcommand, cacheKey string) (cacheDir string, cleanup func(), err error) {
+	cacheSubDir := filepath.Join(cacheHome(), subcommand)
+	if err := os.MkdirAll(cacheSubDir, 0700); err != nil {
+		return "", nil, fmt.Errorf("failed to create cache directory %s: %w", cacheSubDir, err)
+	}
+	if cacheKey != "" {
+		cacheDir = filepath.Join(cacheSubDir, cacheKey)
+		if err := os.Mkdir(cacheDir, 0700); err != nil {
+			return "", nil, fmt.Errorf("failed to create cache directory %s: %w", cacheDir, err)
+		}
+	} else {
+		tmpDir, err := os.MkdirTemp(cacheSubDir, fmt.Sprintf("kitops_%s_", subcommand))
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to create cache directory in %s: %w", cacheSubDir, err)
+		}
+		cacheDir = tmpDir
+	}
+
+	cleanup = func() {
+		if err := os.RemoveAll(cacheDir); err != nil {
+			output.Logf(output.LogLevelWarn, "Failed to remove temporary directory %s: %s", cacheDir, err)
+		}
+	}
+	return cacheDir, cleanup, nil
+}
+
+func MkCacheFile(subcommand, basename string) (tempFile *os.File, cleanup func(), err error) {
+	cacheSubDir := filepath.Join(cacheHome(), subcommand)
+	if err := os.MkdirAll(cacheSubDir, 0700); err != nil {
+		return nil, nil, fmt.Errorf("failed to create cache directory %s: %w", cacheSubDir, err)
+	}
+	f, err := os.CreateTemp(cacheSubDir, basename)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create temporary file in %s: %w", cacheSubDir, err)
+	}
+
+	tempFilePath := filepath.Join(cacheSubDir, f.Name())
+	cleanup = func() {
+		if err := f.Close(); err != nil && !errors.Is(err, fs.ErrClosed) {
+			output.Errorf("Error closing temporary file %s: %s", tempFilePath, err)
+		}
+		if err := os.Remove(f.Name()); err != nil && !os.IsNotExist(err) {
+			output.Errorf("Failed to remove temporary file %s: %w", tempFilePath, err)
+		}
+	}
+	return f, cleanup, nil
+}

--- a/pkg/lib/kitfile/layer.go
+++ b/pkg/lib/kitfile/layer.go
@@ -31,6 +31,7 @@ import (
 	"kitops/pkg/artifact"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/filesystem"
+	"kitops/pkg/lib/filesystem/cache"
 	"kitops/pkg/output"
 
 	"github.com/opencontainers/go-digest"
@@ -59,7 +60,7 @@ func compressLayer(path string, mediaType constants.MediaType, ignore filesystem
 		output.Logf(output.LogLevelWarn, "No files detected in %s layer with path %s", mediaType.BaseType, path)
 	}
 
-	tempFile, err := os.CreateTemp("", "kitops_layer_*")
+	tempFile, tempFileCleanup, err := cache.MkCacheFile("pack", "kitops_layer_")
 	if err != nil {
 		return "", ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("failed to create temporary file: %w", err)
 	}
@@ -99,8 +100,7 @@ func compressLayer(path string, mediaType constants.MediaType, ignore filesystem
 		if compressedWriter != nil {
 			_ = compressedWriter.Close()
 		}
-		_ = tempFile.Close()
-		removeTempFile(tempFileName)
+		tempFileCleanup()
 	}
 	plog.Wait()
 
@@ -112,7 +112,7 @@ func compressLayer(path string, mediaType constants.MediaType, ignore filesystem
 
 	tempFileInfo, err := tempFile.Stat()
 	if err != nil {
-		removeTempFile(tempFileName)
+		tempFileCleanup()
 		return "", ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("failed to stat temporary file: %w", err)
 	}
 	callAndPrintError(tempFile.Close, "Failed to close temporary file: %s")

--- a/pkg/lib/kitfile/layer.go
+++ b/pkg/lib/kitfile/layer.go
@@ -60,7 +60,7 @@ func compressLayer(path string, mediaType constants.MediaType, ignore filesystem
 		output.Logf(output.LogLevelWarn, "No files detected in %s layer with path %s", mediaType.BaseType, path)
 	}
 
-	tempFile, tempFileCleanup, err := cache.MkCacheFile("pack", "kitops_layer_")
+	tempFile, tempFileCleanup, err := cache.MkCacheFile(cache.CachePackSubdir, "kitops_layer_")
 	if err != nil {
 		return "", ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("failed to create temporary file: %w", err)
 	}
@@ -274,12 +274,6 @@ func getTotalSize(basePath string, ignore filesystem.IgnorePaths) (int64, error)
 func callAndPrintError(f func() error, msg string) {
 	if err := f(); err != nil {
 		output.Errorf(msg, err)
-	}
-}
-
-func removeTempFile(filepath string) {
-	if err := os.Remove(filepath); err != nil && !os.IsNotExist(err) {
-		output.Errorf("Failed to clean up temporary file %s: %s", filepath, err)
 	}
 }
 

--- a/pkg/lib/kitfile/local-storage.go
+++ b/pkg/lib/kitfile/local-storage.go
@@ -27,6 +27,7 @@ import (
 	"kitops/pkg/artifact"
 	"kitops/pkg/lib/constants"
 	"kitops/pkg/lib/filesystem"
+	"kitops/pkg/lib/filesystem/cache"
 	"kitops/pkg/lib/repo/local"
 	"kitops/pkg/lib/repo/util"
 	"kitops/pkg/output"
@@ -57,6 +58,11 @@ func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact
 	if err != nil {
 		return nil, err
 	}
+
+	if err := cache.CleanCacheDir(cache.CachePackSubdir); err != nil {
+		output.Logf(output.LogLevelWarn, "Failed to clean cache directory: %s", err)
+	}
+
 	return manifestDesc, nil
 }
 


### PR DESCRIPTION
### Description
Stop using the system's normal temporary directory for temp files, and instead use `$KITOPS_HOME/cache`. This allows more easily mounting storage to e.g. containers to support large cached files. However, since this directory will not be emptied by the system, we have to clean it up.

To manage automatic cleanup (in case a command is cancelled via SIGINT, for example), we do something similar to how we handle the ingest direction for kit pull: if a command completes successfully, we'll clear its corresponding cache subdir (e.g. a successful import will clear all cached import files). This limits how much data can leak into the cache.

This PR also includes a new command: `kit cache [info|clear]`. The `info` subcommand can be used to see to total size of the cache, if it's not empty. The clear command can be used to manually clean up any stray files.

The changes in this PR do not touch `kit pull`, since it manages its own ingest directory and I didn't want to risk introducing a subtle bug. However, the current cache implementation should support that too, as a future improvement.

Finally, this change opens the door to resumable hugging face downloads, which can be implemented in another PR.

### Linked issues
Closes #758 
