### PR TITLE
Add --attestation-output flag to kit import for SLSA Provenance v1

### DIFF
--- a/pkg/cmd/kitimport/cmd.go
+++ b/pkg/cmd/kitimport/cmd.go
@@ -18,6 +18,7 @@ package kitimport
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"slices"
@@ -71,15 +72,16 @@ kit import myorg/myrepo --file ./path/to/Kitfile`
 )
 
 type importOptions struct {
-	configHome   string
-	repo         string
-	repoRef      string
-	tag          string
-	token        string
-	kitfilePath  string
-	downloadTool string
-	concurrency  int
-	modelKitRef  *registry.Reference
+	configHome        string
+	repo              string
+	repoRef           string
+	tag               string
+	token             string
+	kitfilePath       string
+	downloadTool      string
+	concurrency       int
+	attestationOutput string
+	modelKitRef       *registry.Reference
 }
 
 func ImportCommand() *cobra.Command {
@@ -100,6 +102,8 @@ func ImportCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.kitfilePath, "file", "f", "", "Path to Kitfile to use for packing (use '-' to read from standard input)")
 	cmd.Flags().StringVar(&opts.downloadTool, "tool", "", "Tool to use for downloading files: options are 'git' and 'hf' (default: detect based on repository)")
 	cmd.Flags().IntVar(&opts.concurrency, "concurrency", 5, "Maximum number of simultaneous downloads (for huggingface)")
+	cmd.Flags().StringVar(&opts.attestationOutput, "attestation-output", "",
+		"Write SLSA Provenance v1 predicate to <path> ('-' for stdout)")
 	cmd.Flags().SortFlags = false
 	return cmd
 }
@@ -114,8 +118,44 @@ func runCommand(opts *importOptions) func(*cobra.Command, []string) error {
 		if err != nil {
 			return output.Fatalln(err)
 		}
-		if err := importer(cmd.Context(), opts); err != nil {
+
+		var sink output.DataSink
+		if opts.attestationOutput != "" {
+			s, err := output.OpenDataSink(opts.attestationOutput)
+			if err != nil {
+				return output.Fatalln(fmt.Errorf("failed to open attestation output %s: %w", opts.attestationOutput, err))
+			}
+			sink = s
+			// Close cleans up the temp file when Commit wasn't reached
+			// (e.g. importer failure), preserving any pre-existing target.
+			defer func() {
+				if err := sink.Close(); err != nil {
+					output.Logf(output.LogLevelWarn, "failed to close attestation output: %s", err)
+				}
+			}()
+		}
+
+		prov, err := importer(cmd.Context(), opts)
+		if err != nil {
 			return output.Fatalln(err)
+		}
+
+		if prov != nil {
+			if err := prov.validate(); err != nil {
+				return output.Fatalln(err)
+			}
+			pred := BuildPredicate(prov)
+			b, err := json.MarshalIndent(pred, "", "  ")
+			if err != nil {
+				return output.Fatalln(fmt.Errorf("failed to marshal provenance predicate: %w", err))
+			}
+			if _, err := sink.Write(append(b, '\n')); err != nil {
+				return output.Fatalln(fmt.Errorf("failed to write provenance predicate: %w", err))
+			}
+			if err := sink.Commit(); err != nil {
+				return output.Fatalln(fmt.Errorf("failed to finalize attestation output: %w", err))
+			}
+			output.Infof("ModelKit manifest digest: %s", prov.ManifestDigest)
 		}
 
 		return nil
@@ -168,7 +208,7 @@ func (opts *importOptions) complete(ctx context.Context, args []string) error {
 	return nil
 }
 
-func getImporter(opts *importOptions) (func(context.Context, *importOptions) error, error) {
+func getImporter(opts *importOptions) (func(context.Context, *importOptions) (*ProvenanceData, error), error) {
 	switch opts.downloadTool {
 	case "hf":
 		return importUsingHF, nil

--- a/pkg/cmd/kitimport/gitimport.go
+++ b/pkg/cmd/kitimport/gitimport.go
@@ -34,10 +34,15 @@ import (
 	"github.com/kitops-ml/kitops/pkg/output"
 )
 
-func importUsingGit(ctx context.Context, opts *importOptions) error {
+func importUsingGit(ctx context.Context, opts *importOptions) (*ProvenanceData, error) {
+	var prov *ProvenanceData
+	if opts.attestationOutput != "" {
+		prov = newProvenanceData()
+	}
+
 	tmpDir, cleanupTmp, err := cache.MkCacheDir(cache.CacheImportSubdir, "")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	doCleanup := true
 	defer func() {
@@ -46,36 +51,53 @@ func importUsingGit(ctx context.Context, opts *importOptions) error {
 		}
 	}()
 
-	if err := cloneRepository(opts.repo, opts.repoRef, tmpDir, opts.token); err != nil {
-		return err
+	fullRepo := resolveRepoURL(opts.repo)
+	if err := git.CloneRepository(fullRepo, opts.repoRef, tmpDir, opts.token); err != nil {
+		return nil, err
+	}
+
+	// Resolve HEAD before stripping git metadata; the commit pins the source tree.
+	if prov != nil {
+		headSHA, err := git.ResolveHead(tmpDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve git HEAD: %w", err)
+		}
+		// fullRepo may carry userinfo (e.g. https://user:token@host/...) when the
+		// caller embedded credentials in the clone URL; scrub before recording.
+		prov.SourceURI = "git+" + git.SanitizeURL(fullRepo)
+		prov.SourceCommitSHA = headSHA
+	}
+
+	if err := git.CleanGitMetadata(tmpDir); err != nil {
+		return nil, err
 	}
 
 	var kitfile *artifact.KitFile
 	if opts.kitfilePath == "-" {
 		kitfile = &artifact.KitFile{}
 		if err := kitfile.LoadModel(os.Stdin); err != nil {
-			return fmt.Errorf("failed to read Kitfile from input: %w", err)
+			return nil, fmt.Errorf("failed to read Kitfile from input: %w", err)
 		}
 	} else if opts.kitfilePath != "" {
 		kf, err := readExistingKitfile(opts.kitfilePath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		kitfile = kf
 	} else if kfpath, err := filesystem.FindKitfileInPath(tmpDir); err == nil {
 		kf, err := readExistingKitfile(kfpath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		kitfile = kf
 	} else {
 		dirContents, err := kfgen.DirectoryListingFromFS(tmpDir)
 		if err != nil {
-			return fmt.Errorf("error processing directory: %w", err)
+			return nil, fmt.Errorf("error processing directory: %w", err)
 		}
 		kf, err := generateKitfile(dirContents, opts.repo, tmpDir)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		kitfile = kf
 
@@ -92,38 +114,39 @@ func importUsingGit(ctx context.Context, opts *importOptions) error {
 					output.Logf(output.LogLevelWarn, "and run command")
 					output.Logf(output.LogLevelWarn, "    kit pack -t %s %s", opts.tag, tmpDir)
 					output.Logf(output.LogLevelWarn, "to complete process")
-					return err
+					return nil, err
 				}
-				return err
+				return nil, err
 			}
 			kitfile = newKitfile
 		}
 	}
 
 	output.Infof("Packing model to %s", opts.tag)
-	if err := packDirectory(ctx, opts.configHome, tmpDir, kitfile, opts.modelKitRef); err != nil {
-		return fmt.Errorf("failed to pack ModelKit: %w", err)
+	manifestDesc, err := packDirectory(ctx, opts.configHome, tmpDir, kitfile, opts.modelKitRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack ModelKit: %w", err)
 	}
 	output.Infof("Model is packed as %s", opts.tag)
+	if prov != nil {
+		if err := prov.finalize(manifestDesc, kitfile); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := cache.CleanCacheDir(cache.CacheImportSubdir); err != nil {
 		output.Logf(output.LogLevelWarn, "Failed to clean cache directory: %s", err)
 	}
 
-	return nil
+	return prov, nil
 }
 
-func cloneRepository(repo, repoRef, destDir, token string) error {
-	fullRepo := repo
-	if !strings.HasPrefix(fullRepo, "http") {
-		fullRepo = fmt.Sprintf("https://huggingface.co/%s", repo)
+// resolveRepoURL canonicalizes the user-provided repository identifier into a
+// full clone URL. Bare org/repo strings (no scheme) are assumed to refer to a
+// HuggingFace repository, matching kit import's documented default behavior.
+func resolveRepoURL(repo string) string {
+	if strings.HasPrefix(repo, "http") {
+		return repo
 	}
-	if err := git.CloneRepository(fullRepo, repoRef, destDir, token); err != nil {
-		return err
-	}
-	// Clean up git-related files, since we probably don't want those
-	if err := git.CleanGitMetadata(destDir); err != nil {
-		return err
-	}
-	return nil
+	return "https://huggingface.co/" + repo
 }

--- a/pkg/cmd/kitimport/hfimport.go
+++ b/pkg/cmd/kitimport/hfimport.go
@@ -27,23 +27,26 @@ import (
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
 	"github.com/kitops-ml/kitops/pkg/lib/external/hf"
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem/cache"
-	"github.com/kitops-ml/kitops/pkg/lib/filesystem/ignore"
 	kfgen "github.com/kitops-ml/kitops/pkg/lib/kitfile/generate"
-	repoutil "github.com/kitops-ml/kitops/pkg/lib/repo/util"
 	"github.com/kitops-ml/kitops/pkg/lib/util"
 	"github.com/kitops-ml/kitops/pkg/output"
 )
 
-func importUsingHF(ctx context.Context, opts *importOptions) error {
+func importUsingHF(ctx context.Context, opts *importOptions) (*ProvenanceData, error) {
+	var prov *ProvenanceData
+	if opts.attestationOutput != "" {
+		prov = newProvenanceData()
+	}
+
 	// Handle full HF URLs by extracting repository name from URL
 	repo, repoType, err := hf.ParseHuggingFaceRepo(opts.repo)
 	if err != nil {
-		return fmt.Errorf("could not process repository %s: %w", opts.repo, err)
+		return nil, fmt.Errorf("could not process repository %s: %w", opts.repo, err)
 	}
 
 	tmpDir, cleanupTmp, err := cache.MkCacheDir("import", "")
 	if err != nil {
-		return fmt.Errorf("failed to create temporary directory: %w", err)
+		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 	doCleanup := true
 	defer func() {
@@ -52,27 +55,40 @@ func importUsingHF(ctx context.Context, opts *importOptions) error {
 		}
 	}()
 
-	dirListing, err := hf.ListFiles(ctx, repo, opts.repoRef, opts.token, repoType)
+	// Resolve the user-supplied ref to an immutable commit SHA up front.
+	// HF accepts commit SHAs anywhere a ref is expected, so threading this
+	// SHA through ListFiles and DownloadFiles binds the entire import to one
+	// snapshot — even if the branch moves between calls.
+	commitSHA, err := hf.PinCommit(ctx, repo, opts.repoRef, opts.token, repoType)
 	if err != nil {
-		return fmt.Errorf("failed to list files from HuggingFace API: %w", err)
+		return nil, fmt.Errorf("failed to pin commit for %s@%s: %w", repo, opts.repoRef, err)
+	}
+
+	dirListing, err := hf.ListFiles(ctx, repo, commitSHA, opts.token, repoType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files from HuggingFace API: %w", err)
+	}
+	if prov != nil {
+		prov.SourceURI = hfSourceURI(repo, repoType)
+		prov.SourceCommitSHA = commitSHA
 	}
 
 	var kitfile *artifact.KitFile
 	if opts.kitfilePath == "-" {
 		kitfile = &artifact.KitFile{}
 		if err := kitfile.LoadModel(os.Stdin); err != nil {
-			return fmt.Errorf("failed to read Kitfile from input: %w", err)
+			return nil, fmt.Errorf("failed to read Kitfile from input: %w", err)
 		}
 	} else if opts.kitfilePath != "" {
 		kf, err := readExistingKitfile(opts.kitfilePath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		kitfile = kf
 	} else {
 		kf, err := generateKitfile(dirListing, repo, tmpDir)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		kitfile = kf
 
@@ -90,9 +106,9 @@ func importUsingHF(ctx context.Context, opts *importOptions) error {
 					output.Logf(output.LogLevelWarn, "and run command")
 					output.Logf(output.LogLevelWarn, "    kit import %s -t %s -f %s", opts.repo, opts.tag, kfPath)
 					output.Logf(output.LogLevelWarn, "to complete process")
-					return err
+					return nil, err
 				}
-				return err
+				return nil, err
 			}
 			kitfile = newKitfile
 		}
@@ -100,44 +116,46 @@ func importUsingHF(ctx context.Context, opts *importOptions) error {
 
 	toDownload, err := filterListingForKitfile(dirListing, kitfile)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if err := hf.DownloadFiles(ctx, repo, opts.repoRef, tmpDir, toDownload, opts.token, opts.concurrency, repoType); err != nil {
-		return fmt.Errorf("error downloading repository: %w", err)
+	if err := hf.DownloadFiles(ctx, repo, commitSHA, tmpDir, toDownload, opts.token, opts.concurrency, repoType); err != nil {
+		return nil, fmt.Errorf("error downloading repository: %w", err)
 	}
 
 	output.Infof("Packing model to %s", opts.tag)
-	if err := packDirectory(ctx, opts.configHome, tmpDir, kitfile, opts.modelKitRef); err != nil {
-		return fmt.Errorf("failed to pack ModelKit: %w", err)
+	manifestDesc, err := packDirectory(ctx, opts.configHome, tmpDir, kitfile, opts.modelKitRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack ModelKit: %w", err)
 	}
 	output.Infof("Model is packed as %s", opts.tag)
+	if prov != nil {
+		if err := prov.finalize(manifestDesc, kitfile); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := cache.CleanCacheDir(cache.CacheImportSubdir); err != nil {
 		output.Logf(output.LogLevelWarn, "Failed to clean cache directory: %s", err)
 	}
 
-	return nil
+	return prov, nil
 }
 
+// filterListingForKitfile walks the directory listing and returns the subset
+// of files that the Kitfile would pack, so HF only downloads what will end up
+// in the ModelKit. Layer assignment is decided by kitfilePathFilter, which
+// mirrors pack's own ignore-aware layer routing.
 func filterListingForKitfile(contents *kfgen.DirectoryListing, kitfile *artifact.KitFile) ([]kfgen.FileListing, error) {
-	// Repurpose the ignore implementation to find which files we need to download and which ones we can skip.
-	// This works because ignore is designed to _also_ ignore paths that are packed as part of another layer
-	// instead of the current one.
-	ignore, err := ignore.New(nil, kitfile)
+	filter, err := newKitfilePathFilter(kitfile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to process Kitfile to get file list: %w", err)
+		return nil, err
 	}
 
-	hasCatchall := kitfileHasCatchallLayer(kitfile)
 	var pathsToDownload []kfgen.FileListing
 	var processDir func(dir *kfgen.DirectoryListing) error
 	processDir = func(dir *kfgen.DirectoryListing) error {
 		for _, file := range dir.Files {
-			if hasCatchall {
-				pathsToDownload = append(pathsToDownload, file)
-				continue
-			}
-			matches, err := ignore.Matches(file.Path, "")
+			matches, err := filter.Matches(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to process path %s: %w", file.Path, err)
 			}
@@ -159,12 +177,12 @@ func filterListingForKitfile(contents *kfgen.DirectoryListing, kitfile *artifact
 	return pathsToDownload, nil
 }
 
-func kitfileHasCatchallLayer(kitfile *artifact.KitFile) bool {
-	layerPaths := repoutil.LayerPathsFromKitfile(kitfile)
-	for _, path := range layerPaths {
-		if path == "." {
-			return true
-		}
+// hfSourceURI builds the SourceURI for a HF import. Datasets get a "datasets/"
+// segment so a verifier can distinguish them from models — both kinds of repo
+// share the org/name shape but live at different URLs on huggingface.co.
+func hfSourceURI(repo string, repoType hf.RepositoryType) string {
+	if repoType == hf.RepoTypeDataset {
+		return "hf://datasets/" + repo
 	}
-	return false
+	return "hf://" + repo
 }

--- a/pkg/cmd/kitimport/hfimport_test.go
+++ b/pkg/cmd/kitimport/hfimport_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitimport
+
+import (
+	"testing"
+
+	"github.com/kitops-ml/kitops/pkg/lib/external/hf"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHFSourceURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		repo     string
+		repoType hf.RepositoryType
+		want     string
+	}{
+		{name: "model", repo: "org/llama", repoType: hf.RepoTypeModel, want: "hf://org/llama"},
+		{name: "dataset", repo: "org/squad", repoType: hf.RepoTypeDataset, want: "hf://datasets/org/squad"},
+		// Same name across kinds must produce different URIs.
+		{name: "model_collision_left", repo: "org/imagenet", repoType: hf.RepoTypeModel, want: "hf://org/imagenet"},
+		{name: "dataset_collision_right", repo: "org/imagenet", repoType: hf.RepoTypeDataset, want: "hf://datasets/org/imagenet"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hfSourceURI(tt.repo, tt.repoType))
+		})
+	}
+}

--- a/pkg/cmd/kitimport/kitfile_filter.go
+++ b/pkg/cmd/kitimport/kitfile_filter.go
@@ -1,0 +1,98 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitimport
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kitops-ml/kitops/pkg/artifact"
+	"github.com/kitops-ml/kitops/pkg/lib/filesystem/ignore"
+	repoutil "github.com/kitops-ml/kitops/pkg/lib/repo/util"
+)
+
+// kitfilePathFilter answers whether a given relative path would be packed
+// into some layer of the ModelKit defined by a Kitfile. It mirrors the layer
+// assignment that pack uses, so the HF download list agrees with what pack
+// will eventually include.
+type kitfilePathFilter struct {
+	ig     ignore.Paths
+	layers []string
+}
+
+func newKitfilePathFilter(kitfile *artifact.KitFile) (*kitfilePathFilter, error) {
+	ig, err := ignore.New(nil, kitfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process Kitfile to get file list: %w", err)
+	}
+	return &kitfilePathFilter{
+		ig:     ig,
+		layers: repoutil.LayerPathsFromKitfile(kitfile),
+	}, nil
+}
+
+// Matches returns true iff path would be packed into at least one layer.
+//
+// A file is packed when (a) it falls under some layer's path prefix and
+// (b) it is not excluded from that layer. ignore.Paths.Matches(path, layer)
+// returns true when path is *excluded* from the given layer — either because
+// a .kitignore-style pattern (which always covers Kitfile names and
+// .kitignore itself) matches it, or because path belongs to a different
+// layer's prefix. The prefix gate is required because ignore.Matches alone
+// has no notion of "outside any layer": a path with no layer membership
+// returns false for every layer and would otherwise be misreported as
+// packed.
+func (f *kitfilePathFilter) Matches(path string) (bool, error) {
+	for _, layer := range f.layers {
+		if !pathUnderLayer(path, layer) {
+			continue
+		}
+		excluded, err := f.ig.Matches(path, layer)
+		if err != nil {
+			return false, err
+		}
+		if !excluded {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// pathUnderLayer reports whether path is contained in the layer's directory.
+// "." is a catchall and contains everything. Otherwise the match is on
+// directory boundaries so "model_dir" does not contain "model_directory".
+//
+// Both inputs are normalized to forward-slash form before comparison. Input
+// paths reach this filter as forward-slash (HF tree API; kfgen runs
+// filepath.ToSlash on filesystem walks), but layer paths go through
+// filepath.Clean in repoutil.LayerPathsFromKitfile, which on Windows rewrites
+// separators to backslashes for any layer with subdirectories. We do an
+// unconditional ReplaceAll rather than filepath.ToSlash so the comparison is
+// independent of GOOS — filepath.ToSlash is a no-op on non-Windows hosts and
+// would leave a Windows-cleaned layer string mismatched with a forward-slash
+// path during cross-platform handling.
+func pathUnderLayer(path, layer string) bool {
+	if layer == "." {
+		return true
+	}
+	layer = strings.ReplaceAll(layer, `\`, "/")
+	path = strings.ReplaceAll(path, `\`, "/")
+	if path == layer {
+		return true
+	}
+	return strings.HasPrefix(path, layer+"/")
+}

--- a/pkg/cmd/kitimport/kitfile_filter_test.go
+++ b/pkg/cmd/kitimport/kitfile_filter_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitimport
+
+import (
+	"testing"
+
+	"github.com/kitops-ml/kitops/pkg/artifact"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKitfilePathFilterCatchallExcludesKitfile(t *testing.T) {
+	// Catchall code layer that would otherwise sweep up everything.
+	kf := &artifact.KitFile{
+		Code: []artifact.Code{{Path: "."}},
+	}
+	filter, err := newKitfilePathFilter(kf)
+	require.NoError(t, err)
+
+	// Regular files in the catchall are packed.
+	got, err := filter.Matches("README.md")
+	require.NoError(t, err)
+	assert.True(t, got, "README.md should be packed by the catchall layer")
+
+	// Kitfile and .kitignore are always ignore-pattern-matched and must NOT
+	// appear in the packed set even with a catchall layer.
+	for _, name := range []string{"Kitfile", ".kitignore"} {
+		got, err := filter.Matches(name)
+		require.NoError(t, err, name)
+		assert.False(t, got, "%s should never be reported as packed (it's always ignored)", name)
+	}
+}
+
+func TestKitfilePathFilterSpecificLayer(t *testing.T) {
+	kf := &artifact.KitFile{
+		Model: &artifact.Model{Path: "model_dir"},
+	}
+	filter, err := newKitfilePathFilter(kf)
+	require.NoError(t, err)
+
+	in, err := filter.Matches("model_dir/weights.bin")
+	require.NoError(t, err)
+	assert.True(t, in, "files under model_dir belong to the model layer")
+
+	out, err := filter.Matches("README.md")
+	require.NoError(t, err)
+	assert.False(t, out, "files outside any layer must not be reported as packed")
+
+	// Boundary: "model_directory" must not be confused with "model_dir".
+	sibling, err := filter.Matches("model_directory/foo")
+	require.NoError(t, err)
+	assert.False(t, sibling, "sibling-of-prefix paths must not match the layer")
+}
+
+func TestPathUnderLayerNormalizesSeparators(t *testing.T) {
+	// On Windows, repoutil.LayerPathsFromKitfile (filepath.Clean) rewrites
+	// nested layer paths to use backslashes, while file paths reach the filter
+	// as forward-slash. pathUnderLayer must normalize both before comparing or
+	// non-catchall imports break on Windows.
+	tests := []struct {
+		path, layer string
+		want        bool
+	}{
+		// Windows-cleaned layer with forward-slash file paths.
+		{path: "model_dir/sub/weights.bin", layer: "model_dir\\sub", want: true},
+		{path: "other_dir/file.bin", layer: "model_dir\\sub", want: false},
+		// Mixed-separator layer.
+		{path: "a/b/c.bin", layer: "a\\b", want: true},
+		// Boundary check survives normalization.
+		{path: "model_directory/file", layer: "model_dir", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path+" under "+tt.layer, func(t *testing.T) {
+			assert.Equal(t, tt.want, pathUnderLayer(tt.path, tt.layer))
+		})
+	}
+}
+
+func TestKitfilePathFilterMultipleLayersWithCatchall(t *testing.T) {
+	// model_dir owns its files; "." catchall picks up everything else.
+	kf := &artifact.KitFile{
+		Model: &artifact.Model{Path: "model_dir"},
+		Code:  []artifact.Code{{Path: "."}},
+	}
+	filter, err := newKitfilePathFilter(kf)
+	require.NoError(t, err)
+
+	for _, p := range []string{"model_dir/weights.bin", "src/main.py", "README.md"} {
+		got, err := filter.Matches(p)
+		require.NoError(t, err, p)
+		assert.True(t, got, "%s should be packed (catchall + model layer cover everything)", p)
+	}
+
+	// Kitfile / .kitignore still excluded by ignore patterns despite the catchall.
+	for _, name := range []string{"Kitfile", ".kitignore"} {
+		got, err := filter.Matches(name)
+		require.NoError(t, err, name)
+		assert.False(t, got, "%s must remain excluded", name)
+	}
+}

--- a/pkg/cmd/kitimport/provenance.go
+++ b/pkg/cmd/kitimport/provenance.go
@@ -1,0 +1,206 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitimport
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/kitops-ml/kitops/pkg/artifact"
+	"github.com/kitops-ml/kitops/pkg/lib/constants"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	BuildType = "https://kitops.org/import/v1"
+	BuilderID = "https://kitops.org/kit"
+)
+
+// ProvenanceData is the internal aggregate populated as the import runs.
+//
+// We deliberately do not enumerate per-file resolved dependencies. The source
+// commit digest pins the entire input tree byte-for-byte; the Kitfile config
+// digest pins the build recipe; and the manifest digest (which cosign attests
+// from the OCI ref) pins the output bytes via per-layer DiffIDs. That chain is
+// sufficient for verification, so the SLSA-RECOMMENDED resolvedDependencies
+// array is emitted empty rather than restating what those digests already cover.
+type ProvenanceData struct {
+	KitfileConfigDigest digest.Digest
+	ManifestDigest      digest.Digest
+	SourceURI           string
+	SourceCommitSHA     string
+	InvocationID        string
+	StartedOn           time.Time
+	FinishedOn          time.Time
+	KitVersion          string
+	GoVersion           string
+}
+
+// newProvenanceData constructs a ProvenanceData with the importer-invariant
+// fields filled in (start time, invocation ID, builder version).
+func newProvenanceData() *ProvenanceData {
+	return &ProvenanceData{
+		StartedOn:    time.Now().UTC(),
+		InvocationID: newInvocationID(),
+		KitVersion:   constants.Version,
+		GoVersion:    constants.GoVersion,
+	}
+}
+
+// finalize records the digests produced by packing and stamps the finish time.
+// Call once, immediately after a successful packDirectory. The Kitfile config
+// digest is recomputed here from the same MarshalToJSON() pack uses for the
+// OCI config blob, so the predicate is byte-identical to what cosign attests.
+func (p *ProvenanceData) finalize(manifestDesc *ocispec.Descriptor, kitfile *artifact.KitFile) error {
+	cfgBytes, err := kitfile.MarshalToJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshal Kitfile for provenance: %w", err)
+	}
+	p.KitfileConfigDigest = digest.FromBytes(cfgBytes)
+	p.ManifestDigest = manifestDesc.Digest
+	p.FinishedOn = time.Now().UTC()
+	return nil
+}
+
+// validate ensures every field a verifier needs has been populated. Emitting a
+// predicate with an empty source digest, kitfile digest, or manifest digest
+// produces an attestation that cannot be checked back to its inputs — that's
+// worse than no attestation, so we refuse rather than silently emit it.
+func (p *ProvenanceData) validate() error {
+	if p.SourceURI == "" {
+		return fmt.Errorf("provenance: source URI is empty")
+	}
+	if p.SourceCommitSHA == "" {
+		return fmt.Errorf("provenance: source commit SHA missing for %s; predicate would be unverifiable", p.SourceURI)
+	}
+	if p.KitfileConfigDigest == "" {
+		return fmt.Errorf("provenance: Kitfile config digest is empty")
+	}
+	if p.ManifestDigest == "" {
+		return fmt.Errorf("provenance: manifest digest is empty")
+	}
+	return nil
+}
+
+// Wire-format predicate types mirror the SLSA Provenance v1 predicate body.
+// The top-level is the predicate body (no _type/subject/predicateType wrapper);
+// `cosign attest --predicate` derives the in-toto Statement subject from the OCI ref.
+
+type Predicate struct {
+	BuildDefinition BuildDefinition `json:"buildDefinition"`
+	RunDetails      RunDetails      `json:"runDetails"`
+}
+
+type BuildDefinition struct {
+	BuildType            string               `json:"buildType"`
+	ExternalParameters   ExternalParameters   `json:"externalParameters"`
+	ResolvedDependencies []ResourceDescriptor `json:"resolvedDependencies"`
+}
+
+type ExternalParameters struct {
+	Source  ResourceDescriptor `json:"source"`
+	Kitfile ResourceDescriptor `json:"kitfile"`
+}
+
+type ResourceDescriptor struct {
+	URI       string            `json:"uri,omitempty"`
+	Digest    map[string]string `json:"digest"`
+	MediaType string            `json:"mediaType,omitempty"`
+}
+
+type RunDetails struct {
+	Builder  Builder  `json:"builder"`
+	Metadata Metadata `json:"metadata"`
+}
+
+type Builder struct {
+	ID      string            `json:"id"`
+	Version map[string]string `json:"version"`
+}
+
+type Metadata struct {
+	InvocationID string `json:"invocationId"`
+	StartedOn    string `json:"startedOn"`
+	FinishedOn   string `json:"finishedOn"`
+}
+
+// BuildPredicate maps the internal aggregate to the wire-format predicate.
+func BuildPredicate(p *ProvenanceData) Predicate {
+	source := ResourceDescriptor{
+		URI:    p.SourceURI,
+		Digest: map[string]string{},
+	}
+	if p.SourceCommitSHA != "" {
+		// in-toto's digest set uses `gitCommit` for git commit IDs; the HF
+		// X-Repo-Commit header is a git commit ID since HF repos are git-backed.
+		// See https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
+		source.Digest["gitCommit"] = p.SourceCommitSHA
+	}
+
+	kitfileDesc := ResourceDescriptor{
+		Digest: map[string]string{
+			"sha256": p.KitfileConfigDigest.Encoded(),
+		},
+	}
+
+	return Predicate{
+		BuildDefinition: BuildDefinition{
+			BuildType: BuildType,
+			ExternalParameters: ExternalParameters{
+				Source:  source,
+				Kitfile: kitfileDesc,
+			},
+			ResolvedDependencies: []ResourceDescriptor{},
+		},
+		RunDetails: RunDetails{
+			Builder: Builder{
+				ID: BuilderID,
+				Version: map[string]string{
+					"kit": p.KitVersion,
+					"go":  p.GoVersion,
+				},
+			},
+			Metadata: Metadata{
+				InvocationID: p.InvocationID,
+				StartedOn:    p.StartedOn.UTC().Format(time.RFC3339Nano),
+				FinishedOn:   p.FinishedOn.UTC().Format(time.RFC3339Nano),
+			},
+		},
+	}
+}
+
+// newInvocationID returns a UUIDv4 derived from 16 cryptographically-random bytes.
+func newInvocationID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failures are catastrophic; fall back to a timestamp-based ID.
+		return fmt.Sprintf("%016x-%016x", time.Now().UnixNano(), 0)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%s-%s-%s-%s-%s",
+		hex.EncodeToString(b[0:4]),
+		hex.EncodeToString(b[4:6]),
+		hex.EncodeToString(b[6:8]),
+		hex.EncodeToString(b[8:10]),
+		hex.EncodeToString(b[10:16]),
+	)
+}

--- a/pkg/cmd/kitimport/provenance_test.go
+++ b/pkg/cmd/kitimport/provenance_test.go
@@ -1,0 +1,128 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kitimport
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPredicateShape(t *testing.T) {
+	prov := &ProvenanceData{
+		KitfileConfigDigest: digest.NewDigestFromHex("sha256", "deadbeef"),
+		ManifestDigest:      digest.NewDigestFromHex("sha256", "cafebabe"),
+		SourceURI:           "hf://org/repo",
+		SourceCommitSHA:     "abcdef0123456789",
+		InvocationID:        "00000000-0000-4000-8000-000000000000",
+		StartedOn:           time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		FinishedOn:          time.Date(2026, 5, 1, 12, 0, 1, 0, time.UTC),
+		KitVersion:          "test",
+		GoVersion:           "go1.99",
+	}
+
+	pred := BuildPredicate(prov)
+	b, err := json.Marshal(pred)
+	require.NoError(t, err)
+
+	// Round-trip via map to assert the wire shape is exactly the predicate body
+	// (no _type/subject/predicateType wrapper).
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+	require.Contains(t, raw, "buildDefinition")
+	require.Contains(t, raw, "runDetails")
+	assert.NotContains(t, raw, "_type")
+	assert.NotContains(t, raw, "subject")
+	assert.NotContains(t, raw, "predicateType")
+
+	bd := raw["buildDefinition"].(map[string]any)
+	assert.Equal(t, BuildType, bd["buildType"])
+
+	ext := bd["externalParameters"].(map[string]any)
+	src := ext["source"].(map[string]any)
+	assert.Equal(t, "hf://org/repo", src["uri"])
+	srcDig := src["digest"].(map[string]any)
+	assert.Equal(t, "abcdef0123456789", srcDig["gitCommit"])
+	_, hasSha256 := srcDig["sha256"]
+	assert.False(t, hasSha256, "source digest must use gitCommit, not sha256, for git commit IDs")
+
+	kf := ext["kitfile"].(map[string]any)
+	kfDig := kf["digest"].(map[string]any)
+	assert.Equal(t, "deadbeef", kfDig["sha256"])
+
+	// resolvedDependencies is intentionally empty: the source commit digest
+	// pins the input tree and the manifest digest pins the output bytes.
+	deps := bd["resolvedDependencies"].([]any)
+	assert.Empty(t, deps)
+
+	rd := raw["runDetails"].(map[string]any)
+	builder := rd["builder"].(map[string]any)
+	assert.Equal(t, BuilderID, builder["id"])
+	version := builder["version"].(map[string]any)
+	assert.Equal(t, "test", version["kit"])
+	assert.Equal(t, "go1.99", version["go"])
+
+	meta := rd["metadata"].(map[string]any)
+	assert.Equal(t, "00000000-0000-4000-8000-000000000000", meta["invocationId"])
+	assert.Equal(t, "2026-05-01T12:00:00Z", meta["startedOn"])
+	assert.Equal(t, "2026-05-01T12:00:01Z", meta["finishedOn"])
+}
+
+func TestProvenanceValidate(t *testing.T) {
+	good := func() *ProvenanceData {
+		return &ProvenanceData{
+			SourceURI:           "hf://org/repo",
+			SourceCommitSHA:     "abc123",
+			KitfileConfigDigest: digest.NewDigestFromHex("sha256", "deadbeef"),
+			ManifestDigest:      digest.NewDigestFromHex("sha256", "cafebabe"),
+		}
+	}
+
+	require.NoError(t, good().validate())
+
+	tests := []struct {
+		name    string
+		mutate  func(p *ProvenanceData)
+		errLike string
+	}{
+		{"empty source URI", func(p *ProvenanceData) { p.SourceURI = "" }, "source URI"},
+		{"empty source commit", func(p *ProvenanceData) { p.SourceCommitSHA = "" }, "source commit SHA"},
+		{"empty kitfile digest", func(p *ProvenanceData) { p.KitfileConfigDigest = "" }, "Kitfile config digest"},
+		{"empty manifest digest", func(p *ProvenanceData) { p.ManifestDigest = "" }, "manifest digest"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := good()
+			tt.mutate(p)
+			err := p.validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errLike)
+		})
+	}
+}
+
+func TestNewInvocationIDFormat(t *testing.T) {
+	id := newInvocationID()
+	assert.Len(t, id, 36)
+	// Versions: 8-4-4-4-12 hex segments separated by dashes; UUIDv4 has '4' at idx 14, variant 8/9/a/b at idx 19.
+	assert.Equal(t, byte('4'), id[14])
+	assert.Contains(t, "89ab", string(id[19]))
+}

--- a/pkg/cmd/kitimport/util.go
+++ b/pkg/cmd/kitimport/util.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kitops-ml/kitops/pkg/lib/util"
 	"github.com/kitops-ml/kitops/pkg/output"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -81,15 +82,15 @@ func readExistingKitfile(kfPath string) (*artifact.KitFile, error) {
 	return kitfile, nil
 }
 
-func packDirectory(ctx context.Context, configHome, contextDir string, kitfile *artifact.KitFile, ref *registry.Reference) error {
+func packDirectory(ctx context.Context, configHome, contextDir string, kitfile *artifact.KitFile, ref *registry.Reference) (*ocispec.Descriptor, error) {
 	// Packing requires the working dir to be the context dir so that relative paths are correct in the tarball
 	// On Windows, we need to switch back to the current directory or removing the temporary directory will fail
 	curDir, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("failed to get current directory: %w", err)
+		return nil, fmt.Errorf("failed to get current directory: %w", err)
 	}
 	if err := os.Chdir(contextDir); err != nil {
-		return fmt.Errorf("failed to use context path %s: %w", contextDir, err)
+		return nil, fmt.Errorf("failed to use context path %s: %w", contextDir, err)
 	}
 	defer func() {
 		if err := os.Chdir(curDir); err != nil {
@@ -99,11 +100,11 @@ func packDirectory(ctx context.Context, configHome, contextDir string, kitfile *
 
 	localRepo, err := local.NewLocalRepo(constants.StoragePath(configHome), ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	ignore, err := ignore.NewFromContext(contextDir, kitfile)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	manifestDesc, err := filesystem.SaveModel(ctx, localRepo, kitfile, ignore, &filesystem.SaveModelOptions{
 		ModelFormat: mediatype.KitFormat,
@@ -111,12 +112,13 @@ func packDirectory(ctx context.Context, configHome, contextDir string, kitfile *
 		LayerFormat: mediatype.TarFormat,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := localRepo.Tag(ctx, *manifestDesc, ref.Reference); err != nil {
-		return fmt.Errorf("failed to tag manifest: %w", err)
+		return nil, fmt.Errorf("failed to tag manifest: %w", err)
 	}
-	return nil
+
+	return manifestDesc, nil
 }
 
 func promptToEditKitfile(contextDir string, currentKitfile *artifact.KitFile) (*artifact.KitFile, error) {

--- a/pkg/cmd/kitinit/cmd.go
+++ b/pkg/cmd/kitinit/cmd.go
@@ -155,26 +155,42 @@ func runInit(dirContents *kfgen.DirectoryListing, opts *initOptions) error {
 		return output.Fatalf("Error formatting Kitfile: %s", err)
 	}
 
-	if opts.outputPath == "-" {
-		fmt.Print(string(bytes))
-		return nil
-	}
 	return writeKitfile(bytes, opts)
 }
 
 func writeKitfile(bytes []byte, opts *initOptions) error {
-	if _, err := os.Stat(opts.outputPath); err == nil {
-		if !opts.overwrite {
-			return output.Fatalf("Kitfile already exists at %s. Use '--force' to overwrite", opts.outputPath)
+	// For real file paths, honor the existing-file/--force contract before
+	// opening the sink (OpenDataSink truncates unconditionally).
+	if opts.outputPath != "-" {
+		if _, err := os.Stat(opts.outputPath); err == nil {
+			if !opts.overwrite {
+				return output.Fatalf("Kitfile already exists at %s. Use '--force' to overwrite", opts.outputPath)
+			}
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return output.Fatalf("Error checking for existing Kitfile: %s", err)
 		}
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		return output.Fatalf("Error checking for existing Kitfile: %s", err)
 	}
-	if err := os.WriteFile(opts.outputPath, bytes, 0644); err != nil {
+
+	sink, err := output.OpenDataSink(opts.outputPath)
+	if err != nil {
 		return output.Fatalf("Failed to write Kitfile: %s", err)
 	}
-	output.Infof("Generated Kitfile:\n\n%s", string(bytes))
-	output.Infof("Saved to path '%s'", opts.outputPath)
+	defer func() {
+		if err := sink.Close(); err != nil {
+			output.Logf(output.LogLevelWarn, "failed to close output: %s", err)
+		}
+	}()
+	if _, err := sink.Write(bytes); err != nil {
+		return output.Fatalf("Failed to write Kitfile: %s", err)
+	}
+	if err := sink.Commit(); err != nil {
+		return output.Fatalf("Failed to finalize Kitfile: %s", err)
+	}
+
+	if opts.outputPath != "-" {
+		output.Infof("Generated Kitfile:\n\n%s", string(bytes))
+		output.Infof("Saved to path '%s'", opts.outputPath)
+	}
 	return nil
 }
 

--- a/pkg/lib/external/git/clone.go
+++ b/pkg/lib/external/git/clone.go
@@ -20,8 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/kitops-ml/kitops/pkg/output"
 )
@@ -64,9 +66,9 @@ func CloneRepository(repo, repoRef, dest, token string) error {
 	cloneCmd.Env = cloneEnv
 	cloneCmd.Env = append(cloneCmd.Env, "GIT_LFS_SKIP_SMUDGE=1")
 	cloneCmd.Stderr = os.Stderr
-	cloneCmd.Stdout = os.Stdout
+	cloneCmd.Stdout = output.InfoWriter()
 
-	output.Infof("Cloning repository %s", repo)
+	output.Infof("Cloning repository %s", SanitizeURL(repo))
 	if err := cloneCmd.Run(); err != nil {
 		return fmt.Errorf("error cloning repository: %w", err)
 	}
@@ -75,7 +77,7 @@ func CloneRepository(repo, repoRef, dest, token string) error {
 	lfsCmd := exec.Command("git", "lfs", "pull")
 	lfsCmd.Dir = dest
 	lfsCmd.Env = cloneEnv
-	lfsCmd.Stdout = os.Stdout
+	lfsCmd.Stdout = output.InfoWriter()
 	lfsCmd.Stderr = os.Stderr
 	output.Infof("Pulling large files")
 	if err := lfsCmd.Run(); err != nil {
@@ -83,7 +85,7 @@ func CloneRepository(repo, repoRef, dest, token string) error {
 	}
 	// LFS pull prints progress by overwriting a line repeatedly; once it's done
 	// we need to print a newline to avoid overwriting the last line
-	fmt.Printf("\n")
+	fmt.Fprintln(output.InfoWriter())
 
 	return nil
 }
@@ -122,4 +124,28 @@ func checkDestination(path string) error {
 		return fmt.Errorf("cannot clone to a non-empty directory")
 	}
 	return nil
+}
+
+// SanitizeURL strips any userinfo (user:password) from a URL so that
+// credentials embedded in clone URLs do not leak into logs or provenance
+// output. Inputs without userinfo — including ones that fail to parse, since
+// those cannot legally contain RFC 3986 userinfo — are returned unchanged.
+func SanitizeURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.User == nil {
+		return rawURL
+	}
+	u.User = nil
+	return u.String()
+}
+
+// ResolveHead returns the commit SHA at HEAD of the repo at repoDir.
+func ResolveHead(repoDir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve HEAD: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/pkg/lib/external/git/clone_test.go
+++ b/pkg/lib/external/git/clone_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeURL(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{in: "https://user:token@github.com/org/repo", want: "https://github.com/org/repo"},
+		{in: "https://user@github.com/org/repo", want: "https://github.com/org/repo"},
+		{in: "https://github.com/org/repo", want: "https://github.com/org/repo"},
+		{in: "https://huggingface.co/org/repo", want: "https://huggingface.co/org/repo"},
+		// '@' in the path portion is not userinfo and must be preserved.
+		{in: "https://example.com/path@v1", want: "https://example.com/path@v1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, SanitizeURL(tt.in))
+		})
+	}
+}
+
+func TestResolveHead(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		require.NoError(t, cmd.Run(), "git %v failed", args)
+	}
+
+	run("init", "-q")
+	run("config", "commit.gpgsign", "false")
+	run("config", "tag.gpgsign", "false")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello\n"), 0o644))
+	run("add", ".")
+	run("commit", "-q", "-m", "init")
+
+	head, err := ResolveHead(dir)
+	require.NoError(t, err)
+	assert.Len(t, head, 40)
+}

--- a/pkg/lib/external/hf/download.go
+++ b/pkg/lib/external/hf/download.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/kitops-ml/kitops/pkg/lib/filesystem"
 	kfgen "github.com/kitops-ml/kitops/pkg/lib/kitfile/generate"
 	"github.com/kitops-ml/kitops/pkg/output"
 
@@ -39,6 +40,9 @@ const (
 	datasetResolveURLFmt = "https://huggingface.co/datasets/%s/resolve/%s/%s"
 )
 
+// DownloadFiles fetches each entry of files into destDir. The caller is
+// expected to pass an immutable commit SHA as repoRef (via PinCommit) so the
+// snapshot is consistent across all downloads.
 func DownloadFiles(
 	ctx context.Context,
 	modelRepo, repoRef, destDir string,
@@ -47,15 +51,19 @@ func DownloadFiles(
 	maxConcurrency int,
 	repoType RepositoryType) error {
 
-	client := &http.Client{
-		Timeout: 1 * time.Hour,
+	if len(files) == 0 {
+		return nil
 	}
 
-	sem := semaphore.NewWeighted(int64(maxConcurrency))
-	errs, errCtx := errgroup.WithContext(ctx)
-	var semErr error
-
-	progress, plog := output.NewDownloadProgress()
+	// Reject any path that would escape destDir before doing any network or
+	// filesystem work. HF tree responses are not authoritative; a malicious
+	// or compromised repo could embed "../" segments to write files outside
+	// the import temp directory.
+	for _, f := range files {
+		if _, _, err := filesystem.VerifySubpath(destDir, f.Path); err != nil {
+			return fmt.Errorf("rejecting unsafe path %q from HuggingFace API: %w", f.Path, err)
+		}
+	}
 
 	var resolveURLFmt string
 	if repoType == RepoTypeDataset {
@@ -63,6 +71,15 @@ func DownloadFiles(
 	} else {
 		resolveURLFmt = modelResolveURLFmt
 	}
+
+	client := &http.Client{
+		Timeout: 1 * time.Hour,
+	}
+	sem := semaphore.NewWeighted(int64(maxConcurrency))
+	errs, errCtx := errgroup.WithContext(ctx)
+	var semErr error
+
+	progress, plog := output.NewDownloadProgress()
 
 	for _, f := range files {
 		if err := sem.Acquire(errCtx, 1); err != nil {

--- a/pkg/lib/external/hf/list_test.go
+++ b/pkg/lib/external/hf/list_test.go
@@ -1,0 +1,44 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hf
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalkRepoTree(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"type":"file","oid":"o1","size":4,"path":"a.json"}]`))
+	}))
+	defer srv.Close()
+
+	base, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	listing, err := walkRepoTree(context.Background(), srv.Client(), "", base, ".")
+	require.NoError(t, err)
+	require.Len(t, listing.Files, 1)
+	assert.Equal(t, "a.json", listing.Files[0].Path)
+}

