### PR TITLE
Add ModelPack created annotation to manifests

### DIFF
--- a/pkg/lib/constants/consts.go
+++ b/pkg/lib/constants/consts.go
@@ -51,8 +51,9 @@ const (
 
 	// Kitops-specific annotations for modelkit artifacts
 	// TODO: update these to use the newer kitops.org domain
-	CliVersionAnnotation  = "ml.kitops.modelkit.cli-version"
-	KitfileJsonAnnotation = "ml.kitops.modelkit.kitfile"
+	CliVersionAnnotation      = "ml.kitops.modelkit.cli-version"
+	KitfileJsonAnnotation     = "ml.kitops.modelkit.kitfile"
+	OciImageCreatedAnnotation = "org.opencontainers.image.created"
 
 	// LayerSubtypeAnnotation stores additional type information for a given OCI manifest
 	// layer within its annotations (e.g. storing prompts within code-type layers)

--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/kitops-ml/kitops/pkg/artifact"
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
@@ -54,12 +55,12 @@ func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact
 		return nil, err
 	}
 
-	configDesc, err := saveConfig(ctx, localRepo, kitfile, diffIDs, opts.ModelFormat)
+	configDesc, createdAtAnnotation, err := saveConfig(ctx, localRepo, kitfile, diffIDs, opts.ModelFormat)
 	if err != nil {
 		return nil, err
 	}
 
-	manifest, err := createManifest(configDesc, layerDescs, opts.ModelFormat)
+	manifest, err := createManifest(configDesc, layerDescs, opts.ModelFormat, createdAtAnnotation)
 	if err != nil {
 		return nil, fmt.Errorf("error creating manifest: %w", err)
 	}
@@ -88,27 +89,31 @@ func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact
 	return manifestDesc, nil
 }
 
