### PR TITLE
feat: support packaging MCP Bundles (.mcpb) in ModelKits

### DIFF
--- a/pkg/artifact/kitfile.go
+++ b/pkg/artifact/kitfile.go
@@ -51,13 +51,14 @@ const (
 
 type (
 	KitFile struct {
-		ManifestVersion string    `json:"manifestVersion" yaml:"manifestVersion"`
-		Package         Package   `json:"package,omitempty" yaml:"package,omitempty"`
-		Model           *Model    `json:"model,omitempty" yaml:"model,omitempty"`
-		Code            []Code    `json:"code,omitempty" yaml:"code,omitempty"`
-		DataSets        []DataSet `json:"datasets,omitempty" yaml:"datasets,omitempty"`
-		Docs            []Docs    `json:"docs,omitempty" yaml:"docs,omitempty"`
-		Prompts         []Prompt  `json:"prompts,omitempty" yaml:"prompts,omitempty"`
+		ManifestVersion string      `json:"manifestVersion" yaml:"manifestVersion"`
+		Package         Package     `json:"package,omitempty" yaml:"package,omitempty"`
+		Model           *Model      `json:"model,omitempty" yaml:"model,omitempty"`
+		Code            []Code      `json:"code,omitempty" yaml:"code,omitempty"`
+		DataSets        []DataSet   `json:"datasets,omitempty" yaml:"datasets,omitempty"`
+		Docs            []Docs      `json:"docs,omitempty" yaml:"docs,omitempty"`
+		Prompts         []Prompt    `json:"prompts,omitempty" yaml:"prompts,omitempty"`
+		MCPServers      []MCPServer `json:"mcpServers,omitempty" yaml:"mcpServers,omitempty"`
 	}
 
 	Package struct {
@@ -124,6 +125,17 @@ type (
 		//  * It's recommended to store metadata like preprocessing steps, formats, etc.
 		Parameters any `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 		*LayerInfo `json:",inline" yaml:",inline"`
+	}
+
+	// MCPServer describes an MCP server packaged as an MCP Bundle (.mcpb) archive.
+	// The path must point to a single .mcpb file, which is stored verbatim as its
+	// own layer. The bundle's manifest.json remains the source of truth for the
+	// server's configuration; none of its fields are replicated here.
+	MCPServer struct {
+		Name        string `json:"name,omitempty" yaml:"name,omitempty"`
+		Path        string `json:"path,omitempty" yaml:"path,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
+		*LayerInfo  `json:",inline" yaml:",inline"`
 	}
 
 	Prompt struct {
@@ -287,6 +299,26 @@ func (kf *KitFile) Validate() (warnings []string, err error) {
 		}
 		if pathType != LocalPathType {
 			addErr("invalid path for prompt (%s): only local paths are permitted", prompt.Path)
+		}
+	}
+	mcpServerNames := map[string]bool{}
+	for idx, server := range kf.MCPServers {
+		addPath(server.Path, fmt.Sprintf("mcpServer layer %d", idx))
+		pathType, err := GetPathType(server.Path)
+		if err != nil {
+			addErr("invalid path for mcpServer (%s): %s", server.Path, err)
+		}
+		if pathType != LocalPathType {
+			addErr("invalid path for mcpServer (%s): only local paths are permitted", server.Path)
+		} else if !strings.HasSuffix(server.Path, ".mcpb") {
+			addErr("invalid path for mcpServer (%s): path must point to a single .mcpb file", server.Path)
+		}
+		if server.Name == "" {
+			addErr("mcpServer with path %s must have a name", server.Path)
+		} else if mcpServerNames[server.Name] {
+			addErr("duplicate mcpServer name %s: names must be unique", server.Name)
+		} else {
+			mcpServerNames[server.Name] = true
 		}
 	}
 

--- a/pkg/artifact/kitfile.md
+++ b/pkg/artifact/kitfile.md
@@ -4,7 +4,7 @@ The Kitfile manifest for AI/ML is a YAML file designed to encapsulate all the ne
 
 ## Overview
 
-The manifest is structured into several key sections: `manifestVersion`, `package`, `code`, `datasets`, `docs`, `prompts`, and `model`. Each section serves a specific purpose in describing the AI/ML package components and requirements.
+The manifest is structured into several key sections: `manifestVersion`, `package`, `code`, `datasets`, `docs`, `prompts`, `mcpServers`, and `model`. Each section serves a specific purpose in describing the AI/ML package components and requirements.
 
 ### `manifestVersion`
 
@@ -69,6 +69,14 @@ This section provides general information about the AI/ML project.
   - `path`: Location of the prompt file or directory relative to the context
   - `description`: Description of the prompt
 
+### `mcpServers`
+
+- **Description**: Information about MCP servers packaged as MCP Bundle (`.mcpb`) archives. Each entry's path must point to a single `.mcpb` file: a ZIP archive containing a local MCP server and a `manifest.json` at its root. Each bundle is stored verbatim as its own raw, uncompressed layer (media type `application/vnd.kitops.modelkit.mcpb.v1.raw`), so the layer digest covers the exact bundle bytes and unpacking yields a byte-identical archive. The bundle's `manifest.json` remains the source of truth for the server's configuration; none of its fields are duplicated in the Kitfile.
+- **Type**: Object Array
+  - `name`: Name for the MCP server. Required, and must be unique within `mcpServers`.
+  - `path`: Location of the `.mcpb` file relative to the context.
+  - `description`: Description of the MCP server.
+
 ### `model`
 
 - **Description**: Details of the trained models included in the package.
@@ -108,6 +116,10 @@ datasets:
 prompts:
   - path: system.prompt.md
     description: System prompt for the LLM.
+mcpServers:
+  - name: filesystem
+    path: filesystem.mcpb
+    description: MCP server providing filesystem access.
 model:
     name: ModelName
     path: models/model.h5

--- a/pkg/artifact/testdata/validation/duplicate-path-with-mcpserver.yaml
+++ b/pkg/artifact/testdata/validation/duplicate-path-with-mcpserver.yaml
@@ -1,0 +1,8 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  code:
+    - path: filesystem.mcpb
+  mcpServers:
+    - name: filesystem
+      path: filesystem.mcpb
+errRegexp: "use the same path filesystem.mcpb"

--- a/pkg/artifact/testdata/validation/mcpserver-duplicate-name.yaml
+++ b/pkg/artifact/testdata/validation/mcpserver-duplicate-name.yaml
@@ -1,0 +1,8 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  mcpServers:
+    - name: filesystem
+      path: filesystem.mcpb
+    - name: filesystem
+      path: other.mcpb
+errRegexp: "duplicate mcpServer name filesystem"

--- a/pkg/artifact/testdata/validation/mcpserver-missing-name.yaml
+++ b/pkg/artifact/testdata/validation/mcpserver-missing-name.yaml
@@ -1,0 +1,5 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  mcpServers:
+    - path: filesystem.mcpb
+errRegexp: "mcpServer with path filesystem.mcpb must have a name"

--- a/pkg/artifact/testdata/validation/mcpserver-non-mcpb-path.yaml
+++ b/pkg/artifact/testdata/validation/mcpserver-non-mcpb-path.yaml
@@ -1,0 +1,6 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  mcpServers:
+    - name: filesystem
+      path: filesystem.zip
+errRegexp: "invalid path for mcpServer.*path must point to a single .mcpb file"

--- a/pkg/artifact/testdata/validation/mcpserver-valid.yaml
+++ b/pkg/artifact/testdata/validation/mcpserver-valid.yaml
@@ -1,0 +1,8 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  mcpServers:
+    - name: filesystem
+      path: filesystem.mcpb
+    - name: postgres
+      path: postgres.mcpb
+errRegexp: ""

--- a/pkg/artifact/testdata/validation/s3-path-for-mcpserver.yaml
+++ b/pkg/artifact/testdata/validation/s3-path-for-mcpserver.yaml
@@ -1,0 +1,6 @@
+kitfile: |
+  manifestVersion: 1.0.0
+  mcpServers:
+    - name: filesystem
+      path: s3://test-s3/key
+errRegexp: "invalid path for mcpServer.*only local paths are permitted"

--- a/pkg/cmd/list/cmd.go
+++ b/pkg/cmd/list/cmd.go
@@ -165,7 +165,7 @@ func ListCommand() *cobra.Command {
 
 	cmd.Args = cobra.MaximumNArgs(1)
 	cmd.Flags().StringVar(&opts.format, "format", "table", "Output format: table, json, or Go template string")
-	cmd.Flags().StringArrayVarP(&opts.filters, "filter", "f", []string{}, "Filter modelkits by content type (e.g., model, datasets, code, docs, prompts). Can be specified multiple times")
+	cmd.Flags().StringArrayVarP(&opts.filters, "filter", "f", []string{}, "Filter modelkits by content type (e.g., model, datasets, code, docs, prompts, mcpservers). Can be specified multiple times")
 	opts.AddNetworkFlags(cmd)
 	cmd.Flags().SortFlags = false
 

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -58,7 +58,7 @@ to unpack only the dataset named 'my-dataset'.
 Valid filters have the format
     [types]:[filters]
 where [types] is a comma-separated list of Kitfile fields (kitfile, model, datasets
-code, or docs) and [filters] is an optional comma-separated list of additional filters
+code, docs, prompts, or mcpservers) and [filters] is an optional comma-separated list of additional filters
 to apply, which are matched against the Kitfile to further restrict what is extracted.
 Additional filters match elements of the Kitfile on either the name (if present) or
 the path used.

--- a/pkg/lib/constants/mediatype/kitops.go
+++ b/pkg/lib/constants/mediatype/kitops.go
@@ -75,6 +75,8 @@ func (mt *kitopsMediaType) baseTypeString() string {
 		return "code"
 	case DocsBaseType:
 		return "docs"
+	case MCPBBaseType:
+		return "mcpb"
 	}
 	return "invalid mediatype"
 }
@@ -95,6 +97,8 @@ func ParseKitBaseType(s string) (BaseType, error) {
 		return CodeBaseType, nil
 	case "docs":
 		return DocsBaseType, nil
+	case "mcpb":
+		return MCPBBaseType, nil
 	default:
 		return UnknownBaseType, fmt.Errorf("invalid base type %s", s)
 	}

--- a/pkg/lib/constants/mediatype/kitops_test.go
+++ b/pkg/lib/constants/mediatype/kitops_test.go
@@ -56,6 +56,7 @@ func TestParseKitopsMediaType(t *testing.T) {
 		"application/vnd.kitops.modelkit.docs.v1.tar",
 		"application/vnd.kitops.modelkit.docs.v1.tar+gzip",
 		"application/vnd.kitops.modelkit.docs.v1.tar+zstd",
+		"application/vnd.kitops.modelkit.mcpb.v1.raw",
 	}
 
 	for _, mediaType := range mediaTypes {
@@ -67,6 +68,21 @@ func TestParseKitopsMediaType(t *testing.T) {
 			assert.Equal(t, mediaType, parsedType.String(), "Parsed media type should match input")
 		})
 	}
+}
+
+func TestKitopsMCPBMediaType(t *testing.T) {
+	const mcpbMediaType = "application/vnd.kitops.modelkit.mcpb.v1.raw"
+	parsed, err := ParseMediaType(mcpbMediaType)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, MCPBBaseType, parsed.Base())
+	assert.Equal(t, RawFormat, parsed.Format())
+	assert.Equal(t, NoneCompression, parsed.Compression())
+	assert.Equal(t, "mcpb", parsed.UserString())
+
+	created := New(KitFormat, MCPBBaseType, RawFormat, NoneCompression)
+	assert.Equal(t, mcpbMediaType, created.String())
 }
 
 func TestParseKitopsInvalidType(t *testing.T) {

--- a/pkg/lib/constants/mediatype/mediatype.go
+++ b/pkg/lib/constants/mediatype/mediatype.go
@@ -59,6 +59,8 @@ const (
 	CodeBaseType
 	// DocsBaseType is the base type for documentation layers
 	DocsBaseType
+	// MCPBBaseType is the base type for MCP Bundle (.mcpb) layers, stored as verbatim ZIP archives
+	MCPBBaseType
 )
 
 type CompressionType int

--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -230,6 +230,25 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 		diffIDs = append(diffIDs, digest.Digest(layerInfo.DiffId))
 		kitfile.Prompts[idx].LayerInfo = layerInfo
 	}