--- a/pkg/lib/external/hf/revision.go
+++ b/pkg/lib/external/hf/revision.go
@@ -1,0 +1,73 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	modelRevisionURLFmt   = "https://huggingface.co/api/models/%s/revision/%s"
+	datasetRevisionURLFmt = "https://huggingface.co/api/datasets/%s/revision/%s"
+)
+
+// PinCommit resolves ref to an immutable commit SHA via HF's revision
+// metadata endpoint. HF accepts commit SHAs anywhere a ref is expected, so
+// callers can thread the returned SHA through ListFiles and DownloadFiles to
+// bind the entire import to one snapshot even if the branch moves mid-run.
+func PinCommit(ctx context.Context, repo, ref, token string, repoType RepositoryType) (string, error) {
+	var apiURL string
+	if repoType == RepoTypeDataset {
+		apiURL = fmt.Sprintf(datasetRevisionURLFmt, repo, ref)
+	} else {
+		apiURL = fmt.Sprintf(modelRevisionURLFmt, repo, ref)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", err
+	}
+	if token != "" {
+		req.Header.Add("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("revision lookup got status %d", resp.StatusCode)
+	}
+
+	var info struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return "", fmt.Errorf("parsing revision response: %w", err)
+	}
+	if info.SHA == "" {
+		return "", fmt.Errorf("revision response missing sha for %s@%s", repo, ref)
+	}
+	return info.SHA, nil
+}

