### PR TITLE
docs: Fix README Table of Contents link to correctly match the Try KitOps section anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## 📚 Table of Contents
 - [What is KitOps?](#what-is-kitops)
 - [KitOps Architecture](#kitops-architecture)
-- [Try KitOps](#try-kitops-in-under-15-minutes)
+- [Try KitOps](#-try-kitops-in-under-15-minutes)
 - [Benefits](#key-benefits)
 - [Community & Support](#join-kitops-community)
 


### PR DESCRIPTION
### Description

Fix the README Table of Contents link so “Try KitOps” correctly jumps to the “🚀 Try KitOps in under 15 Minutes” section.

### Linked issues

N/A

### AI-Assisted Code

- This PR doesn't contain any AI-generated code

