### PR TITLE
Update version check endpoint to use kitops.org; add current command and kitops version in headers on version check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,7 +104,7 @@ func RunCommand() *cobra.Command {
 			cache.SetCacheHome(constants.CachePath(configHome))
 			cmd.SetContext(ctx)
 
-			update.CheckForUpdate(configHome)
+			update.CheckForUpdate(configHome, cmd.CalledAs())
 
 			// At this point, we've parsed the command tree and args; the CLI is being correctly
 			// so we don't want to print usage. Each subcommand should print its error message before


### PR DESCRIPTION
### Description
This PR switches the version check endpoint to use https://kitops.ml/version. This endpoint reports the current latest full (i.e. not prerelease, not draft) version of KitOps that is available, along with its URL. For now, the fields match the GitHub API for convenience and interoperability.

We also add two headers:
* User-Agent: similar to most requests performed by Kit (e.g. when pushing), we use the user agent `kitops-cli/<version>`
* X-Command: the top-level command being run (e.g. `push` for `kit push <modelkit>`.

Version update checks and notifications can be disabled by running `kit version --show-update-notifications=false`.

### Linked issues
N/A

### AI-Assisted Code
<!-- Check all that apply -->
- [ ] This PR contains AI-generated code that I have reviewed and tested
- [ ] I take full responsibility for all code in this PR, regardless of how it was created
