### PR TITLE
Init improvements

### DIFF
--- a/pkg/cmd/kitimport/cmd.go
+++ b/pkg/cmd/kitimport/cmd.go
@@ -80,6 +80,7 @@ type importOptions struct {
 	kitfilePath       string
 	downloadTool      string
 	concurrency       int
+	depth             int
 	attestationOutput string
 	modelKitRef       *registry.Reference
 }
@@ -102,6 +103,7 @@ func ImportCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.kitfilePath, "file", "f", "", "Path to Kitfile to use for packing (use '-' to read from standard input)")
 	cmd.Flags().StringVar(&opts.downloadTool, "tool", "", "Tool to use for downloading files: options are 'git' and 'hf' (default: detect based on repository)")
 	cmd.Flags().IntVar(&opts.concurrency, "concurrency", 5, "Maximum number of simultaneous downloads (for huggingface)")
+	cmd.Flags().IntVar(&opts.depth, "depth", 0, "Maximum directory depth to process when generating a Kitfile. Setting to -1 processes all files individually")
 	cmd.Flags().StringVar(&opts.attestationOutput, "attestation-output", "",
 		"Write SLSA Provenance v1 predicate to <path> ('-' for stdout)")
 	cmd.Flags().SortFlags = false

--- a/pkg/cmd/kitimport/gitimport.go
+++ b/pkg/cmd/kitimport/gitimport.go
@@ -95,7 +95,7 @@ func importUsingGit(ctx context.Context, opts *importOptions) (*ProvenanceData, 
 		if err != nil {
 			return nil, fmt.Errorf("error processing directory: %w", err)
 		}
-		kf, err := generateKitfile(dirContents, opts.repo, tmpDir)
+		kf, err := generateKitfile(dirContents, opts.repo, tmpDir, opts.depth)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/kitimport/hfimport.go
+++ b/pkg/cmd/kitimport/hfimport.go
@@ -86,7 +86,7 @@ func importUsingHF(ctx context.Context, opts *importOptions) (*ProvenanceData, e
 		}
 		kitfile = kf
 	} else {
-		kf, err := generateKitfile(dirListing, repo, tmpDir)
+		kf, err := generateKitfile(dirListing, repo, tmpDir, opts.depth)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/kitimport/util.go
+++ b/pkg/cmd/kitimport/util.go
@@ -43,7 +43,7 @@ import (
 
 var ErrNoEditorFound = errors.New("no editor found")
 
-func generateKitfile(dirContents *kfgen.DirectoryListing, repo string, outDir string) (*artifact.KitFile, error) {
+func generateKitfile(dirContents *kfgen.DirectoryListing, repo string, outDir string, depth int) (*artifact.KitFile, error) {
 	// Fill fields in package so that they're not empty in `kit list` later.
 	sections := strings.Split(repo, "/")
 	var modelPackage *artifact.Package
@@ -53,7 +53,7 @@ func generateKitfile(dirContents *kfgen.DirectoryListing, repo string, outDir st
 			Authors: []string{sections[len(sections)-2]},
 		}
 	}
-	kitfile, err := kfgen.GenerateKitfile(dirContents, modelPackage)
+	kitfile, err := kfgen.GenerateKitfile(dirContents, modelPackage, depth)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Kitfile: %w", err)
 	}

--- a/pkg/cmd/kitinit/cmd.go
+++ b/pkg/cmd/kitinit/cmd.go
@@ -80,6 +80,7 @@ type initOptions struct {
 	repoRef             string
 	token               string
 	outputPath          string
+	depth               int
 	// Computed fields (remote only)
 	repo     string
 	repoType hf.RepositoryType
@@ -105,6 +106,7 @@ func InitCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.repoRef, "ref", "main", "Branch or tag for remote repository (requires --remote)")
 	cmd.Flags().StringVar(&opts.token, "token", "", "Auth token for remote repository (requires --remote)")
 	cmd.Flags().StringVarP(&opts.outputPath, "output", "o", "", "Output path for generated Kitfile ('-' writes to stdout; default: Kitfile in directory for local, stdout for remote)")
+	cmd.Flags().IntVar(&opts.depth, "depth", 0, "Maximum directory depth to process when generating a Kitfile. Setting to a negative number processes all files individually")
 	cmd.Flags().SortFlags = false
 	return cmd
 }
@@ -146,7 +148,7 @@ func runCommand(opts *initOptions) func(*cobra.Command, []string) error {
 func runInit(dirContents *kfgen.DirectoryListing, opts *initOptions) error {
 	modelPackage := buildPackageFromRepo(opts.repo, opts.modelkitName, opts.modelkitDescription, opts.modelkitAuthor)
 
-	kitfile, err := kfgen.GenerateKitfile(dirContents, modelPackage)
+	kitfile, err := kfgen.GenerateKitfile(dirContents, modelPackage, opts.depth)
 	if err != nil {
 		return output.Fatalf("Error generating Kitfile: %s", err)
 	}

--- a/pkg/lib/kitfile/generate/generate.go
+++ b/pkg/lib/kitfile/generate/generate.go
@@ -263,13 +263,13 @@ func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFile
 	case "docs":
 		output.Logf(output.LogLevelTrace, "Directory %s interpreted as documentation", dir.Name)
 		kitfile.Docs = append(kitfile.Docs, artifact.Docs{
-			Path: withTrailingSlash(dir.Path),
+			Path: unixWithTrailingSlash(dir.Path),
 		})
 		return nil
 	case "src", "pkg", "lib", "build":
 		output.Logf(output.LogLevelTrace, "Directory %s interpreted as code", dir.Name)
 		kitfile.Code = append(kitfile.Code, artifact.Code{
-			Path: withTrailingSlash(dir.Path),
+			Path: unixWithTrailingSlash(dir.Path),
 		})
 		return nil
 	}
@@ -309,7 +309,7 @@ func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFile
 	}
 	if directoryHasMixedContents {
 		output.Logf(output.LogLevelTrace, "Mixed contents in directory %s, adding as code layer", dir.Path)
-		kitfile.Code = append(kitfile.Code, artifact.Code{Path: withTrailingSlash(dir.Path)})
+		kitfile.Code = append(kitfile.Code, artifact.Code{Path: unixWithTrailingSlash(dir.Path)})
 		return modelFiles
 	}
 	switch overallFiletype {
@@ -319,19 +319,19 @@ func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFile
 		modelFiles = append(modelFiles, metadataFiles...)
 	case fileTypeDataset:
 		output.Logf(output.LogLevelTrace, "Interpreting directory %s as a dataset directory", dir.Path)
-		kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: withTrailingSlash(dir.Path)})
+		kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: unixWithTrailingSlash(dir.Path)})
 	case fileTypeDocs:
 		output.Logf(output.LogLevelTrace, "Interpreting directory %s as a docs directory", dir.Path)
