### PR TITLE
Treat .prompt files as code during kit init

### DIFF
--- a/pkg/lib/kitfile/generate/generate.go
+++ b/pkg/lib/kitfile/generate/generate.go
@@ -270,7 +270,7 @@ func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFile
 }
 
 func determineFileType(filename string) fileType {
-	if strings.Contains(filename, ".prompt") {
+	if strings.Contains(filename, ".prompt.") {
 		return fileTypeCode
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/kitops-ml/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/kitops-ml/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description
This PR introduces changes to treat .prompt files as code, while using the init command. The logic is to check whether .prompt is a sub string of the filename.

### Linked issues
closes #974

### AI-Assisted Code
<!-- Check all that apply -->
- [ ] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
