### PR TITLE
 Fix `kit login` failure when trace logging is enabled

### DIFF
--- a/pkg/lib/repo/remote/registry.go
+++ b/pkg/lib/repo/remote/registry.go
@@ -45,7 +45,8 @@ func NewRegistry(hostname string, opts *options.NetworkOptions) (*remote.Registr
 	if err != nil {
 		return nil, err
 	}
-	reg.Client = output.WrapClient(authClient)
+	authClient.Client.Transport = output.WrapHTTPTransport(authClient.Client.Transport)
+	reg.Client = authClient
 
 	return reg, nil
 }

--- a/pkg/output/client.go
+++ b/pkg/output/client.go
@@ -19,26 +19,7 @@ package output
 import (
 	"net/http"
 	"time"
-
-	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/auth"
 )
-
-type LoggingClient struct {
-	remote.Client
-}
-
-func (c *LoggingClient) Do(req *http.Request) (*http.Response, error) {
-	start := time.Now()
-	resp, err := c.Client.Do(req)
-	duration := float64(time.Since(start)) / float64(time.Millisecond)
-	if err != nil {
-		SafeLogf(LogLevelTrace, "%s %s -> ERROR -- duration %.2f ms", req.Method, req.URL, duration)
-	} else {
-		SafeLogf(LogLevelTrace, "%s %s -> %d -- duration %.2f ms", req.Method, req.URL, resp.StatusCode, duration)
-	}
-	return resp, err
-}
 
 type LoggingTransport struct {
 	http.RoundTripper
@@ -60,25 +41,9 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	return resp, err
 }
 
-// WrapClient returns a remote.Client that logs every request at a 'trace' level.
-// If the currently set logging level would not print 'trace' logs, this is a no-op.
-func WrapClient(c remote.Client) remote.Client {
+func WrapHTTPTransport(rt http.RoundTripper) http.RoundTripper {
 	if !logLevel.shouldPrint(LogLevelTrace) {
-		return c
+		return rt
 	}
-
-	// If the client is an *auth.Client, we need to wrap the underlying http.Client Transport
-	if authClient, ok := c.(*auth.Client); ok {
-		if authClient.Client == nil {
-			authClient.Client = &http.Client{}
-		}
-		authClient.Client.Transport = &LoggingTransport{
-			RoundTripper: authClient.Client.Transport,
-		}
-		return authClient
-	}
-
-	return &LoggingClient{
-		Client: c,
-	}
+	return &LoggingTransport{rt}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/kitops-ml/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/kitops-ml/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description
<!-- describe the changes in this PR -->

- Modified `pkg/output/client.go` to use a `LoggingTransport` instead of wrapping the entire client struct. This ensures the client remains satisfied as an `*auth.Client` for the oras library while still logging requests, because The `oras-go` library's `login` function performs a strict type assertion on the registry client, requiring it to be of type `*auth.Client`. Previously, our trace logging mechanism wrapped this client in a custom `LoggingClient` struct to capture request metrics, which caused this type assertion to fail.

### Linked issues
<!-- link any issues in this repository that are related to the PR; use "closes <issue>" or "fixes <issue>" to automatically link issues to this PR -->
- Fixes #807 a bug where running `kit login` with trace logging enabled (e.g., `kit login -vv`) would fail with the error `client type not supported`

### AI-Assisted Code
<!-- Check all that apply -->
- [ ] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
