### PR TITLE
feat(import): resume Hugging Face downloads

### DIFF
--- a/pkg/cmd/kitimport/hfimport.go
+++ b/pkg/cmd/kitimport/hfimport.go
@@ -18,6 +18,8 @@ package kitimport
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -44,17 +46,6 @@ func importUsingHF(ctx context.Context, opts *importOptions) (*ProvenanceData, e
 		return nil, fmt.Errorf("could not process repository %s: %w", opts.repo, err)
 	}
 
-	tmpDir, cleanupTmp, err := cache.MkCacheDir("import", "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
-	}
-	doCleanup := true
-	defer func() {
-		if doCleanup {
-			cleanupTmp()
-		}
-	}()
-
 	// Resolve the user-supplied ref to an immutable commit SHA up front.
 	// HF accepts commit SHAs anywhere a ref is expected, so threading this
 	// SHA through ListFiles and DownloadFiles binds the entire import to one
@@ -62,6 +53,13 @@ func importUsingHF(ctx context.Context, opts *importOptions) (*ProvenanceData, e
 	commitSHA, err := hf.PinCommit(ctx, repo, opts.repoRef, opts.token, repoType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to pin commit for %s@%s: %w", repo, opts.repoRef, err)
+	}
+
+	// Reuse one cache directory per immutable HF snapshot so interrupted
+	// downloads can be resumed. Successful imports clear the import cache below.
+	tmpDir, _, err := cache.MkCacheDir(cache.CacheImportSubdir, hfImportCacheKey(repo, repoType, commitSHA))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 
 	dirListing, err := hf.ListFiles(ctx, repo, commitSHA, opts.token, repoType)
@@ -98,7 +96,6 @@ func importUsingHF(ctx context.Context, opts *importOptions) (*ProvenanceData, e
 			newKitfile, err := promptToEditKitfile(tmpDir, kf)
 			if err != nil {
 				if errors.Is(err, ErrNoEditorFound) {
-					doCleanup = false
 					kfPath := filepath.Join(tmpDir, constants.DefaultKitfileName)
 					output.Logf(output.LogLevelWarn, "Could not determine default editor from $EDITOR environment variable")
 					output.Logf(output.LogLevelWarn, "Please manually edit Kitfile at path")
@@ -185,4 +182,9 @@ func hfSourceURI(repo string, repoType hf.RepositoryType) string {
 		return "hf://datasets/" + repo
 	}
 	return "hf://" + repo
+}
+
+func hfImportCacheKey(repo string, repoType hf.RepositoryType, commitSHA string) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%d\x00%s\x00%s", repoType, repo, commitSHA)))
+	return "hf_" + hex.EncodeToString(sum[:])
 }

--- a/pkg/cmd/kitimport/hfimport_test.go
+++ b/pkg/cmd/kitimport/hfimport_test.go
@@ -43,3 +43,12 @@ func TestHFSourceURI(t *testing.T) {
 		})
 	}
 }
+
+func TestHFImportCacheKey(t *testing.T) {
+	modelKey := hfImportCacheKey("org/repo", hf.RepoTypeModel, "abc123")
+
+	assert.Equal(t, modelKey, hfImportCacheKey("org/repo", hf.RepoTypeModel, "abc123"))
+	assert.NotEqual(t, modelKey, hfImportCacheKey("org/repo", hf.RepoTypeDataset, "abc123"))
+	assert.NotEqual(t, modelKey, hfImportCacheKey("org/repo", hf.RepoTypeModel, "def456"))
+	assert.NotContains(t, modelKey, "/")
+}