-func saveConfig(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact.KitFile, diffIDs []digest.Digest, modelFormat mediatype.ModelFormat) (ocispec.Descriptor, error) {
+func saveConfig(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact.KitFile, diffIDs []digest.Digest, modelFormat mediatype.ModelFormat) (ocispec.Descriptor, string, error) {
 	var configBytes []byte
 	var configMediaType string
+	var createdAtAnnotation string
 	switch modelFormat {
 	case mediatype.KitFormat:
 		configMediaType = mediatype.KitConfigMediaType.String()
 		bytes, err := kitfile.MarshalToJSON()
 		if err != nil {
-			return ocispec.DescriptorEmptyJSON, err
+			return ocispec.DescriptorEmptyJSON, "", err
 		}
 		configBytes = bytes
 	case mediatype.ModelPackFormat:
 		configMediaType = mediatype.ModelPackConfigMediaType.String()
 		modelpackConfig := kitfile.ToModelPackConfig(diffIDs)
+		if modelpackConfig.Descriptor.CreatedAt != nil {
+			createdAtAnnotation = modelpackConfig.Descriptor.CreatedAt.UTC().Format(time.RFC3339)
+		}
 		bytes, err := json.Marshal(modelpackConfig)
 		if err != nil {
-			return ocispec.DescriptorEmptyJSON, err
+			return ocispec.DescriptorEmptyJSON, "", err
 		}
 		configBytes = bytes
 	default:
-		return ocispec.DescriptorEmptyJSON, fmt.Errorf("unrecognized model format")
+		return ocispec.DescriptorEmptyJSON, "", fmt.Errorf("unrecognized model format")
 	}
 
 	desc := ocispec.Descriptor{
@@ -119,20 +124,20 @@ func saveConfig(ctx context.Context, localRepo local.LocalRepo, kitfile *artifac
 
 	exists, err := localRepo.Exists(ctx, desc)
 	if err != nil {
-		return ocispec.DescriptorEmptyJSON, err
+		return ocispec.DescriptorEmptyJSON, "", err
 	}
 	if !exists {
 		// Does not exist in storage, need to push
 		err = localRepo.Push(ctx, desc, bytes.NewReader(configBytes))
 		if err != nil {
-			return ocispec.DescriptorEmptyJSON, err
+			return ocispec.DescriptorEmptyJSON, "", err
 		}
 		output.Infof("Saved configuration: %s", desc.Digest)
 	} else {
 		output.Infof("Configuration already exists in storage: %s", desc.Digest)
 	}
 
-	return desc, nil
+	return desc, createdAtAnnotation, nil
 }
 
 func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact.KitFile, ignore ignore.Paths, opts *SaveModelOptions) (layers []ocispec.Descriptor, diffIDs []digest.Digest, err error) {
@@ -319,7 +324,7 @@ func saveModelManifest(ctx context.Context, store oras.Target, manifest ocispec.
 	return &desc, nil
 }
 
-func createManifest(configDesc ocispec.Descriptor, layerDescs []ocispec.Descriptor, modelFormat mediatype.ModelFormat) (ocispec.Manifest, error) {
+func createManifest(configDesc ocispec.Descriptor, layerDescs []ocispec.Descriptor, modelFormat mediatype.ModelFormat, createdAtAnnotation string) (ocispec.Manifest, error) {
 	var manifest ocispec.Manifest
 	switch modelFormat {
 	case mediatype.KitFormat:
@@ -345,6 +350,9 @@ func createManifest(configDesc ocispec.Descriptor, layerDescs []ocispec.Descript
 		manifest.Annotations = map[string]string{}
 	}
 	manifest.Annotations[constants.CliVersionAnnotation] = constants.Version
+	if modelFormat == mediatype.ModelPackFormat && createdAtAnnotation != "" {
+		manifest.Annotations[constants.OciImageCreatedAnnotation] = createdAtAnnotation
+	}
 
 	return manifest, nil
 }

--- a/pkg/lib/filesystem/local-storage_test.go
+++ b/pkg/lib/filesystem/local-storage_test.go
@@ -1,3 +1,19 @@
+// Copyright 2026 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package filesystem
 
 import (

--- a/pkg/lib/filesystem/local-storage_test.go
+++ b/pkg/lib/filesystem/local-storage_test.go
@@ -1,0 +1,62 @@
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/kitops-ml/kitops/pkg/lib/constants"
+	"github.com/kitops-ml/kitops/pkg/lib/constants/mediatype"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateManifestAddsCreatedAnnotationForModelPack(t *testing.T) {
+	configDesc := ocispec.Descriptor{
+		MediaType: mediatype.ModelPackConfigMediaType.String(),
+		Digest:    digest.FromString("config"),
+		Size:      42,
+	}
+	layerDescs := []ocispec.Descriptor{{
+		MediaType: mediatype.New(mediatype.ModelPackFormat, mediatype.ModelBaseType, mediatype.TarFormat, mediatype.GzipCompression).String(),
+		Digest:    digest.FromString("layer"),
+		Size:      128,
+	}}
+
+	manifest, err := createManifest(
+		configDesc,
+		layerDescs,
+		mediatype.ModelPackFormat,
+		"2026-04-16T12:34:56Z",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, constants.Version, manifest.Annotations[constants.CliVersionAnnotation])
+	assert.Equal(t, "2026-04-16T12:34:56Z", manifest.Annotations[constants.OciImageCreatedAnnotation])
+}
+
+func TestCreateManifestSkipsCreatedAnnotationForKitFormat(t *testing.T) {
+	configDesc := ocispec.Descriptor{
+		MediaType: mediatype.KitConfigMediaType.String(),
+		Digest:    digest.FromString("config"),
+		Size:      42,
+	}
+	layerDescs := []ocispec.Descriptor{{
+		MediaType: mediatype.New(mediatype.KitFormat, mediatype.ModelBaseType, mediatype.TarFormat, mediatype.GzipCompression).String(),
+		Digest:    digest.FromString("layer"),
+		Size:      128,
+	}}
+
+	manifest, err := createManifest(
+		configDesc,
+		layerDescs,
+		mediatype.KitFormat,
+		"2026-04-16T12:34:56Z",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, constants.Version, manifest.Annotations[constants.CliVersionAnnotation])
+	_, exists := manifest.Annotations[constants.OciImageCreatedAnnotation]
+	assert.False(t, exists)
+}


### PR DESCRIPTION
Closes #1138

This adds `org.opencontainers.image.created` to ModelPack manifests only, and it reuses the same `CreatedAt` value already emitted into the ModelPack config instead of minting a second timestamp at manifest creation time. That keeps the manifest aligned with the existing ModelPack metadata while leaving KitFormat behavior unchanged.

Validation:
- `go test ./pkg/lib/filesystem -run TestCreateManifest`
- `go build ./...`
- `go generate ./...` (completed locally; the harness UI generator emitted `pnpm` warnings in this environment but produced no tracked source changes)