+	if len(kitfile.MCPServers) > 0 && opts.ModelFormat == mediatype.ModelPackFormat {
+		// The mcpb media type is KitOps-local; it is not defined for the ModelPack format
+		return nil, nil, fmt.Errorf("mcpServers are not supported when packing in modelpack format")
+	}
+	for idx, server := range kitfile.MCPServers {
+		// MCP Bundles are stored as raw, uncompressed layers so that the .mcpb ZIP archive
+		// round-trips byte-for-byte. Validate it is a well-formed bundle before packing.
+		if err := ValidateMCPB(server.Path); err != nil {
+			return nil, nil, fmt.Errorf("invalid MCP bundle for mcpServer %s: %w", server.Name, err)
+		}
+		mediaType := mediatype.New(mediatype.KitFormat, mediatype.MCPBBaseType, mediatype.RawFormat, mediatype.NoneCompression)
+		layer, layerInfo, err := saveContentLayer(ctx, localRepo, server.Path, mediaType, ignore)
+		if err != nil {
+			return nil, nil, err
+		}
+		layers = append(layers, layer)
+		diffIDs = append(diffIDs, digest.Digest(layerInfo.DiffId))
+		kitfile.MCPServers[idx].LayerInfo = layerInfo
+	}
 
 	if len(toVerifyRemote) > 0 {
 		client, err := s3api.SetUpClient(ctx)

--- a/pkg/lib/filesystem/mcpb.go
+++ b/pkg/lib/filesystem/mcpb.go
@@ -1,0 +1,46 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package filesystem
+
+import (
+	"archive/zip"
+	"fmt"
+	"os"
+)
+
+// ValidateMCPB verifies that the file at path is a well-formed MCP Bundle: a
+// regular file containing a ZIP archive with a manifest.json at its root.
+func ValidateMCPB(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to read MCP bundle %s: %w", path, err)
+	}
+	if !fi.Mode().IsRegular() {
+		return fmt.Errorf("MCP bundle path %s must be a single .mcpb file", path)
+	}
+	zipReader, err := zip.OpenReader(path)
+	if err != nil {
+		return fmt.Errorf("MCP bundle %s is not a valid ZIP archive: %w", path, err)
+	}
+	defer zipReader.Close()
+	for _, f := range zipReader.File {
+		if f.Name == "manifest.json" {
+			return nil
+		}
+	}
+	return fmt.Errorf("MCP bundle %s does not contain a manifest.json at its root", path)
+}

