### PR TITLE
feat: respect SOURCE_DATE_EPOCH for reproducible manifest digests

### DIFF
--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/kitops-ml/kitops/pkg/artifact"
@@ -331,7 +333,14 @@ func createManifest(configDesc ocispec.Descriptor, layerDescs []ocispec.Descript
 		manifest.Annotations = map[string]string{}
 	}
 	manifest.Annotations[constants.CliVersionAnnotation] = constants.Version
-	manifest.Annotations[ocispec.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
+	createdTime := time.Now().UTC()
+	if epochStr := os.Getenv("SOURCE_DATE_EPOCH"); epochStr != "" {
+		if epochSec, err := strconv.ParseInt(epochStr, 10, 64); err == nil {
+			createdTime = time.Unix(epochSec, 0).UTC()
+		}
+	}
+	manifest.Annotations[ocispec.AnnotationCreated] = createdTime.Format(time.RFC3339)
 
 	return manifest, nil
 }
+// AGENT_MODIFIED: Human review required before merge

--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -335,12 +335,13 @@ func createManifest(configDesc ocispec.Descriptor, layerDescs []ocispec.Descript
 	manifest.Annotations[constants.CliVersionAnnotation] = constants.Version
 	createdTime := time.Now().UTC()
 	if epochStr := os.Getenv("SOURCE_DATE_EPOCH"); epochStr != "" {
-		if epochSec, err := strconv.ParseInt(epochStr, 10, 64); err == nil {
-			createdTime = time.Unix(epochSec, 0).UTC()
+		epochSec, err := strconv.ParseInt(epochStr, 10, 64)
+		if err != nil {
+			return ocispec.Manifest{}, fmt.Errorf("invalid SOURCE_DATE_EPOCH %q: %w", epochStr, err)
 		}
+		createdTime = time.Unix(epochSec, 0).UTC()
 	}
 	manifest.Annotations[ocispec.AnnotationCreated] = createdTime.Format(time.RFC3339)
 
 	return manifest, nil
 }
-// AGENT_MODIFIED: Human review required before merge


### PR DESCRIPTION
**Description**

Addresses the concern raised in #1139's review: the `org.opencontainers.image.created` annotation added in #1139 is always `time.Now()`, making reproducible digests impossible for the same content packed at different times.

This change makes createManifest in `pkg/lib/filesystem/local-storage.go` respect `SOURCE_DATE_EPOCH`, standard used by Docker BuildKit and reproducible-build toolchains.

 Behavior:
  - `SOURCE_DATE_EPOCH` unset → `time.Now()` (unchanged)
  - `SOURCE_DATE_EPOCH=<unix seconds>` → manifest created uses that timestamp; digest is stable across runs
  - `SOURCE_DATE_EPOCH=<non-integer>` → pack fails with a clear error, matching [BuildKit's behavior](https://github.com/moby/buildkit/blob/master/docs/build-repro.md)

 Verified:
```
$ SOURCE_DATE_EPOCH=abc ./kit pack -t foo:v1 .
[ERROR] Failed to pack model kit: error creating manifest: invalid SOURCE_DATE_EPOCH "abc": ...
```
```
$ SOURCE_DATE_EPOCH=315532800 ./kit pack -t foo:v1 .
Model saved: sha256:cd204...   # stable across runs with same content
```
**Linked issues**

closes #1224

**AI-Assisted Code**
- [x] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created

