### PR TITLE
docs: remove stray AGENT_MODIFIED markers

### DIFF
--- a/docs/src/docs/index.md
+++ b/docs/src/docs/index.md
@@ -12,5 +12,3 @@ if (typeof window !== 'undefined') {
   window.location.replace('/docs/overview/')
 }
 </script>
-
-<!-- AGENT_MODIFIED: Human review required before merge -->

--- a/docs/src/docs/next-steps.md
+++ b/docs/src/docs/next-steps.md
@@ -398,5 +398,3 @@ You can learn more about all the Kit CLI commands from our [command reference do
 To learn about how to run an LLM locally using Kit, see our [Kit Dev](../deploy/#running-llms-locally) documentation.
 
 Thanks for taking some time to play with Kit. We'd love to hear what you think. Feel free to drop us an [issue in our GitHub repository](https://github.com/kitops-ml/kitops/issues) or join [our Discord server](https://discord.gg/Tapeh8agYy).
-
-<!-- AGENT_MODIFIED: Human review required before merge -->

--- a/docs/src/docs/use-cases.md
+++ b/docs/src/docs/use-cases.md
@@ -129,4 +129,3 @@ For teams running self-hosted models inside agentic systems, KitOps can package 
 **Have feedback or questions?**
 Open an [issue on GitHub](https://github.com/kitops-ml/kitops/issues) or [join us on Discord](https://discord.gg/Tapeh8agYy).
 
-<!-- AGENT_MODIFIED: Human review required before merge -->


### PR DESCRIPTION
### Description
Removes leftover `<!-- AGENT_MODIFIED: Human review required before merge -->` markers from three docs pages that had them appended by mistake. Pure docs cleanup — no content changes.

Files:
- `docs/src/docs/index.md`
- `docs/src/docs/next-steps.md`
- `docs/src/docs/use-cases.md`

### Linked issues
n/a

### Validation
- Confirmed no remaining `AGENT_MODIFIED` markers in `docs/` via grep.
- Attempted `pnpm docs:build` locally; the build failed due to a missing `vite-svg-loader` in my local `node_modules` (unrelated to this change). CI will build from a clean install.

### AI-Assisted Code
- [x] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created