### PR TITLE
added selective filtering to kit import

### DIFF
--- a/frontend/dev-mode/pnpm-lock.yaml
+++ b/frontend/dev-mode/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 1.2.7
       '@vueuse/components':
         specifier: ^10.9.0
-        version: 10.11.1(vue@3.5.13(typescript@5.4.5))
+        version: 10.11.1(vue@3.5.26(typescript@5.4.5))
       just-use-native-fetch:
         specifier: ^1.0.0
         version: 1.0.0
@@ -21,11 +21,11 @@ importers:
         specifier: ^14.1.0
         version: 14.1.0
       vue:
-        specifier: ^3.4.21
-        version: 3.5.13(typescript@5.4.5)
+        specifier: ^3.5.21
+        version: 3.5.26(typescript@5.4.5)
       vue-router:
         specifier: ^4.3.0
-        version: 4.5.0(vue@3.5.13(typescript@5.4.5))
+        version: 4.5.0(vue@3.5.26(typescript@5.4.5))
     devDependencies:
       '@iconify-json/ri':
         specifier: ^1.1.20
@@ -41,7 +41,7 @@ importers:
         version: 20.17.30
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
-        version: 5.2.3(vite@5.4.18(@types/node@20.17.30))(vue@3.5.13(typescript@5.4.5))
+        version: 5.2.3(vite@5.4.18(@types/node@20.17.30))(vue@3.5.26(typescript@5.4.5))
       '@vue/eslint-config-typescript':
         specifier: ^12.0.0
         version: 12.0.0(eslint-plugin-vue@9.33.0(eslint@8.57.1))(eslint@8.57.1)(typescript@5.4.5)
@@ -50,7 +50,7 @@ importers:
         version: 0.5.1
       '@vueuse/core':
         specifier: ^10.9.0
-        version: 10.11.1(vue@3.5.13(typescript@5.4.5))
+        version: 10.11.1(vue@3.5.26(typescript@5.4.5))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.21(postcss@8.5.3)
@@ -77,7 +77,7 @@ importers:
         version: 5.4.5
       unplugin-icons:
         specifier: ^0.16.6
-        version: 0.16.6(@vue/compiler-sfc@3.5.13)
+        version: 0.16.6(@vue/compiler-sfc@3.5.26)
       vite:
         specifier: ^5.2.8
         version: 5.4.18(@types/node@20.17.30)
@@ -110,8 +110,16 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.27.0':
@@ -119,8 +127,17 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.28.5':
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.5':
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -319,6 +336,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
@@ -549,14 +569,20 @@ packages:
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
 
+  '@vue/compiler-core@3.5.26':
+    resolution: {integrity: sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==}
+
   '@vue/compiler-dom@3.5.13':
     resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
 
-  '@vue/compiler-sfc@3.5.13':
-    resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
+  '@vue/compiler-dom@3.5.26':
+    resolution: {integrity: sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==}
 
-  '@vue/compiler-ssr@3.5.13':
-    resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
+  '@vue/compiler-sfc@3.5.26':
+    resolution: {integrity: sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==}
+
+  '@vue/compiler-ssr@3.5.26':
+    resolution: {integrity: sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==}
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
@@ -583,22 +609,25 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.5.13':
-    resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
+  '@vue/reactivity@3.5.26':
+    resolution: {integrity: sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==}
 
-  '@vue/runtime-core@3.5.13':
-    resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
+  '@vue/runtime-core@3.5.26':
+    resolution: {integrity: sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==}
 
-  '@vue/runtime-dom@3.5.13':
-    resolution: {integrity: sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==}
+  '@vue/runtime-dom@3.5.26':
+    resolution: {integrity: sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==}
 
-  '@vue/server-renderer@3.5.13':
-    resolution: {integrity: sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==}
+  '@vue/server-renderer@3.5.26':
+    resolution: {integrity: sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==}
     peerDependencies:
-      vue: 3.5.13
+      vue: 3.5.26
 
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+
+  '@vue/shared@3.5.26':
+    resolution: {integrity: sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==}
 
   '@vue/tsconfig@0.5.1':
     resolution: {integrity: sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==}
