### PR TITLE
docs: update documentation for PR #1000

### DIFF
--- a/docs/src/docs/get-started.md
+++ b/docs/src/docs/get-started.md
@@ -72,7 +72,17 @@ Use the [kit pack command](../cli/cli-reference.md#kit-pack):
 kit pack . -t jozu.ml/your-username/finetune:latest
 ```
 
-This saves the ModelKit locally under the `latest` tag. Verify:
+This saves the ModelKit locally under the `latest` tag.
+
+:::tip Packing as ModelPack format
+To create a [ModelPack](https://github.com/modelpack/model-spec)-formatted artifact instead, add the `--use-model-pack` flag:
+```sh
+kit pack . --use-model-pack -t jozu.ml/your-username/finetune:latest
+```
+All Kit commands work with both ModelKit and ModelPack formats.
+:::
+
+Verify your packed model:
 
 ```sh
 kit list

--- a/docs/src/docs/modelkit/intro.md
+++ b/docs/src/docs/modelkit/intro.md
@@ -43,7 +43,37 @@ ModelKit simplifies the messy handoff between data scientists, engineers, and op
 
 It’s more than a format — it’s a building block for secure, reproducible AI.
 
+## 🔄 ModelPack Format Support
+
+KitOps supports both **ModelKit** and **ModelPack** artifact formats:
+
+* **ModelKit** (default) — KitOps' native format with integrated Kitfile configuration
+* **ModelPack** — The [CNCF model-spec format](https://github.com/modelpack/model-spec) for vendor-neutral AI/ML interchange
+
+### Using ModelPack Format
+
+To pack artifacts in ModelPack format, use the `--use-model-pack` flag:
+
+```sh
+kit pack . --use-model-pack -t registry/repo:tag
+```
+
+### Compatibility
+
+All Kit CLI commands work transparently with both formats:
+
+* `kit pull` — Works with ModelKit and ModelPack artifacts
+* `kit unpack` — Extracts contents from either format
+* `kit inspect` — Shows manifests for both types
+* `kit list` — Displays artifacts regardless of format
+* `kit push` — Pushes any supported artifact type
+
+When you pack with `--use-model-pack`, your Kitfile is preserved as a manifest annotation, ensuring you can still retrieve and use it with Kit commands.
+
+**Note:** ModelPack artifacts created by other tools (not Kit) may not include a Kitfile. Kit can still unpack these artifacts if they use the `org.cncf.model.filepath` annotation to specify file paths.
+
 ---
 
 **Have feedback or questions?**
 Open an [issue on GitHub](https://github.com/kitops-ml/kitops/issues) or [join us on Discord](https://discord.gg/Tapeh8agYy).
+

--- a/docs/src/docs/overview.md
+++ b/docs/src/docs/overview.md
@@ -36,7 +36,7 @@ The KitOps ModelKit is a packaging format that bundles all the artifacts of your
 
 This means ModelKits can be stored in your existing image registry, deployed to Kubernetes (or anywhere else containers run), and managed just like any container image.
 
-KitOps can also create ModelPack-compliant packages. Both ModelPack and ModelKits are vendor-neutral standards for packaging everything needed for an AI/ML project.
+**ModelPack Support:** KitOps can also create ModelPack-compliant packages using the [CNCF model-spec format](https://github.com/modelpack/model-spec). Both ModelPack and ModelKits are vendor-neutral standards for packaging everything needed for an AI/ML project. Kit commands (pull, push, unpack, inspect, list) work transparently with both formats.
 
 See how to [deploy ModelKits](../deploy.md)
 
@@ -44,7 +44,13 @@ See how to [deploy ModelKits](../deploy.md)
 
 The Kitfile is a YAML configuration that describes what goes into a KitOps ModelKit. It’s designed for clarity and security — making it easy to track what’s included, and to share AI/ML projects across environments and teams.
 
-Prefer to use ModelPack? You can simply use `kit pack . --use-model-pack` and KitOps will take care of everything else behind the scenes.
+**Using ModelPack format:** To pack in ModelPack format instead of ModelKit format, add the `--use-model-pack` flag:
+
+```sh
+kit pack . --use-model-pack -t myregistry/mymodel:latest
+```
+
+When packing as ModelPack, KitOps stores your Kitfile as a manifest annotation so you can still retrieve it later. Commands like `kit unpack`, `kit pull`, and `kit inspect` work the same way regardless of format.
 
 ### 🖥️ Kit CLI: Create, Run, Automate
 


### PR DESCRIPTION
Updates user documentation to reflect changes from: Add support for CNCF model-spec artifact (ModelPacks)

Changes:
- Enhanced overview.md with ModelPack format details and usage examples
- Added ModelPack packing option to getting started tutorial
- Created comprehensive ModelPack support section in modelkit/intro.md
