### PR TITLE
fix(skill): tolerate unparseable SKILL.md frontmatter in kit init

### DIFF
--- a/pkg/lib/kitfile/generate/skill.go
+++ b/pkg/lib/kitfile/generate/skill.go
@@ -35,7 +35,11 @@ func parseSkillFrontmatter(contextDir, skillMDPath string) *skill.SkillFrontmatt
 		return nil
 	}
 
-	return skill.ParseSkillFrontmatter(data)
+	fm := skill.ParseSkillFrontmatter(data)
+	if fm == nil || (fm.Name == "" && fm.Description == "") {
+		output.Logf(output.LogLevelWarn, "Could not read a name or description from SKILL.md frontmatter at %s; the generated Kitfile will have no name or description", fullPath)
+	}
+	return fm
 }
 
 func dirContainsSkillMD(dir DirectoryListing) (bool, string) {

--- a/pkg/lib/kitfile/generate/skill_test.go
+++ b/pkg/lib/kitfile/generate/skill_test.go
@@ -56,9 +56,18 @@ func TestParseSkillFrontmatter(t *testing.T) {
 			expectNil: true,
 		},
 		{
-			name:      "malformed YAML",
-			content:   "---\nname: [invalid yaml\n---\n# Body",
-			expectNil: true,
+			// Frontmatter that is not valid YAML falls back to a lenient
+			name:       "malformed YAML recovered leniently",
+			content:    "---\nname: [invalid yaml\n---\n# Body",
+			expectName: "[invalid yaml",
+		},
+		{
+			// The common real-world case: an unquoted colon in a prose
+			// description. Strict YAML rejects it; the lenient fallback keeps it.
+			name:       "unquoted colon in description",
+			content:    "---\nname: pr-triage\ndescription: Handle review feedback on a pull request: address the comments\n---\n# Body",
+			expectName: "pr-triage",
+			expectDesc: "Handle review feedback on a pull request: address the comments",
 		},
 		{
 			name:      "no closing delimiter",

--- a/pkg/lib/skill/skillfile.go
+++ b/pkg/lib/skill/skillfile.go
@@ -173,7 +173,15 @@ func parseFrontmatterLenient(lines []string) *SkillFrontmatter {
 		if !ok {
 			continue
 		}
-		value = unquoteScalar(strings.TrimSpace(value))
+		value = strings.TrimSpace(value)
+		// Skip empty values and bare block-scalar indicators; multi-line
+		// values are not supported here and "|"/">" must not be captured as
+		// literal values. Checked before unquoting so a quoted "|" is kept.
+		switch value {
+		case "", "|", ">", "|-", "|+", ">-", ">+":
+			continue
+		}
+		value = unquoteScalar(value)
 		switch strings.TrimSpace(key) {
 		case "name":
 			if fm.Name == "" {
@@ -199,7 +207,9 @@ func parseFrontmatterLenient(lines []string) *SkillFrontmatter {
 }
 
 // unquoteScalar removes a single layer of matching surrounding quotes from a
-// scalar value, mirroring how a quoted YAML string would be interpreted.
+// scalar value. It does not process YAML escape sequences (e.g. `\n`, `\"`,
+// or doubled single quotes); escapes are left literal, which is acceptable
+// for this best-effort fallback.
 func unquoteScalar(s string) string {
 	if len(s) >= 2 {
 		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {

--- a/pkg/lib/skill/skillfile.go
+++ b/pkg/lib/skill/skillfile.go
@@ -122,7 +122,10 @@ type SkillFrontmatter struct {
 }
 
 // ParseSkillFrontmatter extracts and parses YAML frontmatter from SKILL.md
-// content. Returns nil if no valid frontmatter is found.
+// content. It first attempts a strict YAML parse; if that fails
+// it falls back to a lenient line-based parse of
+// the known keys. Returns nil if no frontmatter block is present or no known
+// fields could be recovered.
 func ParseSkillFrontmatter(data []byte) *SkillFrontmatter {
 	content := strings.ReplaceAll(string(data), "\r\n", "\n")
 	lines := strings.Split(content, "\n")
@@ -141,14 +144,67 @@ func ParseSkillFrontmatter(data []byte) *SkillFrontmatter {
 		return nil
 	}
 
-	fmYAML := strings.Join(lines[1:end], "\n")
+	fmLines := lines[1:end]
+	fmYAML := strings.Join(fmLines, "\n")
 	if strings.TrimSpace(fmYAML) == "" {
 		return nil
 	}
 
+	// Strict parse first
 	var fm SkillFrontmatter
-	if err := yaml.Unmarshal([]byte(fmYAML), &fm); err != nil {
+	if err := yaml.Unmarshal([]byte(fmYAML), &fm); err == nil {
+		return &fm
+	}
+
+	// The block is not valid YAML. Recover the known keys line-by-line
+	return parseFrontmatterLenient(fmLines)
+}
+
+// parseFrontmatterLenient recovers the known SKILL.md frontmatter keys from raw
+// lines by splitting each line on its first colon. It tolerates
+// YAML-significant characters (colons, quotes, '#') inside values but does not
+// support multi-line (block scalar) values. Returns nil if no known key is
+// found.
+func parseFrontmatterLenient(lines []string) *SkillFrontmatter {
+	var fm SkillFrontmatter
+	found := false
+	for _, line := range lines {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		value = unquoteScalar(strings.TrimSpace(value))
+		switch strings.TrimSpace(key) {
+		case "name":
+			if fm.Name == "" {
+				fm.Name = value
+				found = true
+			}
+		case "description":
+			if fm.Description == "" {
+				fm.Description = value
+				found = true
+			}
+		case "license":
+			if fm.License == "" {
+				fm.License = value
+				found = true
+			}
+		}
+	}
+	if !found {
 		return nil
 	}
 	return &fm
+}
+
+// unquoteScalar removes a single layer of matching surrounding quotes from a
+// scalar value, mirroring how a quoted YAML string would be interpreted.
+func unquoteScalar(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }

--- a/pkg/lib/skill/skillfile_test.go
+++ b/pkg/lib/skill/skillfile_test.go
@@ -207,6 +207,21 @@ func TestParseSkillFrontmatter(t *testing.T) {
 			expectedName:        "multi",
 			expectedDescription: "line one\nline two",
 		},
+		{
+			// Only empty known keys plus a malformed line: the lenient
+			// fallback must not report all-empty frontmatter as recovered.
+			name:      "empty values are not recovered leniently",
+			content:   "---\nname:\nunknown: [broken\n---\n",
+			expectNil: true,
+		},
+		{
+			// A block-scalar indicator must not become the literal value "|"
+			// when strict parsing fails for an unrelated reason.
+			name:                "block scalar indicator skipped in lenient fallback",
+			content:             "---\nname: [broken\ndescription: |\n  line one\n---\n",
+			expectedName:        "[broken",
+			expectedDescription: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lib/skill/skillfile_test.go
+++ b/pkg/lib/skill/skillfile_test.go
@@ -161,15 +161,17 @@ func TestReadSkillLayer_RejectsOversizedEntry(t *testing.T) {
 
 func TestParseSkillFrontmatter(t *testing.T) {
 	tests := []struct {
-		name         string
-		content      string
-		expectNil    bool
-		expectedName string
+		name                string
+		content             string
+		expectNil           bool
+		expectedName        string
+		expectedDescription string
 	}{
 		{
-			name:         "basic frontmatter",
-			content:      "---\nname: my-skill\ndescription: test\n---\n\nBody",
-			expectedName: "my-skill",
+			name:                "basic frontmatter",
+			content:             "---\nname: my-skill\ndescription: test\n---\n\nBody",
+			expectedName:        "my-skill",
+			expectedDescription: "test",
 		},
 		{
 			name:      "no frontmatter",
@@ -177,14 +179,33 @@ func TestParseSkillFrontmatter(t *testing.T) {
 			expectNil: true,
 		},
 		{
-			name:         "no name field",
-			content:      "---\ndescription: test\n---\n",
-			expectedName: "",
+			name:                "no name field",
+			content:             "---\ndescription: test\n---\n",
+			expectedName:        "",
+			expectedDescription: "test",
 		},
 		{
 			name:      "empty content",
 			content:   "",
 			expectNil: true,
+		},
+		{
+			name:                "unquoted colon in description (lenient fallback)",
+			content:             "---\nname: pr-review-triage\ndescription: Turn a pull request: \"address the comments\" into a plan\n---\n",
+			expectedName:        "pr-review-triage",
+			expectedDescription: `Turn a pull request: "address the comments" into a plan`,
+		},
+		{
+			name:                "quoted scalar values are unquoted",
+			content:             "---\nname: \"my-skill\"\ndescription: 'a short one'\n---\n",
+			expectedName:        "my-skill",
+			expectedDescription: "a short one",
+		},
+		{
+			name:                "block scalar description parses strictly",
+			content:             "---\nname: multi\ndescription: |\n  line one\n  line two\n---\n",
+			expectedName:        "multi",
+			expectedDescription: "line one\nline two",
 		},
 	}
 
@@ -202,6 +223,9 @@ func TestParseSkillFrontmatter(t *testing.T) {
 			}
 			if fm.Name != tt.expectedName {
 				t.Errorf("Name = %q, want %q", fm.Name, tt.expectedName)
+			}
+			if fm.Description != tt.expectedDescription {
+				t.Errorf("Description = %q, want %q", fm.Description, tt.expectedDescription)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Make `kit init` recover the `name` and `description` from a skill directory's `SKILL.md` even when the frontmatter isn't strictly valid YAML.

## Why

For a directory with a root `SKILL.md`, `kit init` derives the Kitfile `package` name/description from the frontmatter. `ParseSkillFrontmatter` ran a single strict `yaml.Unmarshal` over the whole block and **discarded any error**, returning `nil`. A `description` containing an unquoted colon — e.g. `... on a pull request: "address the comments"` — is not valid YAML (`mapping values are not allowed in this context`), so *all* metadata was silently dropped and the generated Kitfile had no name or description. Such descriptions are extremely common in real skills.

## How

- **Strict-first, lenient-fallback** in `ParseSkillFrontmatter`: try strict YAML first (preserving full YAML semantics, including the multi-line block-scalar descriptions the SKILL.md format permits); only if that fails, fall back to a lenient line-based parse of the known keys (`name`, `description`, `license`) that tolerates colons/quotes/`#` in prose values.
- **No more silent failure**: `kit init` now logs a warning when a `SKILL.md` is found but no name/description could be recovered.

The lenient path only ever runs on input that already failed strict YAML, so well-formed frontmatter is never mis-parsed.

## Validation

- `go test ./pkg/lib/skill/... ./pkg/lib/kitfile/generate/... ./pkg/cmd/kitinit/...` — pass
- Added table-test cases: unquoted colon in description, quoted-scalar unquoting, block-scalar (strict) description, and updated the existing malformed-YAML case to assert lenient recovery
- `gofmt`, `go vet`, `go build`, `addlicense --check`, `go mod tidy` — clean
- Manually verified against a real skill directory: `kit init` now emits both `package.name`/`package.description` and the prompt's `name`/`description`