@@ -788,8 +817,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -870,6 +899,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.0:
+    resolution: {integrity: sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.23.9:
@@ -1370,6 +1403,9 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
@@ -1628,6 +1664,10 @@ packages:
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1999,8 +2039,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.5.13:
-    resolution: {integrity: sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==}
+  vue@3.5.26:
+    resolution: {integrity: sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2084,16 +2124,29 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/parser@7.27.0':
     dependencies:
       '@babel/types': 7.27.0
 
+  '@babel/parser@7.28.5':
+    dependencies:
+      '@babel/types': 7.28.5
+
   '@babel/types@7.27.0':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -2238,6 +2291,8 @@ snapshots:
   '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
@@ -2429,10 +2484,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.3(vite@5.4.18(@types/node@20.17.30))(vue@3.5.13(typescript@5.4.5))':
+  '@vitejs/plugin-vue@5.2.3(vite@5.4.18(@types/node@20.17.30))(vue@3.5.26(typescript@5.4.5))':
     dependencies:
       vite: 5.4.18(@types/node@20.17.30)
-      vue: 3.5.13(typescript@5.4.5)
+      vue: 3.5.26(typescript@5.4.5)
 
   '@volar/language-core@2.4.12':
     dependencies:
@@ -2454,27 +2509,40 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.26':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@vue/shared': 3.5.26
+      entities: 7.0.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.13':
     dependencies:
       '@vue/compiler-core': 3.5.13
       '@vue/shared': 3.5.13
 
-  '@vue/compiler-sfc@3.5.13':
+  '@vue/compiler-dom@3.5.26':
     dependencies:
-      '@babel/parser': 7.27.0
-      '@vue/compiler-core': 3.5.13
-      '@vue/compiler-dom': 3.5.13
-      '@vue/compiler-ssr': 3.5.13
-      '@vue/shared': 3.5.13
+      '@vue/compiler-core': 3.5.26
+      '@vue/shared': 3.5.26
+
+  '@vue/compiler-sfc@3.5.26':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@vue/compiler-core': 3.5.26
+      '@vue/compiler-dom': 3.5.26
+      '@vue/compiler-ssr': 3.5.26
+      '@vue/shared': 3.5.26
       estree-walker: 2.0.2
-      magic-string: 0.30.17
-      postcss: 8.5.3
+      magic-string: 0.30.21
+      postcss: 8.5.6
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.13':
+  '@vue/compiler-ssr@3.5.26':
     dependencies:
-      '@vue/compiler-dom': 3.5.13
-      '@vue/shared': 3.5.13
+      '@vue/compiler-dom': 3.5.26
+      '@vue/shared': 3.5.26
 
   '@vue/compiler-vue2@2.7.16':
     dependencies:
@@ -2508,56 +2576,58 @@ snapshots:
     optionalDependencies:
       typescript: 5.4.5
 
-  '@vue/reactivity@3.5.13':
+  '@vue/reactivity@3.5.26':
     dependencies:
-      '@vue/shared': 3.5.13
+      '@vue/shared': 3.5.26
 
-  '@vue/runtime-core@3.5.13':
+  '@vue/runtime-core@3.5.26':
     dependencies:
-      '@vue/reactivity': 3.5.13
-      '@vue/shared': 3.5.13
+      '@vue/reactivity': 3.5.26
+      '@vue/shared': 3.5.26
 
-  '@vue/runtime-dom@3.5.13':
+  '@vue/runtime-dom@3.5.26':
     dependencies:
-      '@vue/reactivity': 3.5.13
-      '@vue/runtime-core': 3.5.13
-      '@vue/shared': 3.5.13
-      csstype: 3.1.3
+      '@vue/reactivity': 3.5.26
+      '@vue/runtime-core': 3.5.26
+      '@vue/shared': 3.5.26
+      csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.4.5))':
+  '@vue/server-renderer@3.5.26(vue@3.5.26(typescript@5.4.5))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.13
-      '@vue/shared': 3.5.13
-      vue: 3.5.13(typescript@5.4.5)
+      '@vue/compiler-ssr': 3.5.26
+      '@vue/shared': 3.5.26
+      vue: 3.5.26(typescript@5.4.5)
 
   '@vue/shared@3.5.13': {}
 
+  '@vue/shared@3.5.26': {}
+
   '@vue/tsconfig@0.5.1': {}
 
-  '@vueuse/components@10.11.1(vue@3.5.13(typescript@5.4.5))':
+  '@vueuse/components@10.11.1(vue@3.5.26(typescript@5.4.5))':
     dependencies:
