### PR TITLE
Improve auth header handling for push operations

### DIFF
--- a/pkg/lib/repo/remote/repository.go
+++ b/pkg/lib/repo/remote/repository.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -173,9 +174,7 @@ func (r *Repository) uploadBlobMonolithic(ctx context.Context, location *url.URL
 	req.URL.RawQuery = q.Encode()
 
 	// Reuse credentials from POST request that initiated upload
-	if authHeader != "" {
-		req.Header.Set("Authorization", authHeader)
-	}
+	r.copyAuth(req, authHeader)
 
 	output.SafeDebugf("[%s] Uploading blob as one chunk", expected.Digest.Encoded()[0:8])
 	// TODO: Handle warnings from remote
@@ -195,6 +194,7 @@ func (r *Repository) uploadBlobMonolithic(ctx context.Context, location *url.URL
 	blobLocation, err := resp.Location()
 	if err != nil {
 		output.Errorf("Warning: remote registry did not return blob location (layer digest %s)", expected.Digest.Encoded()[0:8])
+		return "", nil
 	}
 
 	return blobLocation.String(), nil
@@ -222,9 +222,7 @@ func (r *Repository) uploadBlobChunked(ctx context.Context, location *url.URL, a
 		req.ContentLength = rangeEnd - rangeStart + 1
 		req.Header.Set("Content-Range", fmt.Sprintf("%d-%d", rangeStart, rangeEnd))
 		req.Header.Set("Content-Type", "application/octet-stream")
-		if authHeader != "" {
-			req.Header.Set("Authorization", authHeader)
-		}
+		r.copyAuth(req, authHeader)
 
 		// Submit the chunk as a PATCH
 		// TODO: Handle 416 response code (range not satisfiable)
@@ -278,10 +276,8 @@ func (r *Repository) uploadBlobChunked(ctx context.Context, location *url.URL, a
 	q := req.URL.Query()
 	q.Set("digest", expected.Digest.String())
 	req.URL.RawQuery = q.Encode()
-	// Reuse credentials from POST request that initiated upload
-	if authHeader != "" {
-		req.Header.Set("Authorization", authHeader)
-	}
+	// Reuse credentials from POST request that initiated upload if same origin
+	r.copyAuth(req, authHeader)
 
 	output.SafeDebugf("[%s] Finalizing upload", expected.Digest.Encoded()[0:8])
 	resp, err := r.client().Do(req)
@@ -297,6 +293,7 @@ func (r *Repository) uploadBlobChunked(ctx context.Context, location *url.URL, a
 	blobLocation, err := resp.Location()
 	if err != nil {
 		output.Errorf("Warning: remote registry did not return blob location")
+		return "", nil
 	}
 
 	return blobLocation.String(), nil
@@ -340,7 +337,7 @@ func (r *Repository) uploadBlobChunkWithRetry(ctx context.Context, req *http.Req
 				output.SafeDebugf("[%s] Failed to fetch new token: %s", shortDigest, err)
 				return resp, respErr
 			}
-			req.Header.Set("Authorization", newAuth)
+			r.copyAuth(req, newAuth)
 			didReauth = true
 
 			if _, err := seekableContent.Seek(rangeStart, io.SeekStart); err != nil {
@@ -450,4 +447,48 @@ func buildRepositoryManifestsURL(plainHTTP bool, registryRef registry.Reference,
 		scheme = "http"
 	}
 	return fmt.Sprintf("%s://%s/v2/%s/manifests/%s", scheme, registryRef.Host(), registryRef.Repository, manifestRef)
+}
+
+// copyAuth attaches the provided authHeader to a request. If the request's URL doesn't match the origin for
+// the repository, copying is skipped and the request is not modified.
+func (r *Repository) copyAuth(req *http.Request, authHeader string) {
+	if authHeader == "" {
+		return
+	}
+
+	// Check scheme matches; registry reference does not include scheme so switch on PlainHTTP
+	registryScheme := "https"
+	if r.PlainHttp {
+		registryScheme = "http"
+	}
+	if req.URL.Scheme != registryScheme {
+		return
+	}
+
+	requestHost := req.URL.Hostname()
+	requestPort := req.URL.Port()
+	if requestPort == "" {
+		switch req.URL.Scheme {
+		case "http":
+			requestPort = "80"
+		case "https":
+			requestPort = "443"
+		default:
+			return
+		}
+	}
+
+	registryHost, registryPort, err := net.SplitHostPort(r.Reference.Host())
+	if err != nil {
+		registryHost = r.Reference.Host()
+		if r.PlainHttp {
+			registryPort = "80"
+		} else {
+			registryPort = "443"
+		}
+	}
+
+	if strings.EqualFold(requestHost, registryHost) && requestPort == registryPort {
+		req.Header.Set("Authorization", authHeader)
+	}
 }

--- a/pkg/lib/repo/remote/repository_test.go
+++ b/pkg/lib/repo/remote/repository_test.go
@@ -195,13 +195,53 @@ func TestUploadBlobChunkedVerifyRequestHeaders(t *testing.T) {
 
 	testRepo := Repository{
 		Repository:      nil, // Not testing library functionality here!
-		Reference:       registry.Reference{Registry: "testreg", Repository: "testrepo", Reference: "testtag"},
+		Reference:       registry.Reference{Registry: "127.0.0.1", Repository: "testrepo", Reference: "testtag"},
 		PlainHttp:       true,
 		Client:          tc,
 		uploadChunkSize: uploadChunkDefaultSize,
 	}
 
 	_, tErr := testRepo.uploadBlobChunked(t.Context(), startUrl, expectedAuthHeader, expectedDesc, testContent)
+	t.Logf("Function output:\n%s\n", logbuf.String())
+	assert.ErrorIs(t, tErr, completedErr, "Unexpected error returned")
+}
+
+func TestUploadBlobChunkedDropsAuthOnCrossOrigin(t *testing.T) {
+	var logbuf bytes.Buffer
+	teardown := setup(&logbuf)
+	defer teardown()
+
+	startUrl, err := url.Parse("http://127.0.0.1/start")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedSize := uploadChunkDefaultSize
+	expectedDigest := ocispec.DescriptorEmptyJSON.Digest
+	expectedDesc := ocispec.Descriptor{Digest: expectedDigest, Size: expectedSize}
+	testContent := io.LimitReader(rand.Reader, expectedSize)
+	completedErr := errors.New("test complete")
+
+	responses := []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			processRequest(req, http.MethodPatch, "/start")
+			assert.Empty(t, req.Header.Get("Authorization"),
+				"Authorization must not be forwarded to a cross-origin upload target")
+			return nil, completedErr
+		},
+	}
+
+	tc := &testClient{responses: responses}
+
+	testRepo := Repository{
+		Repository:      nil,
+		Reference:       registry.Reference{Registry: "testreg", Repository: "testrepo", Reference: "testtag"},
+		PlainHttp:       true,
+		Client:          tc,
+		uploadChunkSize: uploadChunkDefaultSize,
+	}
+
+	_, tErr := testRepo.uploadBlobChunked(t.Context(), startUrl, "test-auth", expectedDesc, testContent)
 	t.Logf("Function output:\n%s\n", logbuf.String())
 	assert.ErrorIs(t, tErr, completedErr, "Unexpected error returned")
 }
@@ -422,6 +462,122 @@ func TestUploadBlobChunkedRetriesLimit(t *testing.T) {
 		return
 	}
 	assert.ErrorContains(t, tErr, "end of test", "Unexpected error returned")
+}
+
+func TestCopyAuth(t *testing.T) {
+	const authHeader = "Bearer test-token"
+
+	tests := []struct {
+		name       string
+		reference  registry.Reference
+		plainHttp  bool
+		authHeader string
+		requestURL string
+		wantAuth   string
+	}{
+		{
+			name:       "empty auth header is a no-op",
+			reference:  registry.Reference{Registry: "registry.example.com", Repository: "repo"},
+			authHeader: "",
+			requestURL: "https://registry.example.com/v2/repo/blobs/uploads/abc",
+			wantAuth:   "",
+		},
+		{
+			name:       "same host with default https port",
+			reference:  registry.Reference{Registry: "registry.example.com", Repository: "repo"},
+			authHeader: authHeader,
+			requestURL: "https://registry.example.com/v2/repo/blobs/uploads/abc",
+			wantAuth:   authHeader,
+		},
+		{
+			name:       "same host with default http port for plainHttp registry",
+			reference:  registry.Reference{Registry: "registry.example.com", Repository: "repo"},
+			plainHttp:  true,
+			authHeader: authHeader,
+			requestURL: "http://registry.example.com/v2/repo/blobs/uploads/abc",
+			wantAuth:   authHeader,
+		},
+		{
+			name:       "same host with matching explicit port",
+			reference:  registry.Reference{Registry: "registry.example.com:5000", Repository: "repo"},
+			authHeader: authHeader,
+			requestURL: "https://registry.example.com:5000/v2/repo/blobs/uploads/abc",
+			wantAuth:   authHeader,
+		},
+		{
+			name:       "host match is case-insensitive",
+			reference:  registry.Reference{Registry: "Registry.Example.com", Repository: "repo"},
+			authHeader: authHeader,
+			requestURL: "https://registry.EXAMPLE.com/v2/repo/blobs/uploads/abc",
+			wantAuth:   authHeader,
+		},
+		{
+			name:       "different host drops auth",
+			reference:  registry.Reference{Registry: "registry.example.com", Repository: "repo"},
+			authHeader: authHeader,
+			requestURL: "https://other.example.com/v2/repo/blobs/uploads/abc",
+			wantAuth:   "",
+		},
+		{
+			name:       "different explicit port drops auth",
+			reference:  registry.Reference{Registry: "registry.example.com:5000", Repository: "repo"},
+			authHeader: authHeader,
+			requestURL: "https://registry.example.com:6000/v2/repo/blobs/uploads/abc",
+			wantAuth:   "",
+		},
+		{
+			name:       "default port mismatch drops auth (https registry, http request)",
+			reference:  registry.Reference{Registry: "registry.example.com", Repository: "repo"},
+			authHeader: authHeader,
+			requestURL: "http://registry.example.com/v2/repo/blobs/uploads/abc",
+			wantAuth:   "",
+		},
+		{
+			name:       "explicit registry port vs default request port drops auth",
+			reference:  registry.Reference{Registry: "registry.example.com:5000", Repository: "repo"},
+			authHeader: authHeader,
+			requestURL: "https://registry.example.com/v2/repo/blobs/uploads/abc",
+			wantAuth:   "",
+		},
+		{
+			name:       "unknown scheme without port drops auth",
+			reference:  registry.Reference{Registry: "registry.example.com", Repository: "repo"},
+			authHeader: authHeader,
+			requestURL: "ftp://registry.example.com/v2/repo/blobs/uploads/abc",
+			wantAuth:   "",
+		},
+		{
+			name:       "plain http scheme mismatch",
+			reference:  registry.Reference{Registry: "registry.example.com:8080", Repository: "repo"},
+			plainHttp:  true,
+			authHeader: authHeader,
+			requestURL: "https://registry.example.com:8080/v2/repo/blobs/uploads/abc",
+			wantAuth:   "",
+		},
+		{
+			name:       "https scheme mismatch",
+			reference:  registry.Reference{Registry: "registry.example.com:8080", Repository: "repo"},
+			authHeader: authHeader,
+			requestURL: "http://registry.example.com:8080/v2/repo/blobs/uploads/abc",
+			wantAuth:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Repository{
+				Reference: tt.reference,
+				PlainHttp: tt.plainHttp,
+			}
+			req, err := http.NewRequest(http.MethodPut, tt.requestURL, nil)
+			if err != nil {
+				t.Fatalf("failed to build request: %v", err)
+			}
+
+			r.copyAuth(req, tt.authHeader)
+			assert.Equal(t, tt.wantAuth, req.Header.Get("Authorization"))
+		})
+	}
 }
 
 func gobbleBody(req *http.Request) error {


### PR DESCRIPTION
### Description
Only copy Auth headers to follow-up requests when a same-origin policy would allow us to; skip copying headers when an upload redirects us to another location (e.g. presigned S3 URL) as those locations should handle auth separately (e.g. within the redirect).

### Linked issues
N/A

### AI-Assisted Code
<!-- Check all that apply -->
- [x] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
