### PR TITLE
Add image manifest mediatype to manifests created by Kit

### DIFF
--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -292,6 +292,7 @@ func createManifest(configDesc ocispec.Descriptor, layerDescs []ocispec.Descript
 	case mediatype.KitFormat:
 		manifest = ocispec.Manifest{
 			Versioned:    specs.Versioned{SchemaVersion: 2},
+			MediaType:    ocispec.MediaTypeImageManifest,
 			ArtifactType: mediatype.ArtifactTypeKitManifest,
 			Config:       configDesc,
 			Layers:       layerDescs,
@@ -299,6 +300,7 @@ func createManifest(configDesc ocispec.Descriptor, layerDescs []ocispec.Descript
 	case mediatype.ModelPackFormat:
 		manifest = ocispec.Manifest{
 			Versioned:    specs.Versioned{SchemaVersion: 2},
+			MediaType:    ocispec.MediaTypeImageManifest,
 			ArtifactType: mediatype.ArtifactTypeModelManifest,
 			Config:       configDesc,
 			Layers:       layerDescs,


### PR DESCRIPTION
### Description
Add mediatype field to manifests generated by KitOps, according to the OCI spec. This field is normally optional, but is marked as "SHOULD" be included -- this PR adds it to new manifests generated by KitOps.

Docs ref: https://github.com/opencontainers/image-spec/blob/main/manifest.md#image-manifest-property-descriptions

### Linked issues
N/A

### AI-Assisted Code
<!-- Check all that apply -->
- [ ] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