-      '@vueuse/core': 10.11.1(vue@3.5.13(typescript@5.4.5))
-      '@vueuse/shared': 10.11.1(vue@3.5.13(typescript@5.4.5))
-      vue-demi: 0.14.10(vue@3.5.13(typescript@5.4.5))
+      '@vueuse/core': 10.11.1(vue@3.5.26(typescript@5.4.5))
+      '@vueuse/shared': 10.11.1(vue@3.5.26(typescript@5.4.5))
+      vue-demi: 0.14.10(vue@3.5.26(typescript@5.4.5))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@10.11.1(vue@3.5.13(typescript@5.4.5))':
+  '@vueuse/core@10.11.1(vue@3.5.26(typescript@5.4.5))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.13(typescript@5.4.5))
-      vue-demi: 0.14.10(vue@3.5.13(typescript@5.4.5))
+      '@vueuse/shared': 10.11.1(vue@3.5.26(typescript@5.4.5))
+      vue-demi: 0.14.10(vue@3.5.26(typescript@5.4.5))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
   '@vueuse/metadata@10.11.1': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.13(typescript@5.4.5))':
+  '@vueuse/shared@10.11.1(vue@3.5.26(typescript@5.4.5))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.13(typescript@5.4.5))
+      vue-demi: 0.14.10(vue@3.5.26(typescript@5.4.5))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -2752,7 +2822,7 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -2827,6 +2897,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   entities@4.5.0: {}
+
+  entities@7.0.0: {}
 
   es-abstract@1.23.9:
     dependencies:
@@ -3462,6 +3534,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   markdown-it@14.1.0:
     dependencies:
       argparse: 2.0.1
@@ -3705,6 +3781,12 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.3:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -4061,7 +4143,7 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  unplugin-icons@0.16.6(@vue/compiler-sfc@3.5.13):
+  unplugin-icons@0.16.6(@vue/compiler-sfc@3.5.26):
     dependencies:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.10
@@ -4071,7 +4153,7 @@ snapshots:
       local-pkg: 0.4.3
       unplugin: 1.16.1
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.13
+      '@vue/compiler-sfc': 3.5.26
     transitivePeerDependencies:
       - supports-color
 
@@ -4110,9 +4192,9 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-demi@0.14.10(vue@3.5.13(typescript@5.4.5)):
+  vue-demi@0.14.10(vue@3.5.26(typescript@5.4.5)):
     dependencies:
-      vue: 3.5.13(typescript@5.4.5)
+      vue: 3.5.26(typescript@5.4.5)
 
   vue-eslint-parser@9.4.3(eslint@8.57.1):
     dependencies:
@@ -4127,10 +4209,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@4.5.0(vue@3.5.13(typescript@5.4.5)):
+  vue-router@4.5.0(vue@3.5.26(typescript@5.4.5)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.13(typescript@5.4.5)
+      vue: 3.5.26(typescript@5.4.5)
 
   vue-tsc@2.2.10(typescript@5.4.5):
     dependencies:
@@ -4138,13 +4220,13 @@ snapshots:
       '@vue/language-core': 2.2.10(typescript@5.4.5)
       typescript: 5.4.5
 
-  vue@3.5.13(typescript@5.4.5):
+  vue@3.5.26(typescript@5.4.5):
     dependencies:
-      '@vue/compiler-dom': 3.5.13
-      '@vue/compiler-sfc': 3.5.13
-      '@vue/runtime-dom': 3.5.13
-      '@vue/server-renderer': 3.5.13(vue@3.5.13(typescript@5.4.5))
-      '@vue/shared': 3.5.13
+      '@vue/compiler-dom': 3.5.26
+      '@vue/compiler-sfc': 3.5.26
+      '@vue/runtime-dom': 3.5.26
+      '@vue/server-renderer': 3.5.26(vue@3.5.26(typescript@5.4.5))
+      '@vue/shared': 3.5.26
     optionalDependencies:
       typescript: 5.4.5
 

--- a/pkg/cmd/kitimport/cmd.go
+++ b/pkg/cmd/kitimport/cmd.go
@@ -66,7 +66,10 @@ kit import myorg/myrepo --ref v1.0.0
 kit import myorg/myrepo --tag myrepository:mytag
 
 # Download repository and pack it using an existing Kitfile
-kit import myorg/myrepo --file ./path/to/Kitfile`
+kit import myorg/myrepo --file ./path/to/Kitfile
+
+# Download only GGUF files from a repository
+kit import myorg/myrepo --filter "*.gguf"`
 )
 
 type importOptions struct {
@@ -78,6 +81,7 @@ type importOptions struct {
 	kitfilePath  string
 	downloadTool string
 	concurrency  int
+	filters      []string
 	modelKitRef  *registry.Reference
 }
 
@@ -99,6 +103,7 @@ func ImportCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.kitfilePath, "file", "f", "", "Path to Kitfile to use for packing (use '-' to read from standard input)")
 	cmd.Flags().StringVar(&opts.downloadTool, "tool", "", "Tool to use for downloading files: options are 'git' and 'hf' (default: detect based on repository)")
 	cmd.Flags().IntVar(&opts.concurrency, "concurrency", 5, "Maximum number of simultaneous downloads (for huggingface)")