--- a/pkg/lib/external/hf/download.go
+++ b/pkg/lib/external/hf/download.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem"
@@ -116,12 +117,28 @@ func downloadFile(
 	plog *output.ProgressLogger) error {
 
 	plog.Debugf("Downloading from %s", srcURL)
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	resumeOffset, complete, err := downloadResumeOffset(destPath, size)
+	if err != nil {
+		return err
+	}
+	if complete {
+		plog.Debugf("Using cached file %s", destPath)
+		return nil
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srcURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to resolve URL: %w", err)
 	}
 	if token != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+	if resumeOffset > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", resumeOffset))
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -133,22 +150,33 @@ func downloadFile(
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK {
+	if resumeOffset > 0 && resp.StatusCode == http.StatusOK {
+		plog.Debugf("Server ignored range request for %s; restarting download", filename)
+		resumeOffset = 0
+	}
+	if resumeOffset > 0 && resp.StatusCode == http.StatusPartialContent {
+		expectedPrefix := fmt.Sprintf("bytes %d-", resumeOffset)
+		if contentRange := resp.Header.Get("Content-Range"); contentRange != "" && !strings.HasPrefix(contentRange, expectedPrefix) {
+			return fmt.Errorf("unexpected content range %q when resuming file %s", contentRange, filename)
+		}
+	} else if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("received status code %d when downloading file %s from %s", resp.StatusCode, filename, srcURL)
 	}
 
-	contentRC := progress.TrackDownload(resp.Body, filename, size)
+	contentRC := progress.TrackDownload(resp.Body, filename, remainingDownloadSize(size, resumeOffset, resp.ContentLength))
 	defer func() {
 		if err := contentRC.Close(); err != nil {
-			plog.Logf(output.LogLevelWarn, "TEMP: see if this is an issue: %s", err)
+			plog.Logf(output.LogLevelWarn, "Failed to close download stream for %s: %s", filename, err)
 		}
 	}()
 
-	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
+	flags := os.O_CREATE | os.O_WRONLY
+	if resumeOffset > 0 {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
 	}
-
-	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(destPath, flags, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
@@ -165,6 +193,62 @@ func downloadFile(
 	if resp.ContentLength > 0 && n != resp.ContentLength {
 		return fmt.Errorf("mismatched file size: expected %d but got %d", resp.ContentLength, n)
 	}
+	if size > 0 {
+		finalSize := n
+		if resumeOffset > 0 {
+			finalSize += resumeOffset
+		}
+		if finalSize != size {
+			return fmt.Errorf("mismatched file size: expected %d but got %d", size, finalSize)
+		}
+	}
 
 	return nil
+}
+
+func downloadResumeOffset(destPath string, size int64) (offset int64, complete bool, err error) {
+	info, err := os.Stat(destPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("failed to examine existing file: %w", err)
+	}
+	if info.IsDir() {
+		return 0, false, fmt.Errorf("download destination %s is a directory", destPath)
+	}
+
+	existingSize := info.Size()
+	if size == 0 {
+		if existingSize == 0 {
+			return 0, true, nil
+		}
+		if err := os.Remove(destPath); err != nil {
+			return 0, false, fmt.Errorf("failed to remove oversized cached file: %w", err)
+		}
+		return 0, false, nil
+	}
+	if existingSize == size {
+		return 0, true, nil
+	}
+	if existingSize > size {
+		if err := os.Remove(destPath); err != nil {
+			return 0, false, fmt.Errorf("failed to remove oversized cached file: %w", err)
+		}
+		return 0, false, nil
+	}
+	return existingSize, false, nil
+}
+
+func remainingDownloadSize(size, resumeOffset, contentLength int64) int64 {
+	if size > 0 && resumeOffset > 0 {
+		return size - resumeOffset
+	}
+	if size > 0 {
+		return size
+	}
+	if contentLength > 0 {
+		return contentLength
+	}
+	return 0
 }

--- a/pkg/lib/external/hf/download_test.go
+++ b/pkg/lib/external/hf/download_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hf
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kitops-ml/kitops/pkg/output"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadFileResumesPartialFile(t *testing.T) {
+	var gotRange string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRange = r.Header.Get("Range")
+		w.Header().Set("Content-Range", "bytes 3-5/6")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("def"))
+	}))
+	defer srv.Close()
+
+	destPath := filepath.Join(t.TempDir(), "model.bin")
+	require.NoError(t, os.WriteFile(destPath, []byte("abc"), 0600))
+
+	progress, plog := output.NewDownloadProgress()
+	err := downloadFile(context.Background(), srv.Client(), "", srv.URL, destPath, "model.bin", 6, progress, plog)
+	progress.Done()
+	require.NoError(t, err)
+
+	require.Equal(t, "bytes=3-", gotRange)
+	contents, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	require.Equal(t, []byte("abcdef"), contents)
+}
+
+func TestDownloadFileRestartsWhenRangeIsIgnored(t *testing.T) {
+	var gotRange string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRange = r.Header.Get("Range")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("abcdef"))
+	}))
+	defer srv.Close()
+
+	destPath := filepath.Join(t.TempDir(), "model.bin")
+	require.NoError(t, os.WriteFile(destPath, []byte("abc"), 0600))
+
+	progress, plog := output.NewDownloadProgress()
+	err := downloadFile(context.Background(), srv.Client(), "", srv.URL, destPath, "model.bin", 6, progress, plog)
+	progress.Done()
+	require.NoError(t, err)
+
+	require.Equal(t, "bytes=3-", gotRange)
+	contents, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	require.Equal(t, []byte("abcdef"), contents)
+}
+
+func TestDownloadFileSkipsCompleteFile(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	destPath := filepath.Join(t.TempDir(), "model.bin")
+	require.NoError(t, os.WriteFile(destPath, []byte("abcdef"), 0600))
+
+	progress, plog := output.NewDownloadProgress()
+	err := downloadFile(context.Background(), srv.Client(), "", srv.URL, destPath, "model.bin", 6, progress, plog)
+	progress.Done()
+	require.NoError(t, err)
+
+	require.False(t, called)
+	contents, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	require.Equal(t, []byte("abcdef"), contents)
+}

