### PR TITLE
Explicitly allow OAI bots

### DIFF
--- a/docs/src/public/robots.txt
+++ b/docs/src/public/robots.txt
@@ -1,3 +1,13 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
 User-agent: *
 Disallow:
+
 Sitemap: https://kitops.org/sitemap.xml


### PR DESCRIPTION
Explicitly add `allow` rules for all the OpenAI bots in our robots.txt, even if we're not blocking any bot 😬 