### PR TITLE
Include INSTALL.md in release artifacts

### DIFF
--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -58,6 +58,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - INSTALL.md
   - id: kit-macos-zip-offline-archive
     format: zip
     builds:
@@ -71,6 +72,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - INSTALL.md
   # tar.gz archives for Mac OS:
   #   - will not be notarized
   #   - will be installable via homebrew (i.e. "brew install kitops")
@@ -87,6 +89,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - INSTALL.md
 
 git:
   ignore_tags:

--- a/.goreleaser.linux.yaml
+++ b/.goreleaser.linux.yaml
@@ -42,6 +42,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - INSTALL.md
   - id: kit-archive-offline
     format: tar.gz
     builds:
@@ -56,6 +57,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - INSTALL.md
 
 git:
   ignore_tags:

--- a/.goreleaser.windows.yaml
+++ b/.goreleaser.windows.yaml
@@ -42,6 +42,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - INSTALL.md
   - id: kit-archive-offline
     format: zip
     builds:
@@ -56,6 +57,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - INSTALL.md
 
 snapshot:
   name_template: "{{ .Version }}"


### PR DESCRIPTION
### Description
Include the INSTALL.md file in release artifacts generated for KitOps on all platforms. This file was recently added (https://github.com/kitops-ml/kitops/pull/1008) but goreleaser is not configured to include it in release artifacts.

### Linked issues
N/A

### AI-Assisted Code
<!-- Check all that apply -->
- [ ] This PR contains AI-generated code that I have reviewed and tested
- [ ] I take full responsibility for all code in this PR, regardless of how it was created
