### PR TITLE
Support remote datasets using a ModelKit reference instead of S3 URL

### DIFF
--- a/pkg/artifact/kitfile.go
+++ b/pkg/artifact/kitfile.go
@@ -194,6 +194,10 @@ func (kf *KitFile) Validate() (warnings []string, err error) {
 		paths[path] = append(paths[path], source)
 	}
 
+	// List of paths used by datasets that include remote ModelKit references; to avoid confusion, no other
+	// layer can include files within a remote dataset's path
+	var remoteDatasetPaths []string
+
 	if kf.Model != nil {
 		addPath(kf.Model.Path, fmt.Sprintf("model %s", kf.Model.Name))
 		modelPathType, err := GetPathType(kf.Model.Path)
@@ -252,8 +256,11 @@ func (kf *KitFile) Validate() (warnings []string, err error) {
 					addErr("remoteHash is required when remote dataset paths are used (%s)", dataset.RemotePath)
 				}
 			case ModelReferencePathType:
-				// ModelKit references carry their own integrity (digest/tag in the OCI reference);
-				// any remoteHash field is ignored.
+				// ModelKit references carry their own integrity (digest/tag in the OCI reference)
+				if dataset.RemoteHash != "" {
+					warnings = append(warnings, fmt.Sprintf("remoteHash is ignored for ModelKit references in datasets (%s)", dataset.Path))
+				}
+				remoteDatasetPaths = append(remoteDatasetPaths, filepath.Clean(dataset.Path))
 			default:
 				addErr("only S3 URLs and ModelKit references are supported for remote dataset paths (%s)", dataset.RemotePath)
 			}
@@ -289,6 +296,21 @@ func (kf *KitFile) Validate() (warnings []string, err error) {
 		}
 		if path.IsAbs(layerPath) || filepath.IsAbs(layerPath) {
 			addErr("absolute paths are not supported in a Kitfile (path %s in %s)", layerPath, layerIds[0])
+		}
+		for _, remoteDatasetPath := range remoteDatasetPaths {
+			if remoteDatasetPath == layerPath {
+				// Skip the remote dataset layer's own path when checking whether other layers are nested within it.
+				// Duplicate-path validation is handled above.
+				continue
+			}
+			relPath, err := filepath.Rel(remoteDatasetPath, layerPath)
+			if err != nil {
+				addErr("error calculating relative path for remote dataset: %s", err)
+				continue
+			}
+			if relPath != ".." && !strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+				addErr("%s uses a path (%s) that is within the path for a remote dataset", layerIds[0], layerPath)
+			}
 		}
 	}
 