--- a/pkg/lib/filesystem/cache/cache.go
+++ b/pkg/lib/filesystem/cache/cache.go
@@ -54,7 +54,7 @@ func MkCacheDir(subDir CacheSubDir, cacheKey string) (cacheDir string, cleanup f
 	}
 	if cacheKey != "" {
 		cacheDir = filepath.Join(cacheSubDir, cacheKey)
-		if err := os.Mkdir(cacheDir, 0700); err != nil {
+		if err := os.MkdirAll(cacheDir, 0700); err != nil {
 			return "", nil, fmt.Errorf("failed to create cache directory %s: %w", cacheDir, err)
 		}
 	} else {

--- a/pkg/lib/filesystem/cache/cache.go
+++ b/pkg/lib/filesystem/cache/cache.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kitops-ml/kitops/pkg/output"
 )
@@ -53,6 +54,9 @@ func MkCacheDir(subDir CacheSubDir, cacheKey string) (cacheDir string, cleanup f
 		return "", nil, fmt.Errorf("failed to create cache directory %s: %w", cacheSubDir, err)
 	}
 	if cacheKey != "" {
+		if err := validateCacheKey(cacheKey); err != nil {
+			return "", nil, err
+		}
 		cacheDir = filepath.Join(cacheSubDir, cacheKey)
 		if err := os.MkdirAll(cacheDir, 0700); err != nil {
 			return "", nil, fmt.Errorf("failed to create cache directory %s: %w", cacheDir, err)
@@ -71,6 +75,14 @@ func MkCacheDir(subDir CacheSubDir, cacheKey string) (cacheDir string, cleanup f
 		}
 	}
 	return cacheDir, cleanup, nil
+}
+
+func validateCacheKey(cacheKey string) error {
+	if filepath.IsAbs(cacheKey) || cacheKey == "." || cacheKey == ".." ||
+		strings.ContainsAny(cacheKey, `/\`) || filepath.Clean(cacheKey) != cacheKey {
+		return fmt.Errorf("invalid cache key %q: must be a single relative path element", cacheKey)
+	}
+	return nil
 }
 
 func MkCacheFile(subDir CacheSubDir, basename string) (tempFile *os.File, cleanup func(), err error) {

--- a/pkg/lib/filesystem/cache/cache_test.go
+++ b/pkg/lib/filesystem/cache/cache_test.go
@@ -47,3 +47,24 @@ func TestMkCacheDirReusesDeterministicDirectory(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("partial"), contents)
 }
+
+func TestMkCacheDirRejectsUnsafeCacheKeys(t *testing.T) {
+	originalCacheHome := cacheHome()
+	t.Cleanup(func() {
+		SetCacheHome(originalCacheHome)
+	})
+	SetCacheHome(t.TempDir())
+
+	for _, cacheKey := range []string{
+		".",
+		"..",
+		"nested/path",
+		`nested\path`,
+		filepath.Join("..", "outside"),
+	} {
+		t.Run(cacheKey, func(t *testing.T) {
+			_, _, err := MkCacheDir(CacheImportSubdir, cacheKey)
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/lib/filesystem/cache/cache_test.go
+++ b/pkg/lib/filesystem/cache/cache_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMkCacheDirReusesDeterministicDirectory(t *testing.T) {
+	originalCacheHome := cacheHome()
+	t.Cleanup(func() {
+		SetCacheHome(originalCacheHome)
+	})
+	SetCacheHome(t.TempDir())
+
+	firstDir, cleanup, err := MkCacheDir(CacheImportSubdir, "repo-ref")
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	partialPath := filepath.Join(firstDir, "partial-file")
+	require.NoError(t, os.WriteFile(partialPath, []byte("partial"), 0600))
+
+	secondDir, secondCleanup, err := MkCacheDir(CacheImportSubdir, "repo-ref")
+	require.NoError(t, err)
+	t.Cleanup(secondCleanup)
+
+	require.Equal(t, firstDir, secondDir)
+	contents, err := os.ReadFile(filepath.Join(secondDir, "partial-file"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("partial"), contents)
+}


### PR DESCRIPTION
### Description

Adds resumable downloads for Hugging Face imports that use `kit import --tool=hf`.

This change:
- reuses a deterministic import cache directory for each pinned Hugging Face snapshot
- resumes partial files with HTTP `Range` requests when cached bytes already exist
- restarts a file download if the server ignores `Range` and returns `200 OK`
- skips files that are already fully cached
- lets deterministic cache directories be opened more than once, matching the documented resume behavior

Successful imports still clean the import cache through the existing cleanup path.

### Linked issues

Fixes #763

### AI-Assisted Code
- [x] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created

### Tests

- `go test -count=1 ./pkg/lib/external/hf ./pkg/cmd/kitimport ./pkg/lib/filesystem/cache`
- `go test -race -count=1 ./pkg/lib/external/hf ./pkg/cmd/kitimport ./pkg/lib/filesystem/cache`
- `go test -count=1 ./pkg/...`
- `go test ./... -run TestDoesNotExist`
- `go build -o kit.exe`
- `git diff --cached --check`
- `go run github.com/google/addlicense@latest --check -s -l apache -c "The KitOps Authors." pkg/lib/external/hf/download_test.go pkg/lib/filesystem/cache/cache_test.go`