### PR TITLE
fix(git): check destination emptiness without full readdir

### DIFF
--- a/pkg/lib/external/git/clone.go
+++ b/pkg/lib/external/git/clone.go
@@ -19,6 +19,7 @@ package git
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -113,13 +114,19 @@ func checkDestination(path string) error {
 	if !stat.IsDir() {
 		return fmt.Errorf("path %s exists and is not a directory", path)
 	}
-	// TODO: probably don't need to read the _whole_ directory
-	contents, err := os.ReadDir(path)
+	// Only check whether at least one entry exists; avoid reading full directory.
+	dir, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("failed to inspect directory %s: %w", path, err)
 	}
-	if len(contents) > 0 {
+	defer dir.Close()
+
+	_, err = dir.ReadDir(1)
+	if err == nil {
 		return fmt.Errorf("cannot clone to a non-empty directory")
+	}
+	if !errors.Is(err, io.EOF) {
+		return fmt.Errorf("failed to inspect directory %s: %w", path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Avoid reading an entire directory just to determine if clone destination is empty. Use ReadDir(1) to detect emptiness efficiently while preserving error behavior for non-empty and inaccessible paths.

<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/kitops-ml/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/kitops-ml/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description

This PR improves clone destination validation in `pkg/lib/external/git/clone.go`.

Previously, `checkDestination` used `os.ReadDir(path)` to determine whether a directory is empty, which reads the entire directory contents even though only an empty/non-empty check is needed.

This change replaces that with a one-entry probe:
- `os.Open(path)`
- `ReadDir(1)`

Behavior is preserved:
- `err == nil` => directory is non-empty
- `err == io.EOF` => directory is empty
- other errors => return wrapped inspection error

Validation:
- `go test ./pkg/lib/external/git` (pass)

### Linked issues

N/A