### PR TITLE
chore: update Go toolchain patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kitops-ml/kitops
 
-go 1.25.7
+go 1.25.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0


### PR DESCRIPTION
### Description
Updates the Go directive from `1.25.7` to `1.25.11` so `actions/setup-go` jobs that use `go-version-file: go.mod` build with the current Go 1.25 patch release.

This keeps the project on the existing Go 1.25 minor line instead of jumping to Go 1.26. The container build already uses `golang:1.25-alpine`, which tracks the current Go 1.25 patch release for that image line.

Validation:
- `GOTOOLCHAIN=go1.25.11 go test -count=1 ./pkg/...`
- `go test -count=1 ./pkg/...`
- `go test -race -count=1 ./pkg/...`
- `go test -run '^$' ./...`
- `go build -o kit.exe`
- `git diff --check`

### Linked issues
Fixes #1199

### AI-Assisted Code
- [x] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created