### PR TITLE
docs: add Kubeflow integration guide

### DIFF
--- a/docs/src/docs/integrations/integrations.md
+++ b/docs/src/docs/integrations/integrations.md
@@ -18,6 +18,7 @@ The KitOps community has built some great integrations:
 - Outputting ModelKits directly from [MLFlow](../mlflow.md)
 - Deploying to any [Kubernetes distribution](../k8s-init-container.md)
 - Working with ML in [KServe](../kserve.md)
+- Running pipelines in [Kubeflow](../kubeflow.md)
 
 ## 🗄️ KitOps Compliant OCI Registries (A-Z)
 
@@ -107,3 +108,4 @@ Thanks to its OCI-compatibility, KitOps works nearly any tool:
 If you've used KitOps with a product or project we've missed, please [open an issue](https://github.com/jozu-ai/kitops/issues/new/choose) in our GitHub repository.
 
 For help please join our [Discord community](https://discord.gg/Tapeh8agYy).
+<!-- AGENT_MODIFIED: Human review required before merge -->

--- a/docs/src/docs/integrations/kubeflow.md
+++ b/docs/src/docs/integrations/kubeflow.md
@@ -52,4 +52,3 @@ If you want fully reproducible pipelines, build a container image that includes 
 - ModelKit references can be any OCI reference supported by your registry (tagged or digested).
 - For air‑gapped clusters or private registries, make sure the pipeline runtime can pull the container image used by the step and authenticate to the ModelKit registry.
 
-<!-- AGENT_MODIFIED: Human review required before merge -->


### PR DESCRIPTION
This guide shows how to pull and unpack a ModelKit inside a **Kubeflow Pipelines** step so downstream steps can use the extracted files.