-		kitfile.Docs = append(kitfile.Docs, artifact.Docs{Path: withTrailingSlash(dir.Path)})
+		kitfile.Docs = append(kitfile.Docs, artifact.Docs{Path: unixWithTrailingSlash(dir.Path)})
 	case fileTypePrompt:
 		output.Logf(output.LogLevelTrace, "Interpreting directory %s as a prompts directory", dir.Path)
-		kitfile.Prompts = append(kitfile.Prompts, artifact.Prompt{Path: withTrailingSlash(dir.Path)})
+		kitfile.Prompts = append(kitfile.Prompts, artifact.Prompt{Path: unixWithTrailingSlash(dir.Path)})
 	case fileTypeCode:
 		output.Logf(output.LogLevelTrace, "Interpreting directory %s as code directory", dir.Path)
-		kitfile.Code = append(kitfile.Code, artifact.Code{Path: withTrailingSlash(dir.Path)})
+		kitfile.Code = append(kitfile.Code, artifact.Code{Path: unixWithTrailingSlash(dir.Path)})
 	default:
 		output.Logf(output.LogLevelTrace, "Could not determine type for directory %s. Adding as code layer", dir.Path)
-		kitfile.Code = append(kitfile.Code, artifact.Code{Path: withTrailingSlash(dir.Path)})
+		kitfile.Code = append(kitfile.Code, artifact.Code{Path: unixWithTrailingSlash(dir.Path)})
 	}
 
 	return modelFiles
@@ -459,7 +459,8 @@ func anyPattern(query string, patterns []string) bool {
 	return false
 }
 