--- a/pkg/output/sink.go
+++ b/pkg/output/sink.go
@@ -1,0 +1,146 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// DataSink is a writer for command-output payloads (e.g. SLSA predicates,
+// generated Kitfiles) that must not corrupt the destination on failure. For a
+// file target, writes go to a temp file in the same directory; Commit renames
+// the temp file to the user-specified path atomically. For stdout, writes go
+// directly to os.Stdout and Commit is a no-op.
+//
+// Lifecycle: open with OpenDataSink, defer Close, Write payload, then call
+// Commit on success. Close removes the temp file if Commit was not called, so
+// the original target stays untouched on the failure path.
+type DataSink interface {
+	io.Writer
+	Commit() error
+	Close() error
+}
+
+// sinkMu guards the swap of the package-level stdout writer when a command
+// directs structured data to stdout via OpenDataSink("-").
+var sinkMu sync.Mutex
+
+// stdoutSink writes data payloads to os.Stdout and reroutes the package info
+// writer to stderr while it is open, so subsequent Infof/Infoln output does
+// not corrupt the data stream. Close restores the original info writer.
+type stdoutSink struct {
+	prevStdout io.Writer
+	restored   bool
+}
+
+func (s *stdoutSink) Write(p []byte) (int, error) { return os.Stdout.Write(p) }
+func (s *stdoutSink) Commit() error               { return nil }
+func (s *stdoutSink) Close() error {
+	if s.restored {
+		return nil
+	}
+	sinkMu.Lock()
+	stdout = s.prevStdout
+	sinkMu.Unlock()
+	s.restored = true
+	return nil
+}
+
+// fileSink stages writes in a temp file alongside the target so the rename in
+// Close removes the temp file when Commit was not called
+type fileSink struct {
+	target    string
+	tmp       *os.File
+	committed bool
+}
+
+func (s *fileSink) Write(p []byte) (int, error) { return s.tmp.Write(p) }
+
+func (s *fileSink) Commit() error {
+	if s.committed {
+		return nil
+	}
+	tmpName := s.tmp.Name()
+	if err := s.tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, s.target); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	s.committed = true
+	return nil
+}
+
+func (s *fileSink) Close() error {
+	if s.committed {
+		return nil
+	}
+	tmpName := s.tmp.Name()
+	_ = s.tmp.Close()
+	return os.Remove(tmpName)
+}
+
+// OpenDataSink prepares a sink for the given path.
+//
+//   - "-": writes go to os.Stdout. The package info writer is rerouted to
+//     stderr so subsequent Infof/Infoln output does not corrupt the data
+//     stream. The original writer is restored on Close.
+//   - any other value: a temp file is created in the same directory as path.
+//     Writes go to that file; Commit renames it onto path. The user's
+//     existing file at path is not touched until Commit succeeds, so a
+//     failure between OpenDataSink and Commit leaves the original intact.
+//
+// Callers must ensure path is non-empty.
+func OpenDataSink(path string) (DataSink, error) {
+	if path == "-" {
+		sinkMu.Lock()
+		defer sinkMu.Unlock()
+		s := &stdoutSink{prevStdout: stdout}
+		stdout = stderr
+		return s, nil
+	}
+
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, base+".*.tmp")
+	if err != nil {
+		return nil, err
+	}
+	// CreateTemp opens with 0600; preserve the historical 0644 for the
+	// final file once renamed.
+	if err := tmp.Chmod(0644); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return nil, err
+	}
+	return &fileSink{target: path, tmp: tmp}, nil
+}
+
+// InfoWriter returns the writer currently used for info-level output. Callers
+// that bypass the standard logging helpers (for example, attaching a child
+// process's stdout) should use this so they share the same routing decisions
+// as Infof/Infoln.
+func InfoWriter() io.Writer {
+	sinkMu.Lock()
+	defer sinkMu.Unlock()
+	return stdout
+}

