### PR TITLE
Print a warning when skipping symlinks during kit pack

### DIFF
--- a/pkg/lib/filesystem/raw.go
+++ b/pkg/lib/filesystem/raw.go
@@ -38,7 +38,7 @@ import (
 func saveContentLayerAsRaw(ctx context.Context, localRepo local.LocalRepo, targetPath string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
 	targetPath = filepath.Clean(targetPath)
 
-	fi, err := os.Stat(targetPath)
+	fi, err := os.Lstat(targetPath)
 	if err != nil {
 		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("failed to read file %s: %w", targetPath, err)
 	}

--- a/pkg/lib/filesystem/tar.go
+++ b/pkg/lib/filesystem/tar.go
@@ -209,14 +209,19 @@ func writeLayerToTar(basePath string, ignore ignore.Paths, tarWriter *output.Pro
 		if file == "." {
 			return nil
 		}
-		// Skip anything that's not a regular file or directory
-		if !fi.Mode().IsRegular() && !fi.Mode().IsDir() {
-			return nil
-		}
 		// Since we're walking from the context directory, we want to skip irrelevant files (e.g. sibling directories)
 		if !sameDirTree(basePath, file) {
 			if fi.IsDir() {
 				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Skip anything that's not a regular file or directory
+		if !fi.Mode().IsRegular() && !fi.Mode().IsDir() {
+			if fi.Mode()&os.ModeSymlink != 0 {
+				plog.Logf(output.LogLevelWarn, "Skipping symlink %s (symlinks are not supported)", file)
+			} else {
+				plog.Debugf("Skipping file %s (not a regular file)", file)
 			}
 			return nil
 		}


### PR DESCRIPTION
### Description
* Print a warning line when pack skips a symlink to make it clearer what is happening
   * Other skipped files are logged as debug lines since they're less common
* Use os.Lstat when packing raw layers to avoid accidentally following symlinks

### Linked issues
N/A

### AI-Assisted Code
<!-- Check all that apply -->
- [ ] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
