### PR TITLE
Fix KitOps build after merge discrepancy

### DIFF
--- a/pkg/cmd/kitinit/cmd.go
+++ b/pkg/cmd/kitinit/cmd.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/kitops-ml/kitops/pkg/artifact"
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
-	"github.com/kitops-ml/kitops/pkg/lib/hf"
+	"github.com/kitops-ml/kitops/pkg/lib/external/hf"
 	kfgen "github.com/kitops-ml/kitops/pkg/lib/kitfile/generate"
 	"github.com/kitops-ml/kitops/pkg/lib/util"
 	"github.com/kitops-ml/kitops/pkg/output"


### PR DESCRIPTION
### Description
Commit 11bb2e37670cb2b39393e02a973f449b26bfd3c8 introduced a dependency on the huggingface package from the init command. However, it was rooted at a base commit that did not include a refactor from commit f72803331017b5dca492c0b29be3c60d6d6902a1 that changed the package path. This causes a build error in the main branch that for some reason was not caught by CI tests.