-func withTrailingSlash(p string) string {
+func unixWithTrailingSlash(p string) string {
+	p = filepath.ToSlash(p)
 	if p == "." || strings.HasSuffix(p, "/") {
 		return p
 	}

--- a/pkg/lib/kitfile/generate/generate.go
+++ b/pkg/lib/kitfile/generate/generate.go
@@ -115,7 +115,17 @@ func GenerateKitfile(dir *DirectoryListing, packageOpt *artifact.Package, depth 
 		return kitfile, nil
 	}
 
-	modelFiles, metadataFiles, unknownFiles, detectedLicenseType := processSubdirFiles(kitfile, *dir, depth)
+	modelFiles, metadataFiles, unknownFiles, licensePath := classifyDirectoryRecursive(kitfile, *dir, depth)
+	detectedLicenseType := ""
+	if licensePath != "" {
+		licenseType, err := detectLicense(licensePath)
+		if err != nil {
+			output.Debugf("Error determining license type: %s", err)
+			output.Logf(output.LogLevelWarn, "Unable to determine license type")
+		}
+		detectedLicenseType = licenseType
+		output.Logf(output.LogLevelTrace, "Detected license %s for license file", detectedLicenseType)
+	}
 
 	if len(unknownFiles) > 5 {
 		output.Logf(output.LogLevelTrace, "Unrecognized files found in %s; adding catch-all code layer", dir.Path)
@@ -159,13 +169,13 @@ func GenerateKitfile(dir *DirectoryListing, packageOpt *artifact.Package, depth 
 	return kitfile, nil
 }
 
-// processSubdirFiles classifies each file in dir individually and adds typed layers to
+// classifyDirectoryRecursive classifies each file in dir individually and adds typed layers to
 // kitfile. depth controls how many additional subdirectory levels are processed
 // file-by-file before switching to addDirToKitfile (whole-directory analysis). Returns
 // model and metadata files for the caller to pair, any files whose type could not be
 // determined (so the caller can decide how to handle them), and any detected license
 // identifier. Unclassifiable directories are added directly to kitfile.Code.
-func processSubdirFiles(kitfile *artifact.KitFile, dir DirectoryListing, depth int) (modelFiles []FileListing, metadataFiles []FileListing, unknownFiles []FileListing, detectedLicenseType string) {
+func classifyDirectoryRecursive(kitfile *artifact.KitFile, dir DirectoryListing, depth int) (modelFiles []FileListing, metadataFiles []FileListing, unknownFiles []FileListing, licensePath string) {
 	if found, _ := dirContainsSkillMD(dir); found {
 		output.Logf(output.LogLevelTrace, "Directory %s contains SKILL.md; treating as skill", dir.Path)
 		prompt, _ := buildPromptFromSkill(dir)
@@ -196,13 +206,7 @@ func processSubdirFiles(kitfile *artifact.KitFile, dir DirectoryListing, depth i
 				Path:        file.Path,
 				Description: "License file",
 			})
-			licenseType, err := detectLicense(file.Path)
-			if err != nil {
-				output.Debugf("Error determining license type: %s", err)
-				output.Logf(output.LogLevelWarn, "Unable to determine license type")
-			}
-			detectedLicenseType = licenseType
-			output.Logf(output.LogLevelTrace, "Detected license %s for license file", detectedLicenseType)
+			licensePath = file.Path
 			continue
 		}
 
@@ -239,7 +243,7 @@ func processSubdirFiles(kitfile *artifact.KitFile, dir DirectoryListing, depth i
 	} else {
 		for _, subDir := range dir.Subdirs {
 			// Ignore licenses in subdirectories -- it's unclear where to assign them
-			subModelFiles, subMetaFiles, subUnknownFiles, _ := processSubdirFiles(kitfile, subDir, depth-1)
+			subModelFiles, subMetaFiles, subUnknownFiles, _ := classifyDirectoryRecursive(kitfile, subDir, depth-1)
 			modelFiles = append(modelFiles, subModelFiles...)
 			metadataFiles = append(metadataFiles, subMetaFiles...)
 			for _, f := range subUnknownFiles {
@@ -248,7 +252,7 @@ func processSubdirFiles(kitfile *artifact.KitFile, dir DirectoryListing, depth i
 			}
 		}
 	}
-	return modelFiles, metadataFiles, unknownFiles, detectedLicenseType
+	return modelFiles, metadataFiles, unknownFiles, licensePath
 }
 
 func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFiles []FileListing) {

--- a/pkg/lib/kitfile/generate/generate.go
+++ b/pkg/lib/kitfile/generate/generate.go
@@ -84,8 +84,10 @@ var promptFilePatterns = []string{
 
 // Generate a basic Kitfile by looking at the contents of a directory. Parameter
 // packageOpt can be used to define metadata for the Kitfile (i.e. the package
-// section), which is left empty if the parameter is nil.
-func GenerateKitfile(dir *DirectoryListing, packageOpt *artifact.Package) (*artifact.KitFile, error) {
+// section), which is left empty if the parameter is nil. depth controls how many
+// levels of subdirectories are processed file-by-file; at depth=0 (the default),
+// subdirectories of the root dir are analyzed as whole units.
+func GenerateKitfile(dir *DirectoryListing, packageOpt *artifact.Package, depth int) (*artifact.KitFile, error) {
 	output.Logf(output.LogLevelTrace, "Generating Kitfile in %s", dir.Path)
 	kitfile := &artifact.KitFile{
 		ManifestVersion: "1.0.0",
@@ -113,15 +115,63 @@ func GenerateKitfile(dir *DirectoryListing, packageOpt *artifact.Package) (*arti
 		return kitfile, nil
 	}
 
-	// We can make sure all files are included by including a layer with path '.'
-	// However, we only want to do this if it is necessary
-	includeCatchallSection := false
-	// Dirs we don't know how to handle automatically.
-	var unprocessedDirPaths []string
-	// Metadata files; we want these to be either model parts (if there is a model)
-	// or datasets
-	var modelFiles, metadataFiles []FileListing
-	var detectedLicenseType string
+	modelFiles, metadataFiles, unknownFiles, detectedLicenseType := processSubdirFiles(kitfile, *dir, depth)
+
+	if len(unknownFiles) > 5 {
+		output.Logf(output.LogLevelTrace, "Unrecognized files found in %s; adding catch-all code layer", dir.Path)
+		kitfile.Code = append(kitfile.Code, artifact.Code{Path: "."})
+	} else if len(unknownFiles) > 0 {
+		output.Logf(output.LogLevelTrace, "Unrecognized files found in %s; adding as code layers", dir.Path)
+		for _, f := range unknownFiles {
+			kitfile.Code = append(kitfile.Code, artifact.Code{Path: f.Path})
+		}
+	}
+
+	if len(modelFiles) > 0 {
+		if err := addModelToKitfile(kitfile, modelFiles); err != nil {
+			return nil, fmt.Errorf("failed to add model to Kitfile: %w", err)
+		}
+		output.Logf(output.LogLevelTrace, "Adding metadata files as model parts")
+		for _, metadataFile := range metadataFiles {
+			kitfile.Model.Parts = append(kitfile.Model.Parts, artifact.ModelPart{Path: metadataFile.Path})
+		}
+	} else {
+		output.Logf(output.LogLevelTrace, "No model detected; adding metadata files as dataset layers")
+		for _, metadataFile := range metadataFiles {
+			kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: metadataFile.Path})
+		}
+	}
+
+	// If we detected a license, try to attach it to the Kitfile section that makes sense
+	if kitfile.Model != nil && detectedLicenseType != "" {
+		kitfile.Model.License = detectedLicenseType
+	} else if len(kitfile.DataSets) == 1 {
+		kitfile.DataSets[0].License = detectedLicenseType
+	} else if len(kitfile.Code) == 1 {
+		kitfile.Code[0].License = detectedLicenseType
+	} else {
+		output.Logf(output.LogLevelTrace, "Unsure what license applies to, adding to Kitfile package")
+		kitfile.Package.License = detectedLicenseType
+	}
+
+	applySkillMetadataToPackage(kitfile, *dir)
+
+	return kitfile, nil
+}
+
+// processSubdirFiles classifies each file in dir individually and adds typed layers to
+// kitfile. depth controls how many additional subdirectory levels are processed
+// file-by-file before switching to addDirToKitfile (whole-directory analysis). Returns
+// model and metadata files for the caller to pair, any files whose type could not be
+// determined (so the caller can decide how to handle them), and any detected license
+// identifier. Unclassifiable directories are added directly to kitfile.Code.
+func processSubdirFiles(kitfile *artifact.KitFile, dir DirectoryListing, depth int) (modelFiles []FileListing, metadataFiles []FileListing, unknownFiles []FileListing, detectedLicenseType string) {
+	if found, _ := dirContainsSkillMD(dir); found {
+		output.Logf(output.LogLevelTrace, "Directory %s contains SKILL.md; treating as skill", dir.Path)
+		prompt, _ := buildPromptFromSkill(dir)
+		kitfile.Prompts = append(kitfile.Prompts, prompt)
+		return nil, nil, nil, ""
+	}
 
 	output.Logf(output.LogLevelTrace, "Reading directory contents")
 	for _, file := range dir.Files {
@@ -136,14 +186,14 @@ func GenerateKitfile(dir *DirectoryListing, packageOpt *artifact.Package) (*arti
 		if strings.HasPrefix(strings.ToLower(file.Name), "readme") {
 			output.Logf(output.LogLevelTrace, "Found readme file '%s'", file.Name)
 			kitfile.Docs = append(kitfile.Docs, artifact.Docs{
-				Path:        file.Name,
+				Path:        file.Path,
 				Description: "Readme file",
 			})
 			continue
 		} else if strings.HasPrefix(strings.ToLower(file.Name), "license") {
 			output.Logf(output.LogLevelTrace, "Found license file '%s'", file.Name)
 			kitfile.Docs = append(kitfile.Docs, artifact.Docs{
-				Path:        file.Name,
+				Path:        file.Path,
 				Description: "License file",
 			})
 			licenseType, err := detectLicense(file.Path)
@@ -173,89 +223,55 @@ func GenerateKitfile(dir *DirectoryListing, packageOpt *artifact.Package) (*arti
 			kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: file.Path})
 		case fileTypePrompt:
 			kitfile.Prompts = append(kitfile.Prompts, artifact.Prompt{Path: file.Path})
+		case fileTypeCode:
+			kitfile.Code = append(kitfile.Code, artifact.Code{Path: file.Path})
 		default:
-			output.Logf(output.LogLevelTrace, "File %s is either code or unknown type. Will be added as a catch-all section", file.Path)
-			// File is either code or unknown; we'll have to include it in a catch-all section
-			includeCatchallSection = true
+			output.Logf(output.LogLevelTrace, "File %s is unknown type; will be included in code section", file.Path)
+			unknownFiles = append(unknownFiles, file)
 		}
 	}
 
-	for _, subDir := range dir.Subdirs {
-		dirModelFiles, err := addDirToKitfile(kitfile, subDir)
-		if err != nil {
-			output.Logf(output.LogLevelTrace, "Failed to determine type for directory %s: %s", subDir.Path, err)
-			unprocessedDirPaths = append(unprocessedDirPaths, subDir.Path)
-		}
-		modelFiles = append(modelFiles, dirModelFiles...)
-		continue
-	}
-
-	if len(modelFiles) > 0 {
-		if err := addModelToKitfile(kitfile, modelFiles); err != nil {
-			return nil, fmt.Errorf("failed to add model to Kitfile: %w", err)
-		}
-		output.Logf(output.LogLevelTrace, "Adding metadata files as model parts")
-		for _, metadataFile := range metadataFiles {
-			kitfile.Model.Parts = append(kitfile.Model.Parts, artifact.ModelPart{Path: metadataFile.Path})
+	if depth == 0 {
+		for _, subDir := range dir.Subdirs {
+			dirModelFiles := addDirToKitfile(kitfile, subDir)
+			modelFiles = append(modelFiles, dirModelFiles...)
 		}
 	} else {
-		output.Logf(output.LogLevelTrace, "No model detected; adding metadata files as dataset layers")
-		for _, metadataFile := range metadataFiles {
-			kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: metadataFile.Path})
+		for _, subDir := range dir.Subdirs {
+			// Ignore licenses in subdirectories -- it's unclear where to assign them
+			subModelFiles, subMetaFiles, subUnknownFiles, _ := processSubdirFiles(kitfile, subDir, depth-1)
+			modelFiles = append(modelFiles, subModelFiles...)
+			metadataFiles = append(metadataFiles, subMetaFiles...)
+			for _, f := range subUnknownFiles {
+				output.Logf(output.LogLevelTrace, "File %s is unknown type; adding as code layer", f.Path)
+				kitfile.Code = append(kitfile.Code, artifact.Code{Path: f.Path})
+			}
 		}
 	}
-
-	// Decide how to handle remaining paths. Either package them in one large code layer with basePath
-	// or as separate layers for each directory.
-	output.Logf(output.LogLevelTrace, "Unable to process %d paths in %s", len(unprocessedDirPaths), dir.Path)
-	if includeCatchallSection || len(unprocessedDirPaths) > 5 {
-		output.Logf(output.LogLevelTrace, "Adding catch-all code layer to include files in %s", dir.Path)
-		// Overwrite any code layers we added before; this is cleaner than e.g. having a layer for '.' and a layer for 'src'
-		kitfile.Code = []artifact.Code{{Path: "."}}
-	} else {
-		for _, path := range unprocessedDirPaths {
-			kitfile.Code = append(kitfile.Code, artifact.Code{Path: path})
-		}
-	}
-
-	// If we detected a license, try to attach it to the Kitfile section that makes sense
-	if kitfile.Model != nil && detectedLicenseType != "" {
-		kitfile.Model.License = detectedLicenseType
-	} else if len(kitfile.DataSets) == 1 {
-		kitfile.DataSets[0].License = detectedLicenseType
-	} else if len(kitfile.Code) == 1 {
-		kitfile.Code[0].License = detectedLicenseType
-	} else {
-		output.Logf(output.LogLevelTrace, "Unsure what license applies to, adding to Kitfile package")
-		kitfile.Package.License = detectedLicenseType
-	}
-
-	applySkillMetadataToPackage(kitfile, *dir)
-
-	return kitfile, nil
+	return modelFiles, metadataFiles, unknownFiles, detectedLicenseType
 }
 
-func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFiles []FileListing, err error) {
+func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFiles []FileListing) {
 	if found, _ := dirContainsSkillMD(dir); found {
 		output.Logf(output.LogLevelTrace, "Directory %s contains SKILL.md; treating as skill", dir.Path)
 		prompt, _ := buildPromptFromSkill(dir)
 		kitfile.Prompts = append(kitfile.Prompts, prompt)
-		return nil, nil
+		return nil
 	}
 
 	switch dir.Name {
 	case "docs":
 		output.Logf(output.LogLevelTrace, "Directory %s interpreted as documentation", dir.Name)
 		kitfile.Docs = append(kitfile.Docs, artifact.Docs{
-			Path: dir.Path,
+			Path: withTrailingSlash(dir.Path),
 		})
-		return nil, nil
+		return nil
 	case "src", "pkg", "lib", "build":
 		output.Logf(output.LogLevelTrace, "Directory %s interpreted as code", dir.Name)
 		kitfile.Code = append(kitfile.Code, artifact.Code{
-			Path: dir.Path,
+			Path: withTrailingSlash(dir.Path),
 		})
-		return nil, nil
+		return nil
 	}
 
 	// Sort entries in the directory to try and figure out what it contains. We'll reuse the
@@ -263,7 +279,7 @@ func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFile
 	// Avoid using maps here since they iterate in a random order.
 	directoryContents := [int(fileTypeUnknown) + 1][]string{}
 	for _, subdir := range dir.Subdirs {
-		// We can, in the future, recurse deeper into the directory tree here. For now, treat secondary dirs as unknowns
+		// We can, in the future, recurse deeper into the directory tree here. For now, treat additional dirs as unknowns
 		directoryContents[int(fileTypeUnknown)] = append(directoryContents[int(fileTypeUnknown)], subdir.Path)
 	}
 
@@ -292,7 +308,9 @@ func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFile
 		}
 	}
 	if directoryHasMixedContents {
-		return modelFiles, fmt.Errorf("mixed content in directory; unable to determine type")
+		output.Logf(output.LogLevelTrace, "Mixed contents in directory %s, adding as code layer", dir.Path)
+		kitfile.Code = append(kitfile.Code, artifact.Code{Path: withTrailingSlash(dir.Path)})
+		return modelFiles
 	}
 	switch overallFiletype {
 	case fileTypeModel:
@@ -301,21 +319,22 @@ func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFile
 		modelFiles = append(modelFiles, metadataFiles...)
 	case fileTypeDataset:
 		output.Logf(output.LogLevelTrace, "Interpreting directory %s as a dataset directory", dir.Path)
-		kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: dir.Path})
+		kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: withTrailingSlash(dir.Path)})
 	case fileTypeDocs:
 		output.Logf(output.LogLevelTrace, "Interpreting directory %s as a docs directory", dir.Path)
-		kitfile.Docs = append(kitfile.Docs, artifact.Docs{Path: dir.Path})
+		kitfile.Docs = append(kitfile.Docs, artifact.Docs{Path: withTrailingSlash(dir.Path)})
 	case fileTypePrompt:
 		output.Logf(output.LogLevelTrace, "Interpreting directory %s as a prompts directory", dir.Path)
-		kitfile.Prompts = append(kitfile.Prompts, artifact.Prompt{Path: dir.Path})
+		kitfile.Prompts = append(kitfile.Prompts, artifact.Prompt{Path: withTrailingSlash(dir.Path)})
+	case fileTypeCode:
+		output.Logf(output.LogLevelTrace, "Interpreting directory %s as code directory", dir.Path)
+		kitfile.Code = append(kitfile.Code, artifact.Code{Path: withTrailingSlash(dir.Path)})
 	default:
-		output.Logf(output.LogLevelTrace, "Could not determine type for directory %s", dir.Path)
-		// If it's overall code, metadata, or unknown, just return it as unprocessed and let it be added as a Code section
-		// later
-		return modelFiles, fmt.Errorf("directory should be handled as Code")
+		output.Logf(output.LogLevelTrace, "Could not determine type for directory %s. Adding as code layer", dir.Path)
+		kitfile.Code = append(kitfile.Code, artifact.Code{Path: withTrailingSlash(dir.Path)})
 	}
 
