### PR TITLE
Fix missing flags on diff command

### DIFF
--- a/pkg/cmd/diff/cmd.go
+++ b/pkg/cmd/diff/cmd.go
@@ -74,6 +74,8 @@ func DiffCommand() *cobra.Command {
 		Example: examples,
 		RunE:    runCommand(opts),
 	}
+	opts.AddNetworkFlags(cmd)
+	cmd.Flags().SortFlags = false
 	return cmd
 }
 


### PR DESCRIPTION
### Description
PR https://github.com/jozu-ai/kitops/pull/742 introduced returning errors if concurrency was less than 1 (see https://github.com/jozu-ai/kitops/pull/742/commits/404f0124520f5623d35db808b4dcbd0945c5d461). This commit broke `kit diff`, since `kit diff` did not add the flags to its command, meaning `opts.complete` would always fail in error (due to having a defaulted `0` for concurrency).

### Linked issues
N/A