--- a/pkg/output/sink_test.go
+++ b/pkg/output/sink_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileSinkCommitWritesTarget(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.json")
+
+	sink, err := OpenDataSink(target)
+	require.NoError(t, err)
+	defer sink.Close()
+
+	_, err = sink.Write([]byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, sink.Commit())
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(got))
+}
+
+func TestFileSinkAbortPreservesOriginal(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.json")
+	require.NoError(t, os.WriteFile(target, []byte("original"), 0o644))
+
+	sink, err := OpenDataSink(target)
+	require.NoError(t, err)
+	// Write something, then close without Commit (simulating importer failure
+	// after open / before commit).
+	_, err = sink.Write([]byte("would-be-new"))
+	require.NoError(t, err)
+	require.NoError(t, sink.Close())
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(got), "Close without Commit must leave the target untouched")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "temp file must be cleaned up; got %v", entries)
+	assert.Equal(t, "out.json", entries[0].Name())
+}
+
+func TestFileSinkCommitIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.json")
+
+	sink, err := OpenDataSink(target)
+	require.NoError(t, err)
+	defer sink.Close()
+
+	_, err = sink.Write([]byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, sink.Commit())
+	require.NoError(t, sink.Commit())
+	require.NoError(t, sink.Close())
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `--attestation-output <path>` flag on `kit import` that emits a SLSA Provenance v1 predicate for the imported ModelKit. Output is byte-compatible with `cosign attest --predicate <path> --type slsaprovenance1`. Default behavior is unchanged.

