### PR TITLE
fix: generate Kitfile for ModelPack if missing from manifest

### DIFF
--- a/pkg/lib/filesystem/unpack/core.go
+++ b/pkg/lib/filesystem/unpack/core.go
@@ -37,7 +37,6 @@ import (
 	"github.com/kitops-ml/kitops/pkg/lib/repo/util"
 	"github.com/kitops-ml/kitops/pkg/output"
 
-	modelspecv1 "github.com/modelpack/model-spec/specs-go/v1"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 )
@@ -96,7 +95,7 @@ func unpackRecursive(ctx context.Context, opts *UnpackOptions, visitedRefs []str
 		output.Logf(output.LogLevelWarn, "Could not get Kitfile: %s", err)
 		output.Logf(output.LogLevelWarn, "Functionality may be impacted")
 		// TODO: we can probably _also_ handle getting the model-spec config and using it here
-		genconfig, err := generateKitfileForModelPack(manifest)
+		genconfig, err := util.GenerateKitfileForModelPack(manifest)
 		if err != nil {
 			return fmt.Errorf("could not process manifest: %w", err)
 		}
@@ -480,41 +479,4 @@ func getIndex(list []string, s string) int {
 		}
 	}
 	return -1
-}
-
-// generateKitfileForModelPack generates a "Kitfile" for a manifest that otherwise does not contain one.
-// This is a minimal Kitfile suitable only for unpacking, containing a path for every layer. If a layer
-// does not use the 'org.cncf.model.filepath' annotation, an error is returned.
-func generateKitfileForModelPack(manifest *ocispec.Manifest) (*artifact.KitFile, error) {
-	if format, err := mediatype.ModelFormatForManifest(manifest); err != nil || format != mediatype.ModelPackFormat {
-		return nil, fmt.Errorf("not a modelpack artifact")
-	}
-	kf := &artifact.KitFile{
-		Model: &artifact.Model{},
-	}
-	for _, desc := range manifest.Layers {
-		if desc.Annotations == nil || desc.Annotations[modelspecv1.AnnotationFilepath] == "" {
-			return nil, fmt.Errorf("unknown file path for layer: no %s annotation", modelspecv1.AnnotationFilepath)
-		}
-		filepath := desc.Annotations[modelspecv1.AnnotationFilepath]
-		mt, err := mediatype.ParseMediaType(desc.MediaType)
-		if err != nil {
-			return nil, err
-		}
-		switch mt.Base() {
-		case mediatype.ModelBaseType:
-			kf.Model.Path = filepath
-		case mediatype.ModelPartBaseType:
-			kf.Model.Parts = append(kf.Model.Parts, artifact.ModelPart{Path: filepath})
-		case mediatype.CodeBaseType:
-			kf.Code = append(kf.Code, artifact.Code{Path: filepath})
-		case mediatype.DatasetBaseType:
-			kf.DataSets = append(kf.DataSets, artifact.DataSet{Path: filepath})
-		case mediatype.DocsBaseType:
-			kf.Docs = append(kf.Docs, artifact.Docs{Path: filepath})
-		default:
-			return nil, fmt.Errorf("unknown layer type: %s", mt)
-		}
-	}
-	return kf, nil
 }

--- a/pkg/lib/repo/util/modelpack.go
+++ b/pkg/lib/repo/util/modelpack.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+
+	"github.com/kitops-ml/kitops/pkg/artifact"
+	"github.com/kitops-ml/kitops/pkg/lib/constants/mediatype"
+	modelspecv1 "github.com/modelpack/model-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// GenerateKitfileForModelPack generates a minimal Kitfile for a ModelPack manifest.
+// This fallback is suitable for unpack and inspect workflows when no Kitfile is
+// available in annotations.
+func GenerateKitfileForModelPack(manifest *ocispec.Manifest) (*artifact.KitFile, error) {
+	if format, err := mediatype.ModelFormatForManifest(manifest); err != nil || format != mediatype.ModelPackFormat {
+		return nil, fmt.Errorf("not a modelpack artifact")
+	}
+	kf := &artifact.KitFile{
+		Model: &artifact.Model{},
+	}
+	for _, desc := range manifest.Layers {
+		if desc.Annotations == nil || desc.Annotations[modelspecv1.AnnotationFilepath] == "" {
+			return nil, fmt.Errorf("unknown file path for layer: no %s annotation", modelspecv1.AnnotationFilepath)
+		}
+		filepath := desc.Annotations[modelspecv1.AnnotationFilepath]
+		mt, err := mediatype.ParseMediaType(desc.MediaType)
+		if err != nil {
+			return nil, err
+		}
+		switch mt.Base() {
+		case mediatype.ModelBaseType:
+			kf.Model.Path = filepath
+		case mediatype.ModelPartBaseType:
+			kf.Model.Parts = append(kf.Model.Parts, artifact.ModelPart{Path: filepath})
+		case mediatype.CodeBaseType:
+			kf.Code = append(kf.Code, artifact.Code{Path: filepath})
+		case mediatype.DatasetBaseType:
+			kf.DataSets = append(kf.DataSets, artifact.DataSet{Path: filepath})
+		case mediatype.DocsBaseType:
+			kf.Docs = append(kf.Docs, artifact.Docs{Path: filepath})
+		default:
+			return nil, fmt.Errorf("unknown layer type: %s", mt)
+		}
+	}
+	return kf, nil
+}