+	cmd.Flags().StringSliceVar(&opts.filters, "filter", []string{}, "Filter files to import using glob patterns (e.g. --filter \"*.gguf\")")
 	cmd.Flags().SortFlags = false
 	return cmd
 }

--- a/pkg/cmd/kitimport/gitimport.go
+++ b/pkg/cmd/kitimport/gitimport.go
@@ -77,6 +77,16 @@ func importUsingGit(ctx context.Context, opts *importOptions) error {
 		if err != nil {
 			return fmt.Errorf("error processing directory: %w", err)
 		}
+		if len(opts.filters) > 0 {
+			dirContents = filterDirectoryListing(dirContents, opts.filters)
+			if len(dirContents.Files) == 0 && len(dirContents.Subdirs) == 0 {
+				return fmt.Errorf("no files match the provided filters: %v", opts.filters)
+			}
+			// For git, we need to actually remove files from disk that don't match the filter
+			if err := removeUnmatchedFiles(tmpDir, dirContents); err != nil {
+				return fmt.Errorf("failed to remove unmatched files: %w", err)
+			}
+		}
 		kf, err := generateKitfile(dirContents, opts.repo, tmpDir)
 		if err != nil {
 			return err
@@ -130,4 +140,37 @@ func cloneRepository(repo, repoRef, destDir, token string) error {
 		return err
 	}
 	return nil
+}
+
+func removeUnmatchedFiles(tmpDir string, filteredListing *kfgen.DirectoryListing) error {
+	// Create a map of files to keep for efficient lookup
+	filesToKeep := make(map[string]bool)
+	var addToListing func(*kfgen.DirectoryListing)
+	addToListing = func(l *kfgen.DirectoryListing) {
+		for _, f := range l.Files {
+			filesToKeep[filepath.Join(tmpDir, f.Path)] = true
+		}
+		for _, s := range l.Subdirs {
+			addToListing(&s)
+		}
+	}
+	addToListing(filteredListing)
+
+	// In addition to files, we need to keep the Kitfile if it was generated
+	filesToKeep[filepath.Join(tmpDir, constants.DefaultKitfileName)] = true
+
+	return filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !filesToKeep[path] {
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("failed to remove %s: %w", path, err)
+			}
+		}
+		return nil
+	})
 }

--- a/pkg/cmd/kitimport/hfimport.go
+++ b/pkg/cmd/kitimport/hfimport.go
@@ -58,6 +58,13 @@ func importUsingHF(ctx context.Context, opts *importOptions) error {
 		return fmt.Errorf("failed to list files from HuggingFace API: %w", err)
 	}
 
+	if len(opts.filters) > 0 {
+		dirListing = filterDirectoryListing(dirListing, opts.filters)
+		if len(dirListing.Files) == 0 && len(dirListing.Subdirs) == 0 {
+			return fmt.Errorf("no files match the provided filters: %v", opts.filters)
+		}
+	}
+
 	var kitfile *artifact.KitFile
 	if opts.kitfilePath == "-" {
 		kitfile = &artifact.KitFile{}
@@ -172,3 +179,4 @@ func kitfileHasCatchallLayer(kitfile *artifact.KitFile) bool {
 	}
 	return false
 }
+

--- a/pkg/cmd/kitimport/util.go
+++ b/pkg/cmd/kitimport/util.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -185,4 +186,36 @@ func extractRepoFromURL(rawUrl string) (string, error) {
 	}
 
 	return path, nil
+}
+
+func filterDirectoryListing(listing *kfgen.DirectoryListing, filters []string) *kfgen.DirectoryListing {
+	newListing := &kfgen.DirectoryListing{
+		Name: listing.Name,
+		Path: listing.Path,
+	}
+
+	for _, file := range listing.Files {
+		for _, filter := range filters {
+			match, err := path.Match(filter, file.Name)
+			if err == nil && match {
+				newListing.Files = append(newListing.Files, file)
+				break
+			}
+			// Also check against full path relative to repo root
+			match, err = path.Match(filter, file.Path)
+			if err == nil && match {
+				newListing.Files = append(newListing.Files, file)
+				break
+			}
+		}
+	}
+
+	for _, subdir := range listing.Subdirs {
+		filteredSubdir := filterDirectoryListing(&subdir, filters)
+		if len(filteredSubdir.Files) > 0 || len(filteredSubdir.Subdirs) > 0 {
+			newListing.Subdirs = append(newListing.Subdirs, *filteredSubdir)
+		}
+	}
+
+	return newListing
 }

--- a/pkg/cmd/kitimport/util_test.go
+++ b/pkg/cmd/kitimport/util_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	kfgen "github.com/kitops-ml/kitops/pkg/lib/kitfile/generate"
 )
 
 func TestExtractRepoFromURL(t *testing.T) {
@@ -57,4 +58,92 @@ func TestExtractRepoFromURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFilterDirectoryListing(t *testing.T) {
+	listing := &kfgen.DirectoryListing{
+		Name: ".",
+		Path: ".",
+		Files: []kfgen.FileListing{
+			{Name: "model.safetensors", Path: "model.safetensors"},
+			{Name: "config.json", Path: "config.json"},
+			{Name: "README.md", Path: "README.md"},
+		},
+		Subdirs: []kfgen.DirectoryListing{
+			{
+				Name: "onnx",
+				Path: "onnx",
+				Files: []kfgen.FileListing{
+					{Name: "model.onnx", Path: "onnx/model.onnx"},
+				},
+			},
+			{
+				Name: "gguf",
+				Path: "gguf",
+				Files: []kfgen.FileListing{
+					{Name: "model-q4_0.gguf", Path: "gguf/model-q4_0.gguf"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		filters   []string
+		wantFiles []string
+		wantDirs  []string
+	}{
+		{
+			name:      "Filter by extension",
+			filters:   []string{"*.gguf"},
+			wantFiles: []string{"model-q4_0.gguf"},
+			wantDirs:  []string{"gguf"},
+		},
+		{
+			name:      "Filter by path",
+			filters:   []string{"onnx/*"},
+			wantFiles: []string{"model.onnx"},
+			wantDirs:  []string{"onnx"},
+		},
+		{
+			name:      "Multiple filters",
+			filters:   []string{"*.safetensors", "config.json"},
+			wantFiles: []string{"model.safetensors", "config.json"},
+			wantDirs:  []string{},
+		},
+		{
+			name:      "No matches",
+			filters:   []string{"*.pth"},
+			wantFiles: []string{},
+			wantDirs:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterDirectoryListing(listing, tt.filters)
+			assert.Equal(t, tt.wantFiles, collectFiles(got))
+			assert.Equal(t, tt.wantDirs, collectDirs(got))
+		})
+	}
+}
+
+func collectFiles(l *kfgen.DirectoryListing) []string {
+	files := []string{}
+	for _, f := range l.Files {
+		files = append(files, f.Name)
+	}
+	for _, s := range l.Subdirs {
+		files = append(files, collectFiles(&s)...)
+	}
+	return files
+}
+
+func collectDirs(l *kfgen.DirectoryListing) []string {
+	dirs := []string{}
+	for _, s := range l.Subdirs {
+		dirs = append(dirs, s.Name)
+		dirs = append(dirs, collectDirs(&s)...)
+	}
+	return dirs
 }


### PR DESCRIPTION
Allows users to filter files during import from Hugging Face and Git using glob patterns.

 Description

This PR introduces selective file filtering for the `kit import` command via a new `--filter` flag. This feature allows users to provide glob patterns to include only specific files or directories when importing from Hugging Face or Git repositories.

 Key Benefits:

1. Bandwidth Efficiency -  For Hugging Face imports, filtering happens at the API level. `kit` only downloads files that match the user's patterns, avoiding the need to download large, unnecessary model formats (e.g., skipping `.safetensors` when only `.gguf` is needed).

2.  Reduced Storage Footprint* : For Git imports, unmatched files are pruned from the temporary workspace before the ModelKit is packed.

3. improved Workflow: Users can now import specific branches or sub-folders of large repositories with surgical precision.


Technical Details:

1. New Flag: Added `--filter` (StringSlice) to `importOptions`.

2. Hugging Face Implementation: Integrated the filter into the `importUsingHF` flow. It modifies the `DirectoryListing` before the download phase begins.

3.  Git Implementation: Integrated the filter into the `importUsingGit` flow. It utilizes a new `removeUnmatchedFiles` helper to clean up the cloned repository post-download but pre-pack.

4. Unified Filtering: Created a reusable `filterDirectoryListing` utility in `pkg/cmd/kitimport/util.go` that uses `path.Match` for cross-platform globbing support.

5.  unit Testing: Added comprehensive tests in `pkg/cmd/kitimport/util_test.go` covering extension-based filtering, path-based filtering, and multiple filter combinations.


Linked issues
Fixes # (Manual contribution)

Example Usage:
```bash
# Import only GGUF files
kit import bartowski/Llama-3.2-3B-Instruct-GGUF --filter "*.gguf"

# Import a specific module from a repository
kit import microsoft/phi-2 --filter "onnx/*"