--- a/pkg/artifact/kitfile.go
+++ b/pkg/artifact/kitfile.go
@@ -246,11 +246,16 @@ func (kf *KitFile) Validate() (warnings []string, err error) {
 			if err != nil {
 				addErr("invalid remote path for dataset (%s): %s", dataset.RemotePath, err)
 			}
-			if remotePathType != S3PathType {
-				addErr("only S3 URLs are supported for remote dataset paths (%s)", dataset.RemotePath)
-			}
-			if dataset.RemoteHash == "" {
-				addErr("remoteHash is required when remote dataset paths are used (%s)", dataset.RemotePath)
+			switch remotePathType {
+			case S3PathType:
+				if dataset.RemoteHash == "" {
+					addErr("remoteHash is required when remote dataset paths are used (%s)", dataset.RemotePath)
+				}
+			case ModelReferencePathType:
+				// ModelKit references carry their own integrity (digest/tag in the OCI reference);
+				// any remoteHash field is ignored.
+			default:
+				addErr("only S3 URLs and ModelKit references are supported for remote dataset paths (%s)", dataset.RemotePath)
 			}
 		} else {
 			if dataset.RemoteHash != "" {

--- a/pkg/artifact/testdata/validation/remote-dataset-collides-with-code.yaml
+++ b/pkg/artifact/testdata/validation/remote-dataset-collides-with-code.yaml
@@ -1,0 +1,8 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  datasets:
+    - path: data/train
+      remotePath: docker.io/kit-org/kit-repo:latest
+  code:
+    - path: data/train/code
+errRegexp: "uses a path \\(data[\\\\/]train[\\\\/]code\\) that is within the path for a remote dataset"

--- a/pkg/artifact/testdata/validation/remote-dataset-collides-with-model.yaml
+++ b/pkg/artifact/testdata/validation/remote-dataset-collides-with-model.yaml
@@ -1,0 +1,8 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  model:
+    path: data/train/model.bin
+  datasets:
+    - path: data/train
+      remotePath: docker.io/kit-org/kit-repo:latest
+errRegexp: "uses a path \\(data[\\\\/]train[\\\\/]model.bin\\) that is within the path for a remote dataset"

--- a/pkg/artifact/testdata/validation/remote-dataset-collides-with-nested-dataset.yaml
+++ b/pkg/artifact/testdata/validation/remote-dataset-collides-with-nested-dataset.yaml
@@ -1,0 +1,7 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  datasets:
+    - path: data/train
+      remotePath: docker.io/kit-org/kit-repo:latest
+    - path: data/train/extra
+errRegexp: "uses a path \\(data[\\\\/]train[\\\\/]extra\\) that is within the path for a remote dataset"

--- a/pkg/artifact/testdata/validation/remote-dataset-modelkit-ref.yaml
+++ b/pkg/artifact/testdata/validation/remote-dataset-modelkit-ref.yaml
@@ -1,0 +1,6 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  datasets:
+    - path: data/train
+      remotePath: docker.io/kit-org/kit-repo:latest
+errRegexp: ""

--- a/pkg/artifact/testdata/validation/remote-dataset-must-use-s3.yaml
+++ b/pkg/artifact/testdata/validation/remote-dataset-must-use-s3.yaml
@@ -4,4 +4,4 @@ kitfile: |
     - path: some/local/path
       remotePath: mybucket.s3.us-east-2.amazonaws.com
       remoteHash: testhash
-errRegexp: "only S3 URLs are supported for remote dataset paths"
+errRegexp: "only S3 URLs and ModelKit references are supported for remote dataset paths"

--- a/pkg/artifact/testdata/validation/remote-dataset-sibling-paths-allowed.yaml
+++ b/pkg/artifact/testdata/validation/remote-dataset-sibling-paths-allowed.yaml
@@ -1,0 +1,12 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  model:
+    path: models/main.bin
+  datasets:
+    - path: data/train
+      remotePath: docker.io/kit-org/kit-repo:latest
+    - path: data/train-eval
+    - path: data/eval
+  code:
+    - path: code
+errRegexp: ""

--- a/pkg/artifact/util.go
+++ b/pkg/artifact/util.go
@@ -21,7 +21,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/kitops-ml/kitops/pkg/lib/constants/mediatype"
+	modelspecv1 "github.com/modelpack/model-spec/specs-go/v1"
 	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -170,4 +173,41 @@ func FormatRepositoryForDisplay(repo string) string {
 	// Trim @ in case what's left is a bare digest
 	repo = strings.TrimPrefix(repo, "@")
 	return repo
+}
+
+// GenerateKitfileForModelPack generates a Kitfile for a manifest that otherwise does not contain one.
+// This is a minimal Kitfile suitable only for unpacking, containing a path for every layer. If a layer
+// does not use the 'org.cncf.model.filepath' annotation, an error is returned.
+func GenerateKitfileForModelPack(manifest *ocispec.Manifest) (*KitFile, error) {
+	if format, err := mediatype.ModelFormatForManifest(manifest); err != nil || format != mediatype.ModelPackFormat {
+		return nil, fmt.Errorf("not a modelpack artifact")
+	}
+	kf := &KitFile{
+		Model: &Model{},
+	}
+	for _, desc := range manifest.Layers {
+		if desc.Annotations == nil || desc.Annotations[modelspecv1.AnnotationFilepath] == "" {
+			return nil, fmt.Errorf("unknown file path for layer: no %s annotation", modelspecv1.AnnotationFilepath)
+		}
+		filepath := desc.Annotations[modelspecv1.AnnotationFilepath]
+		mt, err := mediatype.ParseMediaType(desc.MediaType)
+		if err != nil {
+			return nil, err
+		}
+		switch mt.Base() {
+		case mediatype.ModelBaseType:
+			kf.Model.Path = filepath
+		case mediatype.ModelPartBaseType:
+			kf.Model.Parts = append(kf.Model.Parts, ModelPart{Path: filepath})
+		case mediatype.CodeBaseType:
+			kf.Code = append(kf.Code, Code{Path: filepath})
+		case mediatype.DatasetBaseType:
+			kf.DataSets = append(kf.DataSets, DataSet{Path: filepath})
+		case mediatype.DocsBaseType:
+			kf.Docs = append(kf.Docs, Docs{Path: filepath})
+		default:
+			return nil, fmt.Errorf("unknown layer type: %s", mt)
+		}
+	}
+	return kf, nil
 }

--- a/pkg/cmd/pull/pull.go
+++ b/pkg/cmd/pull/pull.go
@@ -78,18 +78,30 @@ func pullParents(ctx context.Context, localRepo local.LocalRepo, desc ocispec.De
 		}
 		return err
 	}
-	if config.Model == nil || !artifact.IsModelKitReference(config.Model.Path) {
-		return nil
+
+	var parentRefs []string
+	if config.Model != nil && artifact.IsModelKitReference(config.Model.Path) {
+		parentRefs = append(parentRefs, config.Model.Path)
 	}
-	output.Infof("Pulling referenced image %s", config.Model.Path)
-	parentRef, _, err := artifact.ParseReference(config.Model.Path)
-	if err != nil {
-		return err
+	for _, dataset := range config.DataSets {
+		if artifact.IsModelKitReference(dataset.RemotePath) {
+			parentRefs = append(parentRefs, dataset.RemotePath)
+		}
 	}
-	opts := *optsIn
-	opts.modelRef = parentRef
-	_, err = runPullRecursive(ctx, localRepo, &opts, pulledRefs)
-	return err
+
+	for _, refStr := range parentRefs {
+		parentRef, _, err := artifact.ParseReference(refStr)
+		if err != nil {
+			return err
+		}
+		output.Infof("Pulling referenced image %s", refStr)
+		opts := *optsIn
+		opts.modelRef = parentRef
+		if _, err := runPullRecursive(ctx, localRepo, &opts, pulledRefs); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func pullModel(ctx context.Context, localRepo local.LocalRepo, opts *pullOptions) (ocispec.Descriptor, error) {

--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -173,6 +173,9 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	for idx, dataset := range kitfile.DataSets {
 		// First check if dataset is stored remotely
 		if dataset.RemotePath != "" {
+			if artifact.IsModelKitReference(dataset.RemotePath) {
+				continue
+			}
 			ref, err := s3api.ParseS3ObjectReference(dataset.RemotePath, dataset.RemoteHash)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to parse S3 object reference for dataset %s: %w", dataset.Path, err)

--- a/pkg/lib/filesystem/unpack/core.go
+++ b/pkg/lib/filesystem/unpack/core.go
@@ -38,9 +38,9 @@ import (
 	"github.com/kitops-ml/kitops/pkg/lib/skill"
 	"github.com/kitops-ml/kitops/pkg/output"
 
-	modelspecv1 "github.com/modelpack/model-spec/specs-go/v1"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry"
 )
 
 // UnpackModelKit performs the core unpacking logic for a ModelKit.
@@ -96,6 +96,10 @@ func unpackRecursive(ctx context.Context, opts *UnpackOptions, visitedRefs []str
 		return fmt.Errorf("failed to read manifest: %s", err)
 	}
 	config, err := util.GetKitfileForManifest(ctx, store, manifest)
+
+	// A flag to determine whether we should print a warning about remote datasets when opts.IncludeRemote is false
+	containsRemoteDatasets := false
+
 	if err != nil {
 		if !errors.Is(err, util.ErrNoKitfile) {
 			return err
@@ -103,7 +107,7 @@ func unpackRecursive(ctx context.Context, opts *UnpackOptions, visitedRefs []str
 		output.Logf(output.LogLevelWarn, "Could not get Kitfile: %s", err)
 		output.Logf(output.LogLevelWarn, "Functionality may be impacted")
 		// TODO: we can probably _also_ handle getting the model-spec config and using it here
-		genconfig, err := generateKitfileForModelPack(manifest)
+		genconfig, err := artifact.GenerateKitfileForModelPack(manifest)
 		if err != nil {
 			return fmt.Errorf("could not process manifest: %w", err)
 		}
@@ -111,10 +115,36 @@ func unpackRecursive(ctx context.Context, opts *UnpackOptions, visitedRefs []str
 	} else {
 		// These steps only make sense if we have a legitimate Kitfile available
 		if config.Model != nil && artifact.IsModelKitReference(config.Model.Path) {
-			output.Infof("Unpacking referenced modelkit %s", config.Model.Path)
-			if err := unpackParent(ctx, config.Model.Path, opts, visitedRefs); err != nil {
+			modelRef, _, err := artifact.ParseReference(config.Model.Path)
+			if err != nil {
+				return fmt.Errorf("failed to parse remote model reference %s: %w", config.Model.Path, err)
+			}
+			output.Infof("Unpacking referenced ModelKit %s", config.Model.Path)
+			if err := unpackRemote(ctx, modelRef, "", kitfile.BaseTypeModel, opts, visitedRefs); err != nil {
 				return err
 			}
+		}
+		for _, dataset := range config.DataSets {
+			if !artifact.IsModelKitReference(dataset.RemotePath) {
+				continue
+			}
+			if !kitfile.LayerMatchesAnyFilter(dataset, opts.FilterConfs) {
+				continue
+			}
+			// The docstring for the "include remote" option states that it is for remote datasets. This was originally
+			// for S3 remote datasets only but it applies to remote datasets referenced by a ModelKit reference too.
+			if opts.IncludeRemote {
+				datasetRef, _, err := artifact.ParseReference(dataset.RemotePath)
+				if err != nil {
+					return fmt.Errorf("failed to parse remote dataset reference %s: %w", dataset.RemotePath, err)
+				}
+				output.Infof("Unpacking referenced dataset ModelKit %s to %s", dataset.RemotePath, dataset.Path)
+
+				if err := unpackRemote(ctx, datasetRef, dataset.Path, kitfile.BaseTypeDatasets, opts, visitedRefs); err != nil {
+					return err
+				}
+			}
+			containsRemoteDatasets = true
 		}
 		if kitfile.LayerMatchesAnyFilter(config, opts.FilterConfs) {
 			if err := unpackConfig(config, opts.UnpackDir, opts.Overwrite); err != nil {
@@ -245,49 +275,51 @@ func unpackRecursive(ctx context.Context, opts *UnpackOptions, visitedRefs []str
 		if dataset.RemotePath == "" || !kitfile.LayerMatchesAnyFilter(dataset, opts.FilterConfs) {
 			continue
 		}
+		// ModelKit references are handled separately (via unpackRemote rooted at dataset.Path).
+		if artifact.IsModelKitReference(dataset.RemotePath) {
+			continue
+		}
 		ref, err := s3api.ParseS3ObjectReference(dataset.RemotePath, dataset.RemoteHash)
 		if err != nil {
 			return fmt.Errorf("failed to parse S3 object reference for dataset %s: %w", dataset.Path, err)
 		}
 		remoteFiles[dataset.Path] = *ref
+		containsRemoteDatasets = true
 	}
-	if len(remoteFiles) > 0 {
-		if !opts.IncludeRemote {
-			output.Logf(output.LogLevelWarn, "ModelKit contains remote datasets. To unpack, specify the --include-remote flag")
-		} else {
-			client, err := s3api.SetUpClient(ctx)
+
+	if len(remoteFiles) > 0 && opts.IncludeRemote {
+		client, err := s3api.SetUpClient(ctx)
+		if err != nil {
+			return err
+		}
+		for path, s3Ref := range remoteFiles {
+			_, relPath, err := filesystem.VerifySubpath(opts.UnpackDir, path)
 			if err != nil {
-				return err
+				return fmt.Errorf("error verifying path %s for remote reference: %w", path, err)
 			}
-			for path, s3Ref := range remoteFiles {
-				_, relPath, err := filesystem.VerifySubpath(opts.UnpackDir, path)
-				if err != nil {
-					return fmt.Errorf("error verifying path %s for remote reference: %w", path, err)
-				}
 
-				output.Debugf("Downloading remote dataset: Bucket: %s, Key: %s", s3Ref.Bucket, s3Ref.Key)
-				if fi, exists := filesystem.PathExists(relPath); exists {
-					if opts.IgnoreExisting {
-						output.Debugf("File %s already exists; skipping", path)
-						continue
-					}
-					if !opts.Overwrite {
-						return fmt.Errorf("failed to unpack remote dataset: path '%s' already exists", path)
-					}
-					if !fi.Mode().IsRegular() {
-						return fmt.Errorf("failed to unpack remote dataset: path '%s' already exists and is not a regular file", path)
-					}
+			output.Debugf("Downloading remote dataset: Bucket: %s, Key: %s", s3Ref.Bucket, s3Ref.Key)
+			if fi, exists := filesystem.PathExists(relPath); exists {
+				if opts.IgnoreExisting {
+					output.Debugf("File %s already exists; skipping", path)
+					continue
 				}
-
-				pathDir := filepath.Dir(relPath)
-				if err := os.MkdirAll(pathDir, 0755); err != nil {
-					return fmt.Errorf("failed to create directory %s: %w", pathDir, err)
+				if !opts.Overwrite {
+					return fmt.Errorf("failed to unpack remote dataset: path '%s' already exists", path)
 				}
-				if err := s3api.DownloadObject(ctx, client, &s3Ref, relPath); err != nil {
-					return fmt.Errorf("failed to download remote dataset for path %s: %w", path, err)
+				if !fi.Mode().IsRegular() {
+					return fmt.Errorf("failed to unpack remote dataset: path '%s' already exists and is not a regular file", path)
 				}
-				output.Infof("Downloaded remote S3 dataset for path %s", path)
 			}
+
+			pathDir := filepath.Dir(relPath)
+			if err := os.MkdirAll(pathDir, 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", pathDir, err)
+			}
+			if err := s3api.DownloadObject(ctx, client, &s3Ref, relPath); err != nil {
+				return fmt.Errorf("failed to download remote dataset for path %s: %w", path, err)
+			}
+			output.Infof("Downloaded remote S3 dataset for path %s", path)
 		}
 	}
 
@@ -296,6 +328,10 @@ func unpackRecursive(ctx context.Context, opts *UnpackOptions, visitedRefs []str
 	output.Debugf("Unpacked %d dataset layers", datasetIdx)
 	output.Debugf("Unpacked %d docs layers", docsIdx)
 	output.Debugf("Unpacked %d prompt layers", promptIdx)
+
+	if containsRemoteDatasets && !opts.IncludeRemote {
+		output.Logf(output.LogLevelWarn, "ModelKit contains remote datasets. To unpack, specify the --include-remote flag")
+	}
 
 	return nil
 }
@@ -386,44 +422,66 @@ func unpackSkill(ctx context.Context, opts *UnpackOptions) error {
 	return nil
 }
 
-func unpackParent(ctx context.Context, ref string, optsIn *UnpackOptions, visitedRefs []string) error {
-	if idx := getIndex(visitedRefs, ref); idx != -1 {
+// unpackRemote recursively unpacks the contents of a referenced ModelKit, restricted to a
+// single base type (e.g. "model" or "datasets"). If basePath is non-empty, the remote ModelKit
+// is unpacked into that subdirectory of the current unpack dir so the referenced ModelKit's
+// layer paths land beneath it
+func unpackRemote(ctx context.Context, ref *registry.Reference, basePath string, baseType kitfile.BaseType, optsIn *UnpackOptions, visitedRefs []string) error {
+	if idx := getIndex(visitedRefs, ref.String()); idx != -1 {
 		cycleStr := fmt.Sprintf("[%s=>%s]", strings.Join(visitedRefs[idx:], "=>"), ref)
 		return fmt.Errorf("found cycle in modelkit references: %s", cycleStr)
 	}
 
-	parentRef, _, err := artifact.ParseReference(ref)
-	if err != nil {
-		return err
-	}
 	opts := *optsIn
-	opts.ModelRef = parentRef
-	// Unpack only model, ignore code/datasets
+	opts.ModelRef = ref
+	// Restrict unpack to the requested base type from the referenced ModelKit.
 	if len(opts.FilterConfs) == 0 {
-		modelFilter, err := kitfile.ParseFilter("model")
-		if err != nil {
-			// Shouldn't happen, ever
-			return fmt.Errorf("failed to parse filter for parent modelkit: %w", err)
+		filter := kitfile.FilterConf{
+			BaseTypes: []kitfile.BaseType{baseType},
 		}
-		opts.FilterConfs = []kitfile.FilterConf{*modelFilter}
+		opts.FilterConfs = []kitfile.FilterConf{filter}
 	} else {
 		var filterConfs []kitfile.FilterConf
 		for _, conf := range opts.FilterConfs {
-			if conf.MatchesBaseType("model") {
+			if conf.MatchesBaseType(baseType) {
 				// Drop any other base types from this filter
-				conf.BaseTypes = []string{"model"}
+				conf.BaseTypes = []kitfile.BaseType{baseType}
 				filterConfs = append(filterConfs, conf)
 			}
 		}
 		// If we've filtered out all confs, we don't want anything from the parent ModelKit.
 		// We have to return here, as no filters is interpreted as "unpack everything"
 		if len(filterConfs) == 0 {
+			output.Debugf("Skipping unpack of referenced ModelKit %s due to provided filters", ref)
 			return nil
 		}
 		opts.FilterConfs = filterConfs
 	}
 
-	return unpackRecursive(ctx, &opts, append(visitedRefs, ref))
+	if basePath != "" {
+		targetDir, _, err := filesystem.VerifySubpath(opts.UnpackDir, basePath)
+		if err != nil {
+			return fmt.Errorf("error resolving dataset path %s: %w", basePath, err)
+		}
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", targetDir, err)
+		}
+		originalWd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current working directory: %w", err)
+		}
+		if err := os.Chdir(targetDir); err != nil {
+			return fmt.Errorf("failed to change working directory to %s: %w", targetDir, err)
+		}
+		defer func() {
+			if err := os.Chdir(originalWd); err != nil {
+				output.Logf(output.LogLevelWarn, "Failed to restore working directory after unpacking reference ModelKit: %v", err)
+			}
+		}()
+		opts.UnpackDir = targetDir
+	}
+
+	return unpackRecursive(ctx, &opts, append(visitedRefs, ref.String()))
 }
 
 func unpackConfig(config *artifact.KitFile, unpackDir string, overwrite bool) error {
@@ -621,41 +679,4 @@ func getIndex(list []string, s string) int {
 		}
 	}
 	return -1
-}
-
-// generateKitfileForModelPack generates a "Kitfile" for a manifest that otherwise does not contain one.
-// This is a minimal Kitfile suitable only for unpacking, containing a path for every layer. If a layer
-// does not use the 'org.cncf.model.filepath' annotation, an error is returned.
-func generateKitfileForModelPack(manifest *ocispec.Manifest) (*artifact.KitFile, error) {
-	if format, err := mediatype.ModelFormatForManifest(manifest); err != nil || format != mediatype.ModelPackFormat {
-		return nil, fmt.Errorf("not a modelpack artifact")
-	}
-	kf := &artifact.KitFile{
-		Model: &artifact.Model{},
-	}
-	for _, desc := range manifest.Layers {
-		if desc.Annotations == nil || desc.Annotations[modelspecv1.AnnotationFilepath] == "" {
-			return nil, fmt.Errorf("unknown file path for layer: no %s annotation", modelspecv1.AnnotationFilepath)
-		}
-		filepath := desc.Annotations[modelspecv1.AnnotationFilepath]
-		mt, err := mediatype.ParseMediaType(desc.MediaType)
-		if err != nil {
-			return nil, err
-		}
-		switch mt.Base() {
-		case mediatype.ModelBaseType:
-			kf.Model.Path = filepath
-		case mediatype.ModelPartBaseType:
-			kf.Model.Parts = append(kf.Model.Parts, artifact.ModelPart{Path: filepath})
-		case mediatype.CodeBaseType:
-			kf.Code = append(kf.Code, artifact.Code{Path: filepath})
-		case mediatype.DatasetBaseType:
-			kf.DataSets = append(kf.DataSets, artifact.DataSet{Path: filepath})
-		case mediatype.DocsBaseType:
-			kf.Docs = append(kf.Docs, artifact.Docs{Path: filepath})
-		default:
-			return nil, fmt.Errorf("unknown layer type: %s", mt)
-		}
-	}
-	return kf, nil
 }

--- a/pkg/lib/kitfile/filter.go
+++ b/pkg/lib/kitfile/filter.go
@@ -25,18 +25,31 @@ import (
 	"github.com/kitops-ml/kitops/pkg/artifact"
 )
 
+// BaseType identifies one of the well-known Kitfile layer categories that
+// filters may target. Values are restricted to the constants declared below.
+type BaseType string
+
+const (
+	BaseTypeKitfile  BaseType = "kitfile"
+	BaseTypeModel    BaseType = "model"
+	BaseTypeDatasets BaseType = "datasets"
+	BaseTypeCode     BaseType = "code"
+	BaseTypePrompts  BaseType = "prompts"
+	BaseTypeDocs     BaseType = "docs"
+)
+
 var validFilterTypes = []string{"kitfile", "model", "datasets", "code", "prompts", "docs"}
 
 type FilterConf struct {
-	BaseTypes []string
+	BaseTypes []BaseType
 	Filters   []string
 }
 
-func (fc *FilterConf) Matches(baseType, field string) bool {
+func (fc *FilterConf) Matches(baseType BaseType, field string) bool {
 	return fc.MatchesBaseType(baseType) && fc.MatchesField(field)
 }
 
-func (fc *FilterConf) MatchesBaseType(baseType string) bool {
+func (fc *FilterConf) MatchesBaseType(baseType BaseType) bool {
 	return slices.Contains(fc.BaseTypes, baseType)
 }
 
@@ -61,7 +74,7 @@ func ParseFilter(filter string) (*FilterConf, error) {
 		if !slices.Contains(validFilterTypes, filterType) {
 			return nil, fmt.Errorf("invalid filter type %s (must be one of %s)", filterType, strings.Join(validFilterTypes, ", "))
 		}
-		conf.BaseTypes = append(conf.BaseTypes, filterType)
+		conf.BaseTypes = append(conf.BaseTypes, BaseType(filterType))
 	}
 
 	// Check for additional filtering based on name/path
@@ -89,31 +102,31 @@ func LayerMatchesAnyFilter(layer any, filters []FilterConf) bool {
 	switch l := layer.(type) {
 	case artifact.KitFile:
 		for _, filter := range filters {
-			if filter.MatchesBaseType("kitfile") {
+			if filter.MatchesBaseType(BaseTypeKitfile) {
 				return true
 			}
 		}
 		return false
 	case artifact.Model:
-		return matchesFilters("model", l.Name, filters) || matchesFilters("model", l.Path, filters)
+		return matchesFilters(BaseTypeModel, l.Name, filters) || matchesFilters(BaseTypeModel, l.Path, filters)
 	case artifact.ModelPart:
-		return matchesFilters("model", l.Name, filters) || matchesFilters("model", l.Path, filters)
+		return matchesFilters(BaseTypeModel, l.Name, filters) || matchesFilters(BaseTypeModel, l.Path, filters)
 	case artifact.Docs:
 		// Docs does not have an ID/name field so we can only match on path
-		return matchesFilters("docs", l.Path, filters)
+		return matchesFilters(BaseTypeDocs, l.Path, filters)
 	case artifact.DataSet:
-		return matchesFilters("datasets", l.Name, filters) || matchesFilters("datasets", l.Path, filters)
+		return matchesFilters(BaseTypeDatasets, l.Name, filters) || matchesFilters(BaseTypeDatasets, l.Path, filters)
 	case artifact.Code:
 		// Code does not have a ID/name field so we can only match on path
-		return matchesFilters("code", l.Path, filters)
+		return matchesFilters(BaseTypeCode, l.Path, filters)
 	case artifact.Prompt:
-		return matchesFilters("prompts", l.Name, filters) || matchesFilters("prompts", l.Path, filters)
+		return matchesFilters(BaseTypePrompts, l.Name, filters) || matchesFilters(BaseTypePrompts, l.Path, filters)
 	default:
 		return false
 	}
 }
 
-func matchesFilters(baseType, field string, filterConfs []FilterConf) bool {
+func matchesFilters(baseType BaseType, field string, filterConfs []FilterConf) bool {
 	for _, filterConf := range filterConfs {
 		if filterConf.Matches(baseType, field) {
 			return true
@@ -180,19 +193,19 @@ func FiltersFromUnpackConf(unpackKitfile, unpackModels, unpackCode, unpackDatase
 	filter := FilterConf{}
 
 	if unpackKitfile {
-		filter.BaseTypes = append(filter.BaseTypes, "kitfile")
+		filter.BaseTypes = append(filter.BaseTypes, BaseTypeKitfile)
 	}
 	if unpackModels {
-		filter.BaseTypes = append(filter.BaseTypes, "model")
+		filter.BaseTypes = append(filter.BaseTypes, BaseTypeModel)
 	}
 	if unpackDocs {
-		filter.BaseTypes = append(filter.BaseTypes, "docs")
+		filter.BaseTypes = append(filter.BaseTypes, BaseTypeDocs)
 	}
 	if unpackDatasets {
-		filter.BaseTypes = append(filter.BaseTypes, "datasets")
+		filter.BaseTypes = append(filter.BaseTypes, BaseTypeDatasets)
 	}
 	if unpackCode {
-		filter.BaseTypes = append(filter.BaseTypes, "code")
+		filter.BaseTypes = append(filter.BaseTypes, BaseTypeCode)
 	}
 	return []FilterConf{filter}
 }

--- a/pkg/lib/kitfile/filter_test.go
+++ b/pkg/lib/kitfile/filter_test.go
@@ -30,29 +30,29 @@ func TestParseFilter_EdgeCases(t *testing.T) {
 		filter          string
 		expectError     bool
 		errorContains   string
-		expectedTypes   []string
+		expectedTypes   []BaseType
 		expectedFilters []string
 	}{
 		{
 			name:          "simple model filter",
 			filter:        "model",
-			expectedTypes: []string{"model"},
+			expectedTypes: []BaseType{"model"},
 		},
 		{
 			name:            "model with specific filters",
 			filter:          "model:llama-7b,gpt-3",
-			expectedTypes:   []string{"model"},
+			expectedTypes:   []BaseType{"model"},
 			expectedFilters: []string{"llama-7b", "gpt-3"},
 		},
 		{
 			name:          "multiple types",
 			filter:        "model,datasets,code",
-			expectedTypes: []string{"model", "datasets", "code"},
+			expectedTypes: []BaseType{"model", "datasets", "code"},
 		},
 		{
 			name:            "multiple types with filters",
 			filter:          "datasets:training-data,validation",
-			expectedTypes:   []string{"datasets"},
+			expectedTypes:   []BaseType{"datasets"},
 			expectedFilters: []string{"training-data", "validation"},
 		},
 		{
@@ -170,20 +170,20 @@ func TestFiltersFromUnpackConf(t *testing.T) {
 		unpackDatasets    bool
 		unpackDocs        bool
 		expectedTypeCount int
-		expectedTypes     []string
+		expectedTypes     []BaseType
 	}{
 		{
 			name:              "only models",
 			unpackModels:      true,
 			expectedTypeCount: 1,
-			expectedTypes:     []string{"model"},
+			expectedTypes:     []BaseType{"model"},
 		},
 		{
 			name:              "models and datasets",
 			unpackModels:      true,
 			unpackDatasets:    true,
 			expectedTypeCount: 2,
-			expectedTypes:     []string{"model", "datasets"},
+			expectedTypes:     []BaseType{"model", "datasets"},
 		},
 		{
 			name:              "all legacy types (no prompts)",
@@ -193,7 +193,7 @@ func TestFiltersFromUnpackConf(t *testing.T) {
 			unpackDatasets:    true,
 			unpackDocs:        true,
 			expectedTypeCount: 5,
-			expectedTypes:     []string{"kitfile", "model", "code", "datasets", "docs"},
+			expectedTypes:     []BaseType{"kitfile", "model", "code", "datasets", "docs"},
 		},
 		{
 			name:              "none selected",


### PR DESCRIPTION
### Description
Add support for ModelKit references in the `remotePath` field of Kitfile datasets:
```yaml
datasets:
  path: local-path/
  remotePath: registry.io/myorg/datasets:latest
```

If specified in this way, the referenced ModelKit (`registry.io/myorg/datasets:latest`) is included in the ModelKit similarly to how it's handled for remote `model` references, with a few differences:

* During unpacking, the ModelKit is unpacked _into_ the directory specified by the dataset's `path` field, not within the root context of the unpack (files from `registry.io/myorg/datasets:latest` will be within the `local-path/` folder)
* Kit does not attempt to merge path collisions within paths used for remote datasets; while other paths can intersect (e.g. a model with `path: my-model/` and docs with `path: my-model/docs`), no other part of the Kitfile can use paths within the remote dataset's path (i.e. no layer can include a subdirectory of `local-path/`). This is necessary to keep packing/unpacking simple, while still respecting the semantics we have for remote S3 datasets, which include single files. 
* While S3 support requires the `remoteHash` field to be used for integrity, ModelKit references can just be specified with a digest, so the `remoteHash` field is ignored. A warning is printed when processing ModelKits that use remote ModelKit datasets and the `remoteHash` parameter.

Otherwise, behaviour should be the same:

* When pulling, the referenced dataset ModelKit is pulled
* When unpacking, the remote dataset is only unpacked when `--include-remote` is specified
* Only datasets within the remote ModelKit are included (i.e. no model, code, docs, etc.)
* When packing, the paths used for remote datasets are omitted from the ModelKit

Note that currently, unpacking the dataset to `local-path/` behaves similarly to how unpacking a ModelKit works with the `--directory` parameter; Kit uses `os.Chdir` to change the current working directory into the dataset's `path` to ensure relative paths are resolved correctly. I considered updating unpack to not require this step but I believe that should be done as a separate PR. 


### AI-Assisted Code
<!-- Check all that apply -->
- [x] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
