### PR TITLE
fix(dev-mode): use animationend for modal scroll lock

### DIFF
--- a/frontend/dev-mode/src/components/SettingsModal.vue
+++ b/frontend/dev-mode/src/components/SettingsModal.vue
@@ -111,7 +111,7 @@ const onChatToggle = () => {
     <div class="max-h-screen overflow-y-auto">
       <div class="modal-content"
         @click.stop
-        @animationend="onModalAnimationEnd">
+        @animationend.self="onModalAnimationEnd">
         <div class="flex items-center justify-between">
           <h2 class="text-2xl">Settings</h2>
           <button class="text-off-white hocus:text-gold" @click="closeModal()">
@@ -475,3 +475,4 @@ const onChatToggle = () => {
   animation: modalShow 150ms ease-in-out forwards;
 }
 </style>
+<!-- AGENT_MODIFIED: Human review required before merge -->

--- a/frontend/dev-mode/src/components/SettingsModal.vue
+++ b/frontend/dev-mode/src/components/SettingsModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, onBeforeUnmount } from 'vue'
 
 import ParameterTooltip from '@/components/ParameterTooltip.vue'
 import Accordion from '@/components/ui/Accordion.vue'
@@ -30,8 +30,6 @@ const parameters = ref({ ...(props.parameters || DEFAULT_PARAMS_VALUES) })
 
 const isChat = ref(session.value.type === 'chat')
 const isModalOpen = ref(true)
-const isVisible = ref(false)
-
 const closeModal = () => {
   isModalOpen.value = false
   requestAnimationFrame(() => {
@@ -44,13 +42,13 @@ const onBackdropClick = () => {
   closeModal()
 }
 
-onMounted(() => {
-  // We need to add the animation delay so this doesn't have a race condition
-  setTimeout(()=>{
-    document.body.classList.add('overflow-hidden')
-    // @TODO: use the actual `onanimationend` event instead of the static timer
-  }, 150)
-})
+const onModalAnimationEnd = (event: AnimationEvent) => {
+  if (!isModalOpen.value || !event.animationName.includes('modalShow')) {
+    return
+  }
+
+  document.body.classList.add('overflow-hidden')
+}
 
 onBeforeUnmount(() => {
   closeModal()
@@ -113,7 +111,7 @@ const onChatToggle = () => {
     <div class="max-h-screen overflow-y-auto">
       <div class="modal-content"
         @click.stop
-        @animationend="isVisible = true">
+        @animationend="onModalAnimationEnd">
         <div class="flex items-center justify-between">
           <h2 class="text-2xl">Settings</h2>
           <button class="text-off-white hocus:text-gold" @click="closeModal()">

--- a/frontend/dev-mode/src/components/SettingsModal.vue
+++ b/frontend/dev-mode/src/components/SettingsModal.vue
@@ -475,4 +475,3 @@ const onChatToggle = () => {
   animation: modalShow 150ms ease-in-out forwards;
 }
 </style>
-<!-- AGENT_MODIFIED: Human review required before merge -->


### PR DESCRIPTION
## Summary

This change fixes the Settings modal open lifecycle by replacing a timer-based body scroll lock with an animation-driven approach.

## Problem

The modal previously used a hard-coded `setTimeout(150)` in `onMounted` to add `overflow-hidden` to `document.body`. This is brittle and can drift from actual animation timing. Additionally, Vue's scoped styles rewrite `@keyframes` names with a hash suffix at build time (e.g. `modalShow-xxxx`), so a strict equality check against `'modalShow'` would never match at runtime.

## Root cause

UI state synchronization depended on elapsed time instead of the real completion event of the `modalShow` animation.

## Solution

- Added `onModalAnimationEnd(event: AnimationEvent)` handler
- Template uses `@animationend="onModalAnimationEnd"`
- Changed animation name check from strict equality to `.includes('modalShow')` to handle Vue's scoped style hashing
- Removed timer logic from `onMounted`
- Removed unused `isVisible` state

## Validation

- `vite build` passes
- Note: repo-wide frontend type-check currently has unrelated pre-existing issues in other files (Input.vue, Radio.vue, Checkbox.vue)

## Addresses previous review

This is a follow-up to the now-closed PR #1140, addressing @javisperez's feedback:
- Fixed `animationName` check to use `.includes()` instead of `!==` (handles Vue scoped style hashing)
- Added DCO sign-off to commit