--- a/pkg/lib/filesystem/mcpb_test.go
+++ b/pkg/lib/filesystem/mcpb_test.go
@@ -1,0 +1,97 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package filesystem
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func writeZip(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	zw := zip.NewWriter(file)
+	for name, contents := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(contents)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateMCPB(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	validPath := filepath.Join(tmpDir, "valid.mcpb")
+	writeZip(t, validPath, map[string]string{
+		"manifest.json":   `{"name": "test-server"}`,
+		"server/index.js": "console.log('hi')",
+	})
+
+	noManifestPath := filepath.Join(tmpDir, "no-manifest.mcpb")
+	writeZip(t, noManifestPath, map[string]string{
+		"server/index.js": "console.log('hi')",
+	})
+
+	nestedManifestPath := filepath.Join(tmpDir, "nested-manifest.mcpb")
+	writeZip(t, nestedManifestPath, map[string]string{
+		"subdir/manifest.json": `{"name": "test-server"}`,
+	})
+
+	notZipPath := filepath.Join(tmpDir, "not-a-zip.mcpb")
+	if err := os.WriteFile(notZipPath, []byte("this is not a zip archive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		path      string
+		errRegexp string
+	}{
+		{name: "valid bundle", path: validPath},
+		{name: "missing manifest.json", path: noManifestPath, errRegexp: "does not contain a manifest.json at its root"},
+		{name: "nested-only manifest.json", path: nestedManifestPath, errRegexp: "does not contain a manifest.json at its root"},
+		{name: "not a zip archive", path: notZipPath, errRegexp: "is not a valid ZIP archive"},
+		{name: "nonexistent file", path: filepath.Join(tmpDir, "missing.mcpb"), errRegexp: "failed to read MCP bundle"},
+		{name: "directory path", path: tmpDir, errRegexp: "must be a single .mcpb file"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMCPB(tt.path)
+			if tt.errRegexp == "" {
+				assert.NoError(t, err)
+			} else if assert.Error(t, err) {
+				assert.Regexp(t, tt.errRegexp, err.Error())
+			}
+		})
+	}
+}

--- a/pkg/lib/filesystem/unpack/util.go
+++ b/pkg/lib/filesystem/unpack/util.go
@@ -115,6 +115,13 @@ func generateUnpackPlan(manifest *ocispec.Manifest, kitfile *artifact.KitFile, f
 			}
 		}
 	}
+	for _, server := range kitfile.MCPServers {
+		if kfutils.LayerMatchesAnyFilter(server, filters) {
+			if err := addStep(server.Digest, "MCP server", server.Name, server.Path); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	return steps, nil
 }

--- a/pkg/lib/kitfile/filter.go
+++ b/pkg/lib/kitfile/filter.go
@@ -30,15 +30,16 @@ import (
 type BaseType string
 
 const (
-	BaseTypeKitfile  BaseType = "kitfile"
-	BaseTypeModel    BaseType = "model"
-	BaseTypeDatasets BaseType = "datasets"
-	BaseTypeCode     BaseType = "code"
-	BaseTypePrompts  BaseType = "prompts"
-	BaseTypeDocs     BaseType = "docs"
+	BaseTypeKitfile    BaseType = "kitfile"
+	BaseTypeModel      BaseType = "model"
+	BaseTypeDatasets   BaseType = "datasets"
+	BaseTypeCode       BaseType = "code"
+	BaseTypePrompts    BaseType = "prompts"
+	BaseTypeDocs       BaseType = "docs"
+	BaseTypeMCPServers BaseType = "mcpservers"
 )
 
-var validFilterTypes = []string{"kitfile", "model", "datasets", "code", "prompts", "docs"}
+var validFilterTypes = []string{"kitfile", "model", "datasets", "code", "prompts", "docs", "mcpservers"}
 
 type FilterConf struct {
 	BaseTypes []BaseType
@@ -121,6 +122,8 @@ func LayerMatchesAnyFilter(layer any, filters []FilterConf) bool {
 		return matchesFilters(BaseTypeCode, l.Path, filters)
 	case artifact.Prompt:
 		return matchesFilters(BaseTypePrompts, l.Name, filters) || matchesFilters(BaseTypePrompts, l.Path, filters)
+	case artifact.MCPServer:
+		return matchesFilters(BaseTypeMCPServers, l.Name, filters) || matchesFilters(BaseTypeMCPServers, l.Path, filters)
 	default:
 		return false
 	}
@@ -181,6 +184,12 @@ func KitfileContainsMatchingLayer(kf *artifact.KitFile, filters []FilterConf) bo
 
 	for _, prompt := range kf.Prompts {
 		if LayerMatchesAnyFilter(prompt, filters) {
+			return true
+		}
+	}
+
+	for _, server := range kf.MCPServers {
+		if LayerMatchesAnyFilter(server, filters) {
 			return true
 		}
 	}

--- a/pkg/lib/kitfile/filter_test.go
+++ b/pkg/lib/kitfile/filter_test.go
@@ -161,6 +161,55 @@ func TestShouldUnpackLayer_PromptByName(t *testing.T) {
 	}
 }
 
+func TestShouldUnpackLayer_MCPServerByName(t *testing.T) {
+	tests := []struct {
+		name   string
+		server artifact.MCPServer
+		filter string
+		expect bool
+	}{
+		{
+			name:   "match by name",
+			server: artifact.MCPServer{Name: "filesystem", Path: "filesystem.mcpb"},
+			filter: "mcpservers:filesystem",
+			expect: true,
+		},
+		{
+			name:   "match by path",
+			server: artifact.MCPServer{Name: "filesystem", Path: "filesystem.mcpb"},
+			filter: "mcpservers:filesystem.mcpb",
+			expect: true,
+		},
+		{
+			name:   "no match",
+			server: artifact.MCPServer{Name: "filesystem", Path: "filesystem.mcpb"},
+			filter: "mcpservers:postgres",
+			expect: false,
+		},
+		{
+			name:   "mcpservers type without specific filter matches all",
+			server: artifact.MCPServer{Name: "filesystem", Path: "filesystem.mcpb"},
+			filter: "mcpservers",
+			expect: true,
+		},
+		{
+			name:   "other type does not match",
+			server: artifact.MCPServer{Name: "filesystem", Path: "filesystem.mcpb"},
+			filter: "datasets",
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc, err := ParseFilter(tt.filter)
+			require.NoError(t, err)
+			result := LayerMatchesAnyFilter(tt.server, []FilterConf{*fc})
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}
+
 func TestFiltersFromUnpackConf(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/lib/kitfile/generate/generate.go
+++ b/pkg/lib/kitfile/generate/generate.go
@@ -39,6 +39,7 @@ const (
 	fileTypeDocs
 	fileTypeMetadata
 	fileTypePrompt
+	fileTypeMCPServer
 	fileTypeUnknown
 )
 
@@ -72,6 +73,10 @@ var metadataSuffixes = []string{
 
 var datasetSuffixes = []string{
 	".tar", ".zip", ".parquet", ".csv",
+}
+
+var mcpServerSuffixes = []string{
+	".mcpb",
 }
 
 // Files that are considered prompt files based on their names; entries should be in lowercase to support
@@ -227,6 +232,8 @@ func classifyDirectoryRecursive(kitfile *artifact.KitFile, dir DirectoryListing,
 			kitfile.DataSets = append(kitfile.DataSets, artifact.DataSet{Path: file.Path})
 		case fileTypePrompt:
 			kitfile.Prompts = append(kitfile.Prompts, artifact.Prompt{Path: file.Path})
+		case fileTypeMCPServer:
+			kitfile.MCPServers = append(kitfile.MCPServers, mcpServerFromPath(file.Path))
 		case fileTypeCode:
 			kitfile.Code = append(kitfile.Code, artifact.Code{Path: file.Path})
 		default:
@@ -330,6 +337,13 @@ func addDirToKitfile(kitfile *artifact.KitFile, dir DirectoryListing) (modelFile
 	case fileTypePrompt:
 		output.Logf(output.LogLevelTrace, "Interpreting directory %s as a prompts directory", dir.Path)
 		kitfile.Prompts = append(kitfile.Prompts, artifact.Prompt{Path: unixWithTrailingSlash(dir.Path)})
+	case fileTypeMCPServer:
+		// Each mcpServer entry must point to a single .mcpb file, so add the directory's
+		// bundles individually rather than the directory as a whole
+		output.Logf(output.LogLevelTrace, "Interpreting directory %s as MCP server bundles", dir.Path)
+		for _, path := range directoryContents[int(fileTypeMCPServer)] {
+			kitfile.MCPServers = append(kitfile.MCPServers, mcpServerFromPath(path))
+		}
 	case fileTypeCode:
 		output.Logf(output.LogLevelTrace, "Interpreting directory %s as code directory", dir.Path)
 		kitfile.Code = append(kitfile.Code, artifact.Code{Path: unixWithTrailingSlash(dir.Path)})
@@ -366,7 +380,19 @@ func determineFileType(filename string) fileType {
 	if anySuffix(filename, datasetSuffixes) {
 		return fileTypeDataset
 	}
+	if anySuffix(filename, mcpServerSuffixes) {
+		return fileTypeMCPServer
+	}
 	return fileTypeUnknown
+}
+
+// mcpServerFromPath returns an MCPServer entry for a .mcpb file, deriving the
+// required name from the path without the extension
+func mcpServerFromPath(path string) artifact.MCPServer {
+	return artifact.MCPServer{
+		Name: strings.TrimSuffix(filepath.ToSlash(path), ".mcpb"),
+		Path: path,
+	}
 }
 
 func addModelToKitfile(kitfile *artifact.KitFile, files []FileListing) error {

--- a/pkg/lib/repo/util/kitfile.go
+++ b/pkg/lib/repo/util/kitfile.go
@@ -40,6 +40,9 @@ func LayerPathsFromKitfile(kitfile *artifact.KitFile) []string {
 	for _, prompt := range kitfile.Prompts {
 		layerPaths = append(layerPaths, cleanPath(prompt.Path))
 	}
+	for _, server := range kitfile.MCPServers {
+		layerPaths = append(layerPaths, cleanPath(server.Path))
+	}
 
 	if kitfile.Model != nil {
 		if kitfile.Model.Path != "" {

--- a/testing/mcpb_test.go
+++ b/testing/mcpb_test.go
@@ -1,0 +1,185 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kitops-ml/kitops/pkg/lib/constants"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const mcpbMediaType = "application/vnd.kitops.modelkit.mcpb.v1.raw"
+
+const mcpbKitfile = `
+manifestVersion: 1.0.0
+package:
+  name: agent-mcp-bundle
+  version: 1.0.0
+mcpServers:
+  - name: filesystem
+    path: ./filesystem.mcpb
+  - name: postgres
+    path: ./postgres.mcpb
+docs:
+  - path: ./README.md
+`
+
+// writeMCPB creates a ZIP archive at path containing the given entries
+func writeMCPB(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	defer file.Close()
+	zw := zip.NewWriter(file)
+	for name, contents := range entries {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(contents))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+}
+
+func sha256OfFile(t *testing.T, path string) string {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	sum := sha256.Sum256(contents)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func setupMCPBModelKit(t *testing.T, modelKitPath string) {
+	setupKitfileAndKitignore(t, modelKitPath, mcpbKitfile, "")
+	setupFiles(t, modelKitPath, []string{"README.md"})
+	writeMCPB(t, filepath.Join(modelKitPath, "filesystem.mcpb"), map[string]string{
+		"manifest.json":   `{"name": "filesystem-server"}`,
+		"server/index.js": "console.log('fs')",
+	})
+	writeMCPB(t, filepath.Join(modelKitPath, "postgres.mcpb"), map[string]string{
+		"manifest.json":   `{"name": "postgres-server"}`,
+		"server/index.js": "console.log('pg')",
+	})
+}
+
+// TestMCPBPackUnpack packs a ModelKit with two MCP bundles, verifies each is
+// stored as its own layer whose digest is the SHA-256 of the bundle's bytes,
+// and verifies unpacking yields byte-identical archives.
+func TestMCPBPackUnpack(t *testing.T) {
+	testPreflight(t)
+
+	tmpDir := setupTempDir(t)
+	modelKitPath, unpackPath, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
+
+	setupMCPBModelKit(t, modelKitPath)
+
+	filesystemDigest := sha256OfFile(t, filepath.Join(modelKitPath, "filesystem.mcpb"))
+	postgresDigest := sha256OfFile(t, filepath.Join(modelKitPath, "postgres.mcpb"))
+
+	packOut := runCommand(t, expectNoError, "pack", modelKitPath, "-t", modelKitTag)
+	// The layer digest must be the SHA-256 of the .mcpb file's bytes (stored verbatim)
+	assert.Contains(t, packOut, "Saved mcpb layer: "+filesystemDigest)
+	assert.Contains(t, packOut, "Saved mcpb layer: "+postgresDigest)
+
+	inspectOut := runCommand(t, expectNoError, "inspect", modelKitTag)
+	assert.Contains(t, inspectOut, mcpbMediaType)
+	assert.Contains(t, inspectOut, filesystemDigest)
+	assert.Contains(t, inspectOut, postgresDigest)
+
+	runCommand(t, expectNoError, "unpack", modelKitTag, "-d", unpackPath)
+
+	for _, bundle := range []string{"filesystem.mcpb", "postgres.mcpb"} {
+		original, err := os.ReadFile(filepath.Join(modelKitPath, bundle))
+		require.NoError(t, err)
+		unpacked, err := os.ReadFile(filepath.Join(unpackPath, bundle))
+		require.NoError(t, err)
+		assert.Equal(t, original, unpacked, "Unpacked %s should be byte-identical to the original", bundle)
+	}
+}
+
+// TestMCPBUnpackFilter verifies that mcpb layers can be selected via the
+// mcpservers filter type, by name.
+func TestMCPBUnpackFilter(t *testing.T) {
+	testPreflight(t)
+
+	tmpDir := setupTempDir(t)
+	modelKitPath, unpackPath, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
+
+	setupMCPBModelKit(t, modelKitPath)
+
+	runCommand(t, expectNoError, "pack", modelKitPath, "-t", modelKitTag)
+	runCommand(t, expectNoError, "unpack", modelKitTag, "--filter=mcpservers:postgres", "-d", unpackPath)
+
+	checkFilesExist(t, unpackPath, []string{"postgres.mcpb"})
+	checkFilesDoNotExist(t, unpackPath, []string{"filesystem.mcpb", "README.md"})
+}
+
+// TestMCPBPackFailures verifies that packing fails for malformed bundles and
+// for the modelpack format.
+func TestMCPBPackFailures(t *testing.T) {
+	testPreflight(t)
+
+	kitfile := `
+manifestVersion: 1.0.0
+mcpServers:
+  - name: bad
+    path: ./bad.mcpb
+`
+
+	t.Run("missing manifest.json", func(t *testing.T) {
+		tmpDir := setupTempDir(t)
+		modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+		t.Setenv(constants.KitopsHomeEnvVar, contextPath)
+
+		setupKitfileAndKitignore(t, modelKitPath, kitfile, "")
+		writeMCPB(t, filepath.Join(modelKitPath, "bad.mcpb"), map[string]string{
+			"server/index.js": "console.log('no manifest')",
+		})
+
+		runCommand(t, expectError, "pack", modelKitPath, "-t", modelKitTag)
+	})
+
+	t.Run("not a zip archive", func(t *testing.T) {
+		tmpDir := setupTempDir(t)
+		modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+		t.Setenv(constants.KitopsHomeEnvVar, contextPath)
+
+		setupKitfileAndKitignore(t, modelKitPath, kitfile, "")
+		require.NoError(t, os.WriteFile(filepath.Join(modelKitPath, "bad.mcpb"), []byte("not a zip"), 0o644))
+
+		runCommand(t, expectError, "pack", modelKitPath, "-t", modelKitTag)
+	})
+
+	t.Run("modelpack format", func(t *testing.T) {
+		tmpDir := setupTempDir(t)
+		modelKitPath, _, contextPath := setupTestDirs(t, tmpDir)
+		t.Setenv(constants.KitopsHomeEnvVar, contextPath)
+
+		setupMCPBModelKit(t, modelKitPath)
+
+		runCommand(t, expectError, "pack", modelKitPath, "-t", modelKitTag, "--use-model-pack")
+	})
+}

--- a/testing/testdata/kitfile-generation/test_mcp-server-detection.yaml
+++ b/testing/testdata/kitfile-generation/test_mcp-server-detection.yaml
@@ -1,0 +1,25 @@
+description: "Detects .mcpb files as MCP servers"
+
+files:
+  - filesystem.mcpb
+  - postgres.mcpb
+  # directory with only MCP bundles
+  - servers/extra.mcpb
+  - README.md
+
+modelName: test-mcp-server-detection
+expectedKitfile:
+  manifestVersion: "1.0.0"
+  package:
+    name: test-mcp-server-detection
+    description: "Detects .mcpb files as MCP servers"
+  docs:
+    - path: README.md
+      description: Readme file
+  mcpServers:
+    - name: filesystem
+      path: filesystem.mcpb
+    - name: postgres
+      path: postgres.mcpb
+    - name: servers/extra
+      path: servers/extra.mcpb


### PR DESCRIPTION
## What

Adds first-class support for packaging MCP Bundles (`.mcpb`) in ModelKits via a new `mcpServers` Kitfile section.

- New `mcpServers` Kitfile section with the `MCPServer` entry type (name, path, description) and validation: required unique names, local-only paths, `.mcpb` extension, and cross-section duplicate-path checks.
- Each `.mcpb` bundle is validated as a well-formed ZIP containing a root `manifest.json`, then stored verbatim as its own **raw, uncompressed layer** (media type `application/vnd.kitops.modelkit.mcpb.v1.raw`). The layer digest covers the exact bundle bytes, so unpacking yields a byte-identical archive.
- `kit unpack` restores bundles to their Kitfile path; `--filter=mcpservers[:name|path]` selects them.
- `kit init` detects local `.mcpb` files (and directories of bundles) and adds them as `mcpServers` entries.
- `mcpServers` are rejected when packing in ModelPack format, since the media type is KitOps-local.

## Why

MCP Bundles are becoming a common way to distribute local MCP servers. Packaging them in ModelKits lets agents, models, and their MCP servers be versioned and shipped together as a single OCI artifact.

## Notes

Rather than introduce a bespoke verbatim-layer code path, this builds directly on the existing **raw-layer machinery** (`saveContentLayerAsRaw` / `extractRawLayer`): an `.mcpb` is simply a raw layer with `none` compression. The MCP-specific logic is limited to bundle validation, the `mcpServers` Kitfile schema, filtering, and `kit init` detection.

## Validation

- `go build ./...`, full `go test ./...` — all green
- Integration tests (`testing/mcpb_test.go`): digest == file SHA-256, byte-identical pack/unpack round-trip, `mcpservers` filter selection, and pack failures for malformed bundles and the ModelPack format
- Local CI mirror: `go mod tidy` (clean), `go fmt`, `addlicense` headers, `go generate` (no diff), trailing-whitespace check