-	return modelFiles, nil
+	return modelFiles
 }
 
 func determineFileType(filename string) fileType {
@@ -344,7 +363,6 @@ func determineFileType(filename string) fileType {
 		return fileTypeDataset
 	}
 	return fileTypeUnknown
-
 }
 
 func addModelToKitfile(kitfile *artifact.KitFile, files []FileListing) error {
@@ -439,4 +457,11 @@ func anyPattern(query string, patterns []string) bool {
 		}
 	}
 	return false
+}
+
+func withTrailingSlash(p string) string {
+	if p == "." || strings.HasSuffix(p, "/") {
+		return p
+	}
+	return p + "/"
 }

--- a/pkg/lib/kitfile/generate/generate_test.go
+++ b/pkg/lib/kitfile/generate/generate_test.go
@@ -18,6 +18,9 @@ package generate
 
 import (
 	"testing"
+
+	"github.com/kitops-ml/kitops/pkg/artifact"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDetermineFileType(t *testing.T) {
@@ -129,5 +132,277 @@ func TestDetermineFileType(t *testing.T) {
 				t.Errorf("determineFileType(%q) = %v, want %v", tt.filename, result, tt.expectedType)
 			}
 		})
+	}
+}
+
+func TestGenerateWithDepth(t *testing.T) {
+	testDirListing := DirectoryListing{
+		Name: "root-dir",
+		Path: "root-dir",
+		Files: []FileListing{
+			{Name: "root-one", Path: "root-one.md", Size: 100},
+			{Name: "root-two", Path: "root-two.md", Size: 100},
+			{Name: "root-three", Path: "root-three.md", Size: 100},
+		},
+		Subdirs: []DirectoryListing{
+			{
+				Name: "subdir-one",
+				Path: "subdir-one",
+				Files: []FileListing{
+					{Name: "subdir-one-one", Path: "subdir-one/subdir-one-one.md", Size: 100},
+					{Name: "subdir-one-two", Path: "subdir-one/subdir-one-two.md", Size: 100},
+					{Name: "subdir-one-three", Path: "subdir-one/subdir-one-three.md", Size: 100},
+				},
+				Subdirs: []DirectoryListing{
+					{
+						Name: "subdir-two",
+						Path: "subdir-one/subdir-two",
+						Files: []FileListing{
+							{Name: "subdir-two-one", Path: "subdir-one/subdir-two/subdir-two-one.md", Size: 100},
+							{Name: "subdir-two-two", Path: "subdir-one/subdir-two/subdir-two-two.md", Size: 100},
+							{Name: "subdir-two-three", Path: "subdir-one/subdir-two/subdir-two-three.md", Size: 100},
+						},
+						Subdirs: []DirectoryListing{
+							{
+								Name: "subdir-three",
+								Path: "subdir-one/subdir-two/subdir-three",
+								Files: []FileListing{
+									{Name: "subdir-three-one", Path: "subdir-one/subdir-two/subdir-three/subdir-three-one.md", Size: 100},
+									{Name: "subdir-three-two", Path: "subdir-one/subdir-two/subdir-three/subdir-three-two.md", Size: 100},
+									{Name: "subdir-three-three", Path: "subdir-one/subdir-two/subdir-three/subdir-three-three.md", Size: 100},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("Depth zero Kitfile", func(t *testing.T) {
+		kitfile, err := GenerateKitfile(&testDirListing, nil, 0)
+		assert.NoError(t, err)
+		expectedDocs := []artifact.Docs{
+			{Path: "root-one.md"},
+			{Path: "root-two.md"},
+			{Path: "root-three.md"},
+		}
+		for _, expectedDoc := range expectedDocs {
+			assert.Contains(t, kitfile.Docs, expectedDoc)
+		}
+		assert.Contains(t, kitfile.Code, artifact.Code{Path: "subdir-one/"})
+	})
+
+	t.Run("Depth one Kitfile", func(t *testing.T) {
+		kitfile, err := GenerateKitfile(&testDirListing, nil, 1)
+		assert.NoError(t, err)
+		expectedDocs := []artifact.Docs{
+			{Path: "root-one.md"},
+			{Path: "root-two.md"},
+			{Path: "root-three.md"},
+			{Path: "subdir-one/subdir-one-one.md"},
+			{Path: "subdir-one/subdir-one-two.md"},
+			{Path: "subdir-one/subdir-one-three.md"},
+		}
+		for _, expectedDoc := range expectedDocs {
+			assert.Contains(t, kitfile.Docs, expectedDoc)
+		}
+		assert.Contains(t, kitfile.Code, artifact.Code{Path: "subdir-one/subdir-two/"})
+	})
+
+	t.Run("Depth two Kitfile", func(t *testing.T) {
+		kitfile, err := GenerateKitfile(&testDirListing, nil, 2)
+		assert.NoError(t, err)
+		expectedDocs := []artifact.Docs{
+			{Path: "root-one.md"},
+			{Path: "root-two.md"},
+			{Path: "root-three.md"},
+			{Path: "subdir-one/subdir-one-one.md"},
+			{Path: "subdir-one/subdir-one-two.md"},
+			{Path: "subdir-one/subdir-one-three.md"},
+			{Path: "subdir-one/subdir-two/subdir-two-one.md"},
+			{Path: "subdir-one/subdir-two/subdir-two-two.md"},
+			{Path: "subdir-one/subdir-two/subdir-two-three.md"},
+		}
+		for _, expectedDoc := range expectedDocs {
+			assert.Contains(t, kitfile.Docs, expectedDoc)
+		}
+		assert.Contains(t, kitfile.Code, artifact.Code{Path: "subdir-one/subdir-two/subdir-three/"})
+	})
+
+	t.Run("Depth three Kitfile", func(t *testing.T) {
+		kitfile, err := GenerateKitfile(&testDirListing, nil, 3)
+		assert.NoError(t, err)
+		expectedDocs := []artifact.Docs{
+			{Path: "root-one.md"},
+			{Path: "root-two.md"},
+			{Path: "root-three.md"},
+			{Path: "subdir-one/subdir-one-one.md"},
+			{Path: "subdir-one/subdir-one-two.md"},
+			{Path: "subdir-one/subdir-one-three.md"},
+			{Path: "subdir-one/subdir-two/subdir-two-one.md"},
+			{Path: "subdir-one/subdir-two/subdir-two-two.md"},
+			{Path: "subdir-one/subdir-two/subdir-two-three.md"},
+			{Path: "subdir-one/subdir-two/subdir-three/subdir-three-one.md"},
+			{Path: "subdir-one/subdir-two/subdir-three/subdir-three-two.md"},
+			{Path: "subdir-one/subdir-two/subdir-three/subdir-three-three.md"},
+		}
+		for _, expectedDoc := range expectedDocs {
+			assert.Contains(t, kitfile.Docs, expectedDoc)
+		}
+		assert.Len(t, kitfile.Code, 0, "Should not contain any code layers")
+	})
+
+	t.Run("Full depth Kitfile", func(t *testing.T) {
+		kitfile, err := GenerateKitfile(&testDirListing, nil, -1)
+		assert.NoError(t, err)
+		expectedDocs := []artifact.Docs{
+			{Path: "root-one.md"},
+			{Path: "root-two.md"},
+			{Path: "root-three.md"},
+			{Path: "subdir-one/subdir-one-one.md"},
+			{Path: "subdir-one/subdir-one-two.md"},
+			{Path: "subdir-one/subdir-one-three.md"},
+			{Path: "subdir-one/subdir-two/subdir-two-one.md"},
+			{Path: "subdir-one/subdir-two/subdir-two-two.md"},
+			{Path: "subdir-one/subdir-two/subdir-two-three.md"},
+			{Path: "subdir-one/subdir-two/subdir-three/subdir-three-one.md"},
+			{Path: "subdir-one/subdir-two/subdir-three/subdir-three-two.md"},
+			{Path: "subdir-one/subdir-two/subdir-three/subdir-three-three.md"},
+		}
+		for _, expectedDoc := range expectedDocs {
+			assert.Contains(t, kitfile.Docs, expectedDoc)
+		}
+		assert.Len(t, kitfile.Code, 0, "Should not contain any code layers")
+	})
+}
+
+func TestGenerateReadmeAndLicenseInSubdirs(t *testing.T) {
+	testDirListing := DirectoryListing{
+		Name: "root-dir",
+		Path: "root-dir",
+		Files: []FileListing{
+			{Name: "README.md", Path: "README.md", Size: 100},
+			{Name: "LICENSE", Path: "LICENSE", Size: 100},
+		},
+		Subdirs: []DirectoryListing{
+			{
+				Name: "subdir-one",
+				Path: "subdir-one",
+				Files: []FileListing{
+					{Name: "README.md", Path: "subdir-one/README.md", Size: 100},
+					{Name: "LICENSE", Path: "subdir-one/LICENSE", Size: 100},
+				},
+				Subdirs: []DirectoryListing{
+					{
+						Name: "subdir-two",
+						Path: "subdir-one/subdir-two",
+						Files: []FileListing{
+							{Name: "README.md", Path: "subdir-one/subdir-two/README.md", Size: 100},
+							{Name: "LICENSE", Path: "subdir-one/subdir-two/LICENSE", Size: 100},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("Depth zero only includes root README and LICENSE", func(t *testing.T) {
+		kitfile, err := GenerateKitfile(&testDirListing, nil, 0)
+		assert.NoError(t, err)
+		assert.Len(t, kitfile.Docs, 2)
+		assert.Contains(t, kitfile.Docs, artifact.Docs{Path: "README.md", Description: "Readme file"})
+		assert.Contains(t, kitfile.Docs, artifact.Docs{Path: "LICENSE", Description: "License file"})
+	})
+
+	t.Run("Depth one includes subdir README and LICENSE with full path", func(t *testing.T) {
+		kitfile, err := GenerateKitfile(&testDirListing, nil, 1)
+		assert.NoError(t, err)
+		assert.Len(t, kitfile.Docs, 4)
+		assert.Contains(t, kitfile.Docs, artifact.Docs{Path: "README.md", Description: "Readme file"})
+		assert.Contains(t, kitfile.Docs, artifact.Docs{Path: "LICENSE", Description: "License file"})
+		assert.Contains(t, kitfile.Docs, artifact.Docs{Path: "subdir-one/README.md", Description: "Readme file"})
+		assert.Contains(t, kitfile.Docs, artifact.Docs{Path: "subdir-one/LICENSE", Description: "License file"})
+	})
+
+	t.Run("Full depth includes all README and LICENSE files with full paths", func(t *testing.T) {
+		kitfile, err := GenerateKitfile(&testDirListing, nil, -1)
+		assert.NoError(t, err)
+		expectedDocs := []artifact.Docs{
+			{Path: "README.md", Description: "Readme file"},
+			{Path: "LICENSE", Description: "License file"},
+			{Path: "subdir-one/README.md", Description: "Readme file"},
+			{Path: "subdir-one/LICENSE", Description: "License file"},
+			{Path: "subdir-one/subdir-two/README.md", Description: "Readme file"},
+			{Path: "subdir-one/subdir-two/LICENSE", Description: "License file"},
+		}
+		for _, expected := range expectedDocs {
+			assert.Contains(t, kitfile.Docs, expected)
+		}
+	})
+}
+
+func TestGenerateModelPartsDepth(t *testing.T) {
+	testDirListing := DirectoryListing{
+		Name: "root-dir",
+		Path: "root-dir",
+		Files: []FileListing{
+			{Name: "root-one", Path: "root-one.onnx", Size: 100},
+			{Name: "root-two", Path: "root-two.onnx", Size: 100},
+			{Name: "root-meta", Path: "root-meta.json", Size: 100},
+		},
+		Subdirs: []DirectoryListing{
+			{
+				Name: "subdir-one",
+				Path: "subdir-one",
+				Files: []FileListing{
+					{Name: "subdir-one-one", Path: "subdir-one/subdir-one-one.onnx", Size: 100},
+					{Name: "subdir-one-two", Path: "subdir-one/subdir-one-two.onnx", Size: 100},
+					{Name: "subdir-one-meta", Path: "subdir-one/subdir-one-meta.json", Size: 100},
+				},
+				Subdirs: []DirectoryListing{
+					{
+						Name: "subdir-two",
+						Path: "subdir-one/subdir-two",
+						Files: []FileListing{
+							{Name: "subdir-two-one", Path: "subdir-one/subdir-two/subdir-two-one.onnx", Size: 100},
+							{Name: "subdir-two-two", Path: "subdir-one/subdir-two/subdir-two-two.onnx", Size: 100},
+							{Name: "subdir-two-meta", Path: "subdir-one/subdir-two/subdir-two-meta.json", Size: 100},
+						},
+						Subdirs: []DirectoryListing{
+							{
+								Name: "subdir-three",
+								Path: "subdir-one/subdir-two/subdir-three",
+								Files: []FileListing{
+									{Name: "subdir-three-one", Path: "subdir-one/subdir-two/subdir-three/subdir-three-one.onnx", Size: 100},
+									{Name: "subdir-three-two", Path: "subdir-one/subdir-two/subdir-three/subdir-three-two.onnx", Size: 100},
+									{Name: "subdir-three-meta", Path: "subdir-one/subdir-two/subdir-three/subdir-three-meta.json", Size: 100},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	kitfile, err := GenerateKitfile(&testDirListing, nil, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, "root-one.onnx", kitfile.Model.Path)
+	assert.Len(t, kitfile.Model.Parts, 11)
+	expectedModelParts := []artifact.ModelPart{
+		{Path: "root-two.onnx"},
+		{Path: "subdir-one/subdir-one-one.onnx"},
+		{Path: "subdir-one/subdir-one-two.onnx"},
+		{Path: "subdir-one/subdir-two/subdir-two-one.onnx"},
+		{Path: "subdir-one/subdir-two/subdir-two-two.onnx"},
+		{Path: "subdir-one/subdir-two/subdir-three/subdir-three-one.onnx"},
+		{Path: "subdir-one/subdir-two/subdir-three/subdir-three-two.onnx"},
+		{Path: "root-meta.json"},
+		{Path: "subdir-one/subdir-one-meta.json"},
+		{Path: "subdir-one/subdir-two/subdir-two-meta.json"},
+		{Path: "subdir-one/subdir-two/subdir-three/subdir-three-meta.json"},
+	}
+	for _, expectedModelPart := range expectedModelParts {
+		assert.Contains(t, kitfile.Model.Parts, expectedModelPart)
 	}
 }

--- a/pkg/lib/kitfile/generate/skill.go
+++ b/pkg/lib/kitfile/generate/skill.go
@@ -49,7 +49,7 @@ func dirContainsSkillMD(dir DirectoryListing) (bool, string) {
 
 func buildPromptFromSkill(dir DirectoryListing) (artifact.Prompt, *skill.SkillFrontmatter) {
 	prompt := artifact.Prompt{
-		Path: dir.Path,
+		Path: withTrailingSlash(dir.Path),
 	}
 
 	found, skillPath := dirContainsSkillMD(dir)

--- a/pkg/lib/kitfile/generate/skill.go
+++ b/pkg/lib/kitfile/generate/skill.go
@@ -49,7 +49,7 @@ func dirContainsSkillMD(dir DirectoryListing) (bool, string) {
 
 func buildPromptFromSkill(dir DirectoryListing) (artifact.Prompt, *skill.SkillFrontmatter) {
 	prompt := artifact.Prompt{
-		Path: withTrailingSlash(dir.Path),
+		Path: unixWithTrailingSlash(dir.Path),
 	}
 
 	found, skillPath := dirContainsSkillMD(dir)

--- a/pkg/lib/kitfile/generate/skill_test.go
+++ b/pkg/lib/kitfile/generate/skill_test.go
@@ -184,8 +184,8 @@ func TestBuildPromptFromSkill(t *testing.T) {
 	}
 
 	prompt, _ := buildPromptFromSkill(dir)
-	if prompt.Path != "myskill" {
-		t.Errorf("Path = %q, want %q", prompt.Path, "myskill")
+	if prompt.Path != "myskill/" {
+		t.Errorf("Path = %q, want %q", prompt.Path, "myskill/")
 	}
 	if prompt.Name != "test-skill" {
 		t.Errorf("Name = %q, want %q", prompt.Name, "test-skill")
@@ -214,7 +214,7 @@ func TestGenerateKitfile_RootSkillMD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kitfile, err := GenerateKitfile(dir, nil)
+	kitfile, err := GenerateKitfile(dir, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestGenerateKitfile_SubdirSkillMD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kitfile, err := GenerateKitfile(dir, nil)
+	kitfile, err := GenerateKitfile(dir, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,8 +268,8 @@ func TestGenerateKitfile_SubdirSkillMD(t *testing.T) {
 	if len(kitfile.Prompts) != 1 {
 		t.Fatalf("expected 1 prompt, got %d", len(kitfile.Prompts))
 	}
-	if kitfile.Prompts[0].Path != "pdf-tools" {
-		t.Errorf("prompt path = %q, want %q", kitfile.Prompts[0].Path, "pdf-tools")
+	if kitfile.Prompts[0].Path != "pdf-tools/" {
+		t.Errorf("prompt path = %q, want %q", kitfile.Prompts[0].Path, "pdf-tools/")
 	}
 	if kitfile.Prompts[0].Name != "pdf-tools" {
 		t.Errorf("prompt name = %q, want %q", kitfile.Prompts[0].Name, "pdf-tools")
@@ -299,7 +299,7 @@ func TestGenerateKitfile_UserOverridesFrontmatter(t *testing.T) {
 		Name:        "user-name",
 		Description: "user desc",
 	}
-	kitfile, err := GenerateKitfile(dir, userPkg)
+	kitfile, err := GenerateKitfile(dir, userPkg, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -342,7 +342,7 @@ func TestGenerateKitfile_MultiSkill(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kitfile, err := GenerateKitfile(dir, nil)
+	kitfile, err := GenerateKitfile(dir, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func TestGenerateKitfile_MultiSkillMixedDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kitfile, err := GenerateKitfile(dir, nil)
+	kitfile, err := GenerateKitfile(dir, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -429,7 +429,7 @@ func TestGenerateKitfile_RootSkillOverridesSubdir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kitfile, err := GenerateKitfile(dir, nil)
+	kitfile, err := GenerateKitfile(dir, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testing/testdata/kitfile-generation/test_directory-handling.yaml
+++ b/testing/testdata/kitfile-generation/test_directory-handling.yaml
@@ -44,6 +44,6 @@ expectedKitfile:
   code:
     - path: build/
     - path: lib/
+    - path: mixed-contents/
     - path: pkg/
     - path: src/
-    - path: mixed-contents/

--- a/testing/testdata/kitfile-generation/test_directory-handling.yaml
+++ b/testing/testdata/kitfile-generation/test_directory-handling.yaml
@@ -37,13 +37,13 @@ expectedKitfile:
       - path: model-contents/my-model2.gguf
       - path: model-contents/z-metadata.json
   datasets:
-    - path: dataset-contents
+    - path: dataset-contents/
   docs:
-    - path: docs
-    - path: my-files
+    - path: docs/
+    - path: my-files/
   code:
-    - path: build
-    - path: lib
-    - path: pkg
-    - path: src
-    - path: mixed-contents
+    - path: build/
+    - path: lib/
+    - path: pkg/
+    - path: src/
+    - path: mixed-contents/

--- a/testing/testdata/kitfile-generation/test_prompt-handling.yaml
+++ b/testing/testdata/kitfile-generation/test_prompt-handling.yaml
@@ -32,11 +32,11 @@ expectedKitfile:
     - path: my.prompt.md
     - path: suffix.prompt
     - path: test.prompt.pdf
-    - path: prompts-dir
+    - path: prompts-dir/
   docs:
     - path: README.md
       description: Readme file
     - path: notes.md
     - path: prompt.md
   code:
-    - path: mixed-prompts
+    - path: mixed-prompts/

--- a/testing/testdata/kitfile-generation/test_type-detect.yaml
+++ b/testing/testdata/kitfile-generation/test_type-detect.yaml
@@ -17,6 +17,10 @@ files:
   # Generic code files that should be caught in a catch-all section
   - test.sh
   - bootstrap.sh
+  - main.sh
+  - common.sh
+  - utility.sh
+  - shared.sh
 
 modelName: test-model-detect
 expectedKitfile:


### PR DESCRIPTION
### Description
Add a `--depth` flag for Kitfile generation (`kit init` and `kit import`) that can be used to control how far down a directory tree we traverse before starting to add less fine-grained directory entries. For `--depth=0` (the default), behaviour is the same as in the current main branch: all files in the context directory are classified and added to the Kitfile, and any subdirectories are added on a best-effort basis (if we can tell they're all one type, we use that type; otherwise we add a code layer for the directory).

Increasing the depth parameter means files in individual subdirectories are also classified in the same way, so `--depth=1` includes files in immediate subdirectories, `--depth=2` goes one directory further, etc. Depth can be set to `-1` to process all files individually. 

This flag can lead to much larger Kitfiles if a lot of individual files are added. However, this behaviour may be desirable in some cases, such as when a directory contains a large number of moderate or large files -- adding them as separate entries means they each appear in their own layer, and prevents the entire directory layer from being invalidated if a single file in the directory is updated.

Additionally, this PR makes one small change to how Kitfiles are generated: when directories are added to the Kitfile, we add a trailing slash to make it clearer that the layer represents a directory versus a regular file.

### Linked issues
N/A

### AI-Assisted Code
<!-- Check all that apply -->
- [x] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