The predicate pins:
- `source.uri` — `hf://[datasets/]<repo>` or `git+https://host/repo` (userinfo scrubbed from logs and predicate)
- `source.digest.gitCommit` — HF: `PinCommit` via `/api/.../revision/{ref}` before listing/downloading; git: `ResolveHead` on the local clone
- `kitfile.digest.sha256` — the OCI config blob hash, byte-identical to what cosign attests
- manifest digest — logged to stderr; cosign derives the in-toto Statement subject from the OCI ref

`resolvedDependencies` is intentionally `[]` — the source commit and manifest digests already form a complete integrity chain, so per-file enumeration would just restate what's already pinned.

## Other changes

- **Atomic data sink** (`pkg/output/sink.go`): `OpenDataSink` writes file targets through a temp file in the same directory, atomically renamed on `Commit`. A failing import leaves the user's existing attestation file untouched. For `-`, the info writer reroutes to stderr so logs don't corrupt the JSON. `kit init` also uses this helper.
- **Commit pinning before listing** (HF): `PinCommit` runs first so `ListFiles` and `DownloadFiles` both bind to one immutable SHA — closes the TOCTOU window where a branch could move mid-import.
- **Path-traversal guard**: `DownloadFiles` runs `filesystem.VerifySubpath` on every entry before any network/filesystem work, rejecting `..`-bearing paths from a malicious or compromised HF response.
- **Layer-aware download filter**: `kitfilePathFilter` mirrors pack's ignore-aware layer routing so HF only downloads files that will end up in the ModelKit. Handles catchall layers, `.kitignore` patterns (which always cover Kitfile names and `.kitignore` itself), Windows-style separators in cleaned layer paths, and the prefix-boundary case.
- **URL scrubbing**: `git.SanitizeURL` strips userinfo from clone URLs in both the `Cloning repository …` log line and the predicate `SourceURI`.
- **Validation**: `(*ProvenanceData).validate()` refuses to emit a predicate with empty source/kitfile/manifest digests, so an unverifiable attestation can't slip through silently.