--- a/pkg/lib/repo/util/modelpack_test.go
+++ b/pkg/lib/repo/util/modelpack_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"testing"
+
+	"github.com/kitops-ml/kitops/pkg/lib/constants/mediatype"
+	modelspecv1 "github.com/modelpack/model-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateKitfileForModelPack(t *testing.T) {
+	manifest := &ocispec.Manifest{
+		ArtifactType: mediatype.ArtifactTypeModelManifest,
+		Config: ocispec.Descriptor{
+			MediaType: mediatype.ModelPackConfigMediaType.String(),
+		},
+		Layers: []ocispec.Descriptor{
+			{
+				MediaType: mediatype.New(mediatype.ModelPackFormat, mediatype.ModelBaseType, mediatype.TarFormat, mediatype.GzipCompression).String(),
+				Annotations: map[string]string{
+					modelspecv1.AnnotationFilepath: "models/main.gguf",
+				},
+			},
+			{
+				MediaType: mediatype.New(mediatype.ModelPackFormat, mediatype.CodeBaseType, mediatype.TarFormat, mediatype.GzipCompression).String(),
+				Annotations: map[string]string{
+					modelspecv1.AnnotationFilepath: "src/app.py",
+				},
+			},
+			{
+				MediaType: mediatype.New(mediatype.ModelPackFormat, mediatype.DatasetBaseType, mediatype.TarFormat, mediatype.GzipCompression).String(),
+				Annotations: map[string]string{
+					modelspecv1.AnnotationFilepath: "data/train.csv",
+				},
+			},
+			{
+				MediaType: mediatype.New(mediatype.ModelPackFormat, mediatype.DocsBaseType, mediatype.TarFormat, mediatype.GzipCompression).String(),
+				Annotations: map[string]string{
+					modelspecv1.AnnotationFilepath: "docs/readme.md",
+				},
+			},
+		},
+	}
+
+	kf, err := GenerateKitfileForModelPack(manifest)
+	require.NoError(t, err)
+	require.NotNil(t, kf.Model)
+	require.Equal(t, "models/main.gguf", kf.Model.Path)
+	require.Len(t, kf.Code, 1)
+	require.Equal(t, "src/app.py", kf.Code[0].Path)
+	require.Len(t, kf.DataSets, 1)
+	require.Equal(t, "data/train.csv", kf.DataSets[0].Path)
+	require.Len(t, kf.Docs, 1)
+	require.Equal(t, "docs/readme.md", kf.Docs[0].Path)
+}
+
+func TestGenerateKitfileForModelPackMissingPathAnnotation(t *testing.T) {
+	manifest := &ocispec.Manifest{
+		ArtifactType: mediatype.ArtifactTypeModelManifest,
+		Config: ocispec.Descriptor{
+			MediaType: mediatype.ModelPackConfigMediaType.String(),
+		},
+		Layers: []ocispec.Descriptor{
+			{
+				MediaType: mediatype.New(mediatype.ModelPackFormat, mediatype.ModelBaseType, mediatype.TarFormat, mediatype.GzipCompression).String(),
+			},
+		},
+	}
+
+	_, err := GenerateKitfileForModelPack(manifest)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), modelspecv1.AnnotationFilepath)
+}

--- a/pkg/lib/repo/util/reference.go
+++ b/pkg/lib/repo/util/reference.go
@@ -84,16 +84,15 @@ func GetKitfileForManifest(ctx context.Context, store oras.ReadOnlyTarget, manif
 	case mediatype.KitFormat:
 		return GetConfig(ctx, store, manifest.Config)
 	case mediatype.ModelPackFormat:
-		// TODO: can we (try to) generate a Kitfile from a ModelPack manifest?
-		if manifest.Annotations == nil || manifest.Annotations[constants.KitfileJsonAnnotation] == "" {
-			return nil, ErrNoKitfile
+		if manifest.Annotations != nil && manifest.Annotations[constants.KitfileJsonAnnotation] != "" {
+			kfstring := manifest.Annotations[constants.KitfileJsonAnnotation]
+			kitfile := &artifact.KitFile{}
+			if err := json.Unmarshal([]byte(kfstring), kitfile); err != nil {
+				return nil, fmt.Errorf("failed to parse config: %w", err)
+			}
+			return kitfile, nil
 		}
-		kfstring := manifest.Annotations[constants.KitfileJsonAnnotation]
-		kitfile := &artifact.KitFile{}
-		if err := json.Unmarshal([]byte(kfstring), kitfile); err != nil {
-			return nil, fmt.Errorf("failed to parse config: %w", err)
-		}
-		return kitfile, nil
+		return GenerateKitfileForModelPack(manifest)
 	default:
 		// Won't happen but necessary for completeness
 		return nil, fmt.Errorf("unknown artifact type")


### PR DESCRIPTION
Use fallback generation for missing Kitfile in ModelPacks.

<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/kitops-ml/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/kitops-ml/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description

This PR introduces a fallback mechanism to generate a Kitfile in-memory when a ModelPack manifest does not contain one in its annotations. 

Previously, if the `org.cncf.model.kitfile` annotation was missing, `GetKitfileForManifest` would return `ErrNoKitfile`. This change adds `GenerateKitfileForModelPack` to reconstruct the Kitfile from layer metadata (filepaths and media types), allowing tools to inspect and unpack these artifacts seamlessy.

Validation:
- Added new unit tests in `pkg/lib/repo/util/modelpack_test.go`
- Verified existing logic in `pkg/lib/filesystem/unpack/core.go` now uses the shared utility.

### Linked issues

Fixes missing Kitfile handling for ModelPacks.