### PR TITLE
Clarify GitLab support

### DIFF
--- a/docs/src/docs/integrations/integrations.md
+++ b/docs/src/docs/integrations/integrations.md
@@ -96,7 +96,7 @@ Thanks to its OCI-compatibility, KitOps works nearly any tool:
 * Git
 * Git LFS
 * GitHub Actions
-* GitLab Pipelines (on-prem only, [see their docs](https://gitlab.com/gitlab-org/container-registry/-/blob/master/docs/supported-media-types.md?ref_type=heads))
+* GitLab Pipelines
 * Jenkins CI/CD
 * Kubeflow
 * Spinnaker


### PR DESCRIPTION
### Description
GitLab only supports a set list of media types they control. On-Prem customers can customize that. This PR clarifies that and provides a link to the GitLab supported media types document

### AI-Assisted Code
<!-- Check all that apply -->
- [ ] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
