### PR TITLE
fix(harness): prevent OOM in verifyChecksum using stream

### DIFF
--- a/pkg/lib/harness/llm_download.go
+++ b/pkg/lib/harness/llm_download.go
@@ -176,13 +176,18 @@ func verifyChecksum(folder, filename string, checksums map[string]string) error 
 	}
 
 	filePath := filepath.Join(folder, filename)
-	fileData, err := os.ReadFile(filePath)
+	file, err := os.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to read file %s: %w", filePath, err)
+		return fmt.Errorf("failed to open file %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return fmt.Errorf("failed to compute checksum for %s: %w", filePath, err)
 	}
 
-	hash := sha256.Sum256(fileData)
-	computedChecksum := hex.EncodeToString(hash[:])
+	computedChecksum := hex.EncodeToString(hash.Sum(nil))
 
 	if computedChecksum != expectedChecksum {
 		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", filename, expectedChecksum, computedChecksum)


### PR DESCRIPTION
### Summary
This PR fixes an Out-Of-Memory (OOM) risk in the harness download process.

Currently, `pkg/lib/harness/llm_download.go` uses `os.ReadFile()` inside `verifyChecksum` to load the entire downloaded harness file (`llamafile.tar.gz` or `ui.tar.gz`) into RAM all at once in order to compute the SHA-256 hash. In memory-constrained environments or with future larger harness binaries, this memory spike can trigger an OOM kill.

### Changes Made
- Replaced `os.ReadFile` and `sha256.Sum256` with a streaming approach.
- Implemented `io.Copy` to stream the file contents directly into a `sha256.New()` hasher.
- This guarantees a small, constant memory footprint regardless of the downloaded file size.

### Related Issue
Closes #1114

### Testing Done
- Successfully built `kit` locally.
- Confirmed `go test ./...` passes locally.
- Ensured my commit is DCO signed-off (`-s`).

### AI-Assisted Contribution Checklist
- [x] I have read all AI-generated code. I understand what it does and why.
- [x] **Testing**: I have tested the code and verified its behavior.
- [x] **Cleanup**: I have removed verbose AI comments, unnecessary explanations, and boilerplate.
- [x] **No Hallucinations**: I have verified all imports, function calls, and APIs.