### PR TITLE
Fix #1138: Set org.opencontainers.image.created annotation on ModelKit manifests

### DIFF
--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/kitops-ml/kitops/pkg/artifact"
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
@@ -63,6 +64,11 @@ func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact
 	if err != nil {
 		return nil, fmt.Errorf("error creating manifest: %w", err)
 	}
+
+	if manifest.Annotations == nil {
+		manifest.Annotations = map[string]string{}
+	}
+	manifest.Annotations[ocispec.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
 
 	// If not storing a Kitfile, save the Kitfile to an annotation since it will be lost otherwise
 	if opts.ModelFormat == mediatype.ModelPackFormat {

--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -65,11 +65,6 @@ func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact
 		return nil, fmt.Errorf("error creating manifest: %w", err)
 	}
 
-	if manifest.Annotations == nil {
-		manifest.Annotations = map[string]string{}
-	}
-	manifest.Annotations[ocispec.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
-
 	// If not storing a Kitfile, save the Kitfile to an annotation since it will be lost otherwise
 	if opts.ModelFormat == mediatype.ModelPackFormat {
 		kitfileBytes, err := kitfile.MarshalToJSON()
@@ -351,6 +346,7 @@ func createManifest(configDesc ocispec.Descriptor, layerDescs []ocispec.Descript
 		manifest.Annotations = map[string]string{}
 	}
 	manifest.Annotations[constants.CliVersionAnnotation] = constants.Version
+	manifest.Annotations[ocispec.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
 
 	return manifest, nil
 }


### PR DESCRIPTION
## Summary

Add the standard OCI annotation `org.opencontainers.image.created` with the current time in RFC 3339 format to ModelKit manifests during the pack operation, alongside the existing `ml.kitops.modelkit.cli-version` annotation.

## Approach

In the function within `pkg/lib/filesystem/local-storage.go` that constructs the manifest and sets annotations (where `ml.kitops.modelkit.cli-version` is already set), add a new annotation entry with key `org.opencontainers.image.created` and value set to `time.Now().UTC().Format(time.RFC3339)`. This requires importing the `time` package if not already imported. The change should be placed right next to the existing CLI version annotation assignment to keep annotation logic grouped together.

## Files Changed

- `pkg/lib/filesystem/local-storage.go`

## Related Issue

Fixes #1138

## Testing

No tests were added with this change. Happy to add them if needed.
