### PR TITLE
Fixup duplicated default documented in pack command

### DIFF
--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -769,8 +769,8 @@ kit pack . -f /path/to/your/Kitfile -t registry/repository:modelv1
 ```
   -f, --file string           Specifies the path to the Kitfile explicitly (use "-" to read from standard input)
   -t, --tag string            Assigns one or more tags to the built modelkit. Example: -t registry/repository:tag1,tag2
-      --compression string    Compression format to use for layers. Valid options: 'none' (default), 'gzip', 'gzip-fastest', 'zstd' (default "none")
-      --layer-format string   Packaging format to use for layers. Valid options: 'tar' (default), 'raw' (default "tar")
+      --compression string    Compression format to use for layers. Valid options: 'none', 'gzip', 'gzip-fastest', 'zstd' (default "none")
+      --layer-format string   Packaging format to use for layers. Valid options: 'tar', 'raw' (default "tar")
       --use-model-pack        Pack model in ModelPack format instead of ModelKit
   -h, --help                  help for pack
 ```

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -80,8 +80,8 @@ func PackCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&opts.modelFile, "file", "f", "", "Specifies the path to the Kitfile explicitly (use \"-\" to read from standard input)")
 	cmd.Flags().StringVarP(&opts.fullTagRef, "tag", "t", "", "Assigns one or more tags to the built modelkit. Example: -t registry/repository:tag1,tag2")
-	cmd.Flags().StringVar(&opts.compression, "compression", "none", "Compression format to use for layers. Valid options: 'none' (default), 'gzip', 'gzip-fastest', 'zstd'")
-	cmd.Flags().StringVar(&opts.layerFormat, "layer-format", "tar", "Packaging format to use for layers. Valid options: 'tar' (default), 'raw'")
+	cmd.Flags().StringVar(&opts.compression, "compression", "none", "Compression format to use for layers. Valid options: 'none', 'gzip', 'gzip-fastest', 'zstd'")
+	cmd.Flags().StringVar(&opts.layerFormat, "layer-format", "tar", "Packaging format to use for layers. Valid options: 'tar', 'raw'")
 	cmd.Flags().BoolVar(&opts.useModelPack, "use-model-pack", false, "Pack model in ModelPack format instead of ModelKit")
 	cmd.Flags().SortFlags = false
 	cmd.Args = cobra.ExactArgs(1)


### PR DESCRIPTION
### Description
The Cobra library automatically documents default values, so listing the default in flag descriptions is not necessary.

This PR does update the cli-reference.md doc outside of a release, but the change is minor enough (wording, not correctness) that I don't think a bugfix release is necessary here.

### AI-Assisted Code
<!-- Check all that apply -->
- [ ] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
