### PR TITLE
fix: tolerate missing content in local list and remove

### DIFF
--- a/pkg/cmd/list/list.go
+++ b/pkg/cmd/list/list.go
@@ -53,6 +53,11 @@ func listLocalKits(ctx context.Context, opts *listOptions) ([]modelInfo, error) 
 func readInfoFromRepo(ctx context.Context, repo local.LocalRepo, filterConfs []kitfile.FilterConf) ([]modelInfo, error) {
 	var infos []modelInfo
 	manifestDescs := repo.GetAllModels()
+	// Strip localhost from repo if present, since we added it
+	repository := artifact.FormatRepositoryForDisplay(repo.GetRepoName())
+	if repository == "" {
+		repository = "<none>"
+	}
 	for _, manifestDesc := range manifestDescs {
 		manifest, config, err := util.GetManifestAndKitfile(ctx, repo, manifestDesc)
 		if err != nil {
@@ -64,7 +69,7 @@ func readInfoFromRepo(ctx context.Context, repo local.LocalRepo, filterConfs []k
 				// The manifest references content that is no longer in local storage (e.g. left over from
 				// an interrupted removal). Skip it rather than failing the entire listing; the entry can be
 				// cleaned up with 'kit remove'.
-				output.Logf(output.LogLevelWarn, "Skipping %s@%s: content is missing from local storage; run 'kit remove' to clean it up", repo.GetRepoName(), manifestDesc.Digest)
+				output.Logf(output.LogLevelWarn, "Skipping %s@%s: content is missing from local storage; run 'kit remove' to clean it up", repository, manifestDesc.Digest)
 				continue
 			}
 			// Allow artifacts without Kitfiles as all that will be lacking is some metadata; we can still
@@ -80,11 +85,6 @@ func readInfoFromRepo(ctx context.Context, repo local.LocalRepo, filterConfs []k
 		}
 
 		tags := repo.GetTags(manifestDesc)
-		// Strip localhost from repo if present, since we added it
-		repository := artifact.FormatRepositoryForDisplay(repo.GetRepoName())
-		if repository == "" {
-			repository = "<none>"
-		}
 		info := modelInfo{
 			Repo:   repository,
 			Digest: string(manifestDesc.Digest),

--- a/pkg/cmd/list/list.go
+++ b/pkg/cmd/list/list.go
@@ -26,6 +26,9 @@ import (
 	"github.com/kitops-ml/kitops/pkg/lib/kitfile"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/local"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/util"
+	"github.com/kitops-ml/kitops/pkg/output"
+
+	"oras.land/oras-go/v2/errdef"
 )
 
 func listLocalKits(ctx context.Context, opts *listOptions) ([]modelInfo, error) {
@@ -55,6 +58,13 @@ func readInfoFromRepo(ctx context.Context, repo local.LocalRepo, filterConfs []k
 		if err != nil {
 			if errors.Is(err, util.ErrNotAModelKit) {
 				// Shouldn't happen since this is a local repo, but either way it's not a supported artifact
+				continue
+			}
+			if errors.Is(err, errdef.ErrNotFound) {
+				// The manifest references content that is no longer in local storage (e.g. left over from
+				// an interrupted removal). Skip it rather than failing the entire listing; the entry can be
+				// cleaned up with 'kit remove'.
+				output.Logf(output.LogLevelWarn, "Skipping %s@%s: content is missing from local storage; run 'kit remove' to clean it up", repo.GetRepoName(), manifestDesc.Digest)
 				continue
 			}
 			// Allow artifacts without Kitfiles as all that will be lacking is some metadata; we can still

--- a/pkg/lib/repo/local/registry.go
+++ b/pkg/lib/repo/local/registry.go
@@ -142,7 +142,11 @@ func (lr *localRepo) Delete(ctx context.Context, target ocispec.Descriptor) erro
 		return fmt.Errorf("failed to check if manifest can be deleted: %w", err)
 	}
 	if canDelete {
-		if err := lr.Store.Delete(ctx, target); err != nil {
+		// Delete the manifest and its now-dangling blobs. If some referenced content is already
+		// gone from storage (e.g. left over from an interrupted delete or external cleanup), treat
+		// it as already-deleted so we can still remove the manifest from the local index below and
+		// leave the repository in a consistent state.
+		if err := lr.Store.Delete(ctx, target); err != nil && !errors.Is(err, errdef.ErrNotFound) {
 			return err
 		}
 	}


### PR DESCRIPTION
## What

Make local `list` and `remove` tolerant of ModelKits whose blobs are partially missing from local storage.

- **`kit list`**: skip a manifest whose content can't be read (`errdef.ErrNotFound`), logging a warning that points at `kit remove` for cleanup, instead of aborting the entire listing.
- **`kit remove`**: treat already-missing content from the underlying store delete as already-deleted, so the manifest is still removed from the per-repo index and the repository is left consistent.

## Why

If a ModelKit's blobs go missing from local storage — e.g. left over from an interrupted removal — both commands fail hard:

```
kit list
[ERROR] Failed to read manifest sha256:…: …image.manifest.v1+json: not found

kit remove <ref>
[ERROR] Failed to remove: failed to delete model: sha256:…: …image.manifest.v1+json: not found
```

Worse, the failed `remove` deletes the manifest blob via the store but returns before cleaning the per-repo index, leaving a dangling reference that then breaks `list` for *every* ModelKit in the store. A single corrupted entry shouldn't make the whole store unusable, and there should be a way to clean it up.

## How it was validated

- `go build ./...`, `go test ./pkg/...` — all green
- `gofmt`, `addlicense` headers, `go vet`, trailing-whitespace check
- Manually reproduced the corrupted state (manifest blob removed from disk, dangling tag) and confirmed: `kit list` now warns-and-skips while still listing healthy kits, and `kit remove <tag>` cleans up the dangling entry, after which `list` is clean.
