### PR TITLE
feat: support packing and pushing directly to a remote registry

### DIFF
--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -750,9 +750,6 @@ at the root of the provided context directory. Any relative paths defined
 within the kitfile are interpreted as being relative to this context
 directory.
 
-If --push is set along with a --tag pointing to a remote registry, the modelkit
-is streamed directly to that registry instead of being stored locally.
-
 ```
 kit pack [flags] DIRECTORY
 ```
@@ -765,9 +762,6 @@ kit pack .
 
 # Pack a modelkit with a specific kitfile and tag
 kit pack . -f /path/to/your/Kitfile -t registry/repository:modelv1
-
-# Pack a modelkit and push it directly to a remote registry without storing it locally
-kit pack . -t registry.example.com/my-org/my-model:latest --push
 ```
 
 ### Options
@@ -778,14 +772,6 @@ kit pack . -t registry.example.com/my-org/my-model:latest --push
       --compression string    Compression format to use for layers. Valid options: 'none', 'gzip', 'gzip-fastest', 'zstd' (default "none")
       --layer-format string   Packaging format to use for layers. Valid options: 'tar', 'raw' (default "tar")
       --use-model-pack        Pack model in ModelPack format instead of ModelKit
-      --push                  Stream the packed modelkit directly to the remote registry specified by --tag, without storing it locally
-      --plain-http            Use plain HTTP when connecting to remote registries
-      --tls-verify            Require TLS and verify certificates when connecting to remote registries (default true)
-      --tls-cert strings      Path to TLS cert to add to trust store (flag can be repeated)
-      --cert string           Path to client certificate used for authentication (can also be set via environment variable KITOPS_CLIENT_CERT)
-      --key string            Path to client certificate key used for authentication (can also be set via environment variable KITOPS_CLIENT_KEY)
-      --concurrency int       Maximum number of simultaneous uploads/downloads (default 5)
-      --proxy string          Proxy to use for connections (overrides proxy set by environment)
   -h, --help                  help for pack
 ```
 

--- a/docs/src/docs/cli/cli-reference.md
+++ b/docs/src/docs/cli/cli-reference.md
@@ -750,6 +750,9 @@ at the root of the provided context directory. Any relative paths defined
 within the kitfile are interpreted as being relative to this context
 directory.
 
+If --push is set along with a --tag pointing to a remote registry, the modelkit
+is streamed directly to that registry instead of being stored locally.
+
 ```
 kit pack [flags] DIRECTORY
 ```
@@ -762,6 +765,9 @@ kit pack .
 
 # Pack a modelkit with a specific kitfile and tag
 kit pack . -f /path/to/your/Kitfile -t registry/repository:modelv1
+
+# Pack a modelkit and push it directly to a remote registry without storing it locally
+kit pack . -t registry.example.com/my-org/my-model:latest --push
 ```
 
 ### Options
@@ -772,6 +778,14 @@ kit pack . -f /path/to/your/Kitfile -t registry/repository:modelv1
       --compression string    Compression format to use for layers. Valid options: 'none', 'gzip', 'gzip-fastest', 'zstd' (default "none")
       --layer-format string   Packaging format to use for layers. Valid options: 'tar', 'raw' (default "tar")
       --use-model-pack        Pack model in ModelPack format instead of ModelKit
+      --push                  Stream the packed modelkit directly to the remote registry specified by --tag, without storing it locally
+      --plain-http            Use plain HTTP when connecting to remote registries
+      --tls-verify            Require TLS and verify certificates when connecting to remote registries (default true)
+      --tls-cert strings      Path to TLS cert to add to trust store (flag can be repeated)
+      --cert string           Path to client certificate used for authentication (can also be set via environment variable KITOPS_CLIENT_CERT)
+      --key string            Path to client certificate key used for authentication (can also be set via environment variable KITOPS_CLIENT_KEY)
+      --concurrency int       Maximum number of simultaneous uploads/downloads (default 5)
+      --proxy string          Proxy to use for connections (overrides proxy set by environment)
   -h, --help                  help for pack
 ```
 

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -17,7 +17,6 @@
 package pack
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -102,7 +101,7 @@ func PackCommand() *cobra.Command {
 
 func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		err := opts.complete(cmd.Context(), args)
+		err := opts.complete(cmd, args)
 		if err != nil {
 			return output.Fatalf("Invalid arguments: %s", err)
 		}
@@ -121,7 +120,8 @@ func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) error
 	}
 }
 
-func (opts *packOptions) complete(ctx context.Context, args []string) error {
+func (opts *packOptions) complete(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 	contextDir, err := filepath.Abs(args[0])
 	if err != nil {
 		return fmt.Errorf("failed to get context dir %s: %w", args[0], err)
@@ -173,6 +173,8 @@ func (opts *packOptions) complete(ctx context.Context, args []string) error {
 		if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
 			return err
 		}
+	} else if networkFlagsChanged(cmd) {
+		output.Infof("Warning: network-related flags are only applicable with --push flag")
 	}
 
 	printConfig(opts)
@@ -192,3 +194,14 @@ func printConfig(opts *packOptions) {
 		output.Debugf("Additional tags: %s", strings.Join(opts.extraRefs, ", "))
 	}
 }
+
+func networkFlagsChanged(cmd *cobra.Command) bool {
+	flags := []string{"plain-http", "tls-verify", "tls-cert", "cert", "key", "concurrency", "proxy"}
+	for _, f := range flags {
+		if cmd.Flags().Changed(f) {
+			return true
+		}
+	}
+	return false
+}
+

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/kitops-ml/kitops/pkg/artifact"
+	"github.com/kitops-ml/kitops/pkg/cmd/options"
 	"github.com/kitops-ml/kitops/pkg/lib/constants/mediatype"
 
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
@@ -46,16 +47,23 @@ as pushing to a remote registry for collaboration.
 Unless a different location is specified, this command looks for the kitfile
 at the root of the provided context directory. Any relative paths defined
 within the kitfile are interpreted as being relative to this context
-directory.`
+directory.
+
+If --push is set along with a --tag pointing to a remote registry, the modelkit
+is streamed directly to that registry instead of being stored locally.`
 
 	examples = `# Pack a modelkit using the kitfile in the current directory
 kit pack .
 
 # Pack a modelkit with a specific kitfile and tag
-kit pack . -f /path/to/your/Kitfile -t registry/repository:modelv1`
+kit pack . -f /path/to/your/Kitfile -t registry/repository:modelv1
+
+# Pack a modelkit and push it directly to a remote registry without storing it locally
+kit pack . -t registry.example.com/my-org/my-model:latest --push`
 )
 
 type packOptions struct {
+	options.NetworkOptions
 	modelFile    string
 	contextDir   string
 	configHome   string
@@ -66,6 +74,7 @@ type packOptions struct {
 	modelRef     *registry.Reference
 	extraRefs    []string
 	useModelPack bool
+	push         bool
 }
 
 func PackCommand() *cobra.Command {
@@ -83,6 +92,8 @@ func PackCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.compression, "compression", "none", "Compression format to use for layers. Valid options: 'none', 'gzip', 'gzip-fastest', 'zstd'")
 	cmd.Flags().StringVar(&opts.layerFormat, "layer-format", "tar", "Packaging format to use for layers. Valid options: 'tar', 'raw'")
 	cmd.Flags().BoolVar(&opts.useModelPack, "use-model-pack", false, "Pack model in ModelPack format instead of ModelKit")
+	cmd.Flags().BoolVar(&opts.push, "push", false, "Stream the packed modelkit directly to the remote registry specified by --tag, without storing it locally")
+	opts.AddNetworkFlags(cmd)
 	cmd.Flags().SortFlags = false
 	cmd.Args = cobra.ExactArgs(1)
 	cmd.CompletionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveDefault)
@@ -153,6 +164,15 @@ func (opts *packOptions) complete(ctx context.Context, args []string) error {
 
 	if err := mediatype.IsValidLayerFormat(opts.layerFormat); err != nil {
 		return err
+	}
+
+	if opts.push {
+		if opts.modelRef.Registry == artifact.DefaultRegistry {
+			return fmt.Errorf("--push requires a remote registry to be specified with --tag")
+		}
+		if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
+			return err
+		}
 	}
 
 	printConfig(opts)

--- a/pkg/cmd/pack/pack.go
+++ b/pkg/cmd/pack/pack.go
@@ -29,10 +29,12 @@ import (
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem/ignore"
 	kfutils "github.com/kitops-ml/kitops/pkg/lib/kitfile"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/local"
+	"github.com/kitops-ml/kitops/pkg/lib/repo/remote"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/util"
 	"github.com/kitops-ml/kitops/pkg/output"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
 )
 
 // runPack compresses and stores a modelkit based on a Kitfile. Returns an error if packing
@@ -42,42 +44,59 @@ import (
 // Packed modelkits are saved to the local on-disk cache. As OCI-spec indexes only support one
 // registry/repository reference at a time, individual blobs may be duplicated on disk if stored
 // under different references.
+//
+// If options.push is set, the modelkit is instead streamed directly to the remote registry
+// specified by options.modelRef, skipping local storage entirely.
 func runPack(ctx context.Context, options *packOptions) error {
 	kitfile, err := readKitfile(options.modelFile)
 	if err != nil {
 		return err
 	}
 
-	storageHome := constants.StoragePath(options.configHome)
-	localRepo, err := local.NewLocalRepo(storageHome, options.modelRef)
-	if err != nil {
-		return fmt.Errorf("failed to open local storage: %w", err)
+	var target oras.Target
+	if options.push {
+		remoteRepo, err := remote.NewRepository(ctx, options.modelRef.Registry, options.modelRef.Repository, &options.NetworkOptions)
+		if err != nil {
+			return fmt.Errorf("failed to connect to remote registry: %w", err)
+		}
+		target = remoteRepo
+	} else {
+		storageHome := constants.StoragePath(options.configHome)
+		localRepo, err := local.NewLocalRepo(storageHome, options.modelRef)
+		if err != nil {
+			return fmt.Errorf("failed to open local storage: %w", err)
+		}
+		target = localRepo
 	}
 
-	manifestDesc, err := pack(ctx, options, kitfile, localRepo)
+	manifestDesc, err := pack(ctx, options, kitfile, target)
 	if err != nil {
 		return err
 	}
 
 	if options.modelRef != nil && options.modelRef.Reference != "" {
-		if err := localRepo.Tag(ctx, *manifestDesc, options.modelRef.Reference); err != nil {
+		if err := target.Tag(ctx, *manifestDesc, options.modelRef.Reference); err != nil {
 			return fmt.Errorf("failed to tag manifest: %w", err)
 		}
 		output.Debugf("Added tag to manifest: %s", options.modelRef.Reference)
 	}
 
 	for _, tag := range options.extraRefs {
-		if err := localRepo.Tag(ctx, *manifestDesc, tag); err != nil {
+		if err := target.Tag(ctx, *manifestDesc, tag); err != nil {
 			return err
 		}
 	}
 
-	output.Infof("Model saved: %s", manifestDesc.Digest)
+	if options.push {
+		output.Infof("Model pushed: %s", manifestDesc.Digest)
+	} else {
+		output.Infof("Model saved: %s", manifestDesc.Digest)
+	}
 
 	return nil
 }
 
-func pack(ctx context.Context, opts *packOptions, kitfile *artifact.KitFile, localRepo local.LocalRepo) (*ocispec.Descriptor, error) {
+func pack(ctx context.Context, opts *packOptions, kitfile *artifact.KitFile, target oras.Target) (*ocispec.Descriptor, error) {
 	var extraLayerPaths []string
 	if kitfile.Model != nil && artifact.IsModelKitReference(kitfile.Model.Path) {
 		baseRef := artifact.FormatRepositoryForDisplay(opts.modelRef.String())
@@ -105,7 +124,7 @@ func pack(ctx context.Context, opts *packOptions, kitfile *artifact.KitFile, loc
 	if err != nil {
 		return nil, err
 	}
-	manifestDesc, err := filesystem.SaveModel(ctx, localRepo, kitfile, ignore, &filesystem.SaveModelOptions{
+	manifestDesc, err := filesystem.SaveModel(ctx, target, kitfile, ignore, &filesystem.SaveModelOptions{
 		ModelFormat: modelFormat,
 		Compression: compression,
 		LayerFormat: layerFormat,

--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -29,7 +29,6 @@ import (
 	"github.com/kitops-ml/kitops/pkg/lib/external/s3api"
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem/cache"
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem/ignore"
-	"github.com/kitops-ml/kitops/pkg/lib/repo/local"
 	"github.com/kitops-ml/kitops/pkg/output"
 
 	"github.com/opencontainers/go-digest"
@@ -55,18 +54,19 @@ func (o *SaveModelOptions) Validate() error {
 
 // SaveModel saves an *artifact.Model to the provided oras.Target, compressing layers. It attempts to block
 // modelkits that include paths that leave the base context directory, allowing only subdirectories of the root
-// context to be included in the modelkit.
-func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact.KitFile, ignore ignore.Paths, opts *SaveModelOptions) (*ocispec.Descriptor, error) {
+// context to be included in the modelkit. The target may be local storage or a remote registry; in the latter
+// case, layers are streamed directly to the registry without being persisted to local storage.
+func SaveModel(ctx context.Context, target oras.Target, kitfile *artifact.KitFile, ignore ignore.Paths, opts *SaveModelOptions) (*ocispec.Descriptor, error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
 
-	layerDescs, diffIDs, err := saveKitfileLayers(ctx, localRepo, kitfile, ignore, opts)
+	layerDescs, diffIDs, err := saveKitfileLayers(ctx, target, kitfile, ignore, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	configDesc, err := saveConfig(ctx, localRepo, kitfile, diffIDs, opts.ModelFormat)
+	configDesc, err := saveConfig(ctx, target, kitfile, diffIDs, opts.ModelFormat)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact
 		manifest.Annotations[constants.KitfileJsonAnnotation] = string(kitfileBytes)
 	}
 
-	manifestDesc, err := saveModelManifest(ctx, localRepo, manifest)
+	manifestDesc, err := saveModelManifest(ctx, target, manifest)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact
 	return manifestDesc, nil
 }
 
-func saveConfig(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact.KitFile, diffIDs []digest.Digest, modelFormat mediatype.ModelFormat) (ocispec.Descriptor, error) {
+func saveConfig(ctx context.Context, target oras.Target, kitfile *artifact.KitFile, diffIDs []digest.Digest, modelFormat mediatype.ModelFormat) (ocispec.Descriptor, error) {
 	var configBytes []byte
 	var configMediaType string
 	switch modelFormat {
@@ -129,13 +129,13 @@ func saveConfig(ctx context.Context, localRepo local.LocalRepo, kitfile *artifac
 		Size:      int64(len(configBytes)),
 	}
 
-	exists, err := localRepo.Exists(ctx, desc)
+	exists, err := target.Exists(ctx, desc)
 	if err != nil {
 		return ocispec.DescriptorEmptyJSON, err
 	}
 	if !exists {
 		// Does not exist in storage, need to push
-		err = localRepo.Push(ctx, desc, bytes.NewReader(configBytes))
+		err = target.Push(ctx, desc, bytes.NewReader(configBytes))
 		if err != nil {
 			return ocispec.DescriptorEmptyJSON, err
 		}
@@ -147,12 +147,12 @@ func saveConfig(ctx context.Context, localRepo local.LocalRepo, kitfile *artifac
 	return desc, nil
 }
 
-func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact.KitFile, ignore ignore.Paths, opts *SaveModelOptions) (layers []ocispec.Descriptor, diffIDs []digest.Digest, err error) {
+func saveKitfileLayers(ctx context.Context, target oras.Target, kitfile *artifact.KitFile, ignore ignore.Paths, opts *SaveModelOptions) (layers []ocispec.Descriptor, diffIDs []digest.Digest, err error) {
 	toVerifyRemote := map[string]s3api.S3ObjectReference{}
 	if kitfile.Model != nil {
 		if kitfile.Model.Path != "" && !artifact.IsModelKitReference(kitfile.Model.Path) {
 			mediaType := mediatype.New(opts.ModelFormat, mediatype.ModelBaseType, opts.LayerFormat, opts.Compression)
-			layer, layerInfo, err := saveContentLayer(ctx, localRepo, kitfile.Model.Path, mediaType, ignore)
+			layer, layerInfo, err := saveContentLayer(ctx, target, kitfile.Model.Path, mediaType, ignore)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -162,7 +162,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 		}
 		for idx, part := range kitfile.Model.Parts {
 			mediaType := mediatype.New(opts.ModelFormat, mediatype.ModelPartBaseType, opts.LayerFormat, opts.Compression)
-			layer, layerInfo, err := saveContentLayer(ctx, localRepo, part.Path, mediaType, ignore)
+			layer, layerInfo, err := saveContentLayer(ctx, target, part.Path, mediaType, ignore)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -173,7 +173,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	}
 	for idx, code := range kitfile.Code {
 		mediaType := mediatype.New(opts.ModelFormat, mediatype.CodeBaseType, opts.LayerFormat, opts.Compression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, code.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, target, code.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -197,7 +197,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 
 		// Otherwise, pack a locally-stored dataset
 		mediaType := mediatype.New(opts.ModelFormat, mediatype.DatasetBaseType, opts.LayerFormat, opts.Compression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, dataset.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, target, dataset.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -207,7 +207,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	}
 	for idx, docs := range kitfile.Docs {
 		mediaType := mediatype.New(opts.ModelFormat, mediatype.DocsBaseType, opts.LayerFormat, opts.Compression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, docs.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, target, docs.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -218,7 +218,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	for idx, prompt := range kitfile.Prompts {
 		// Prompt layers are saved as `code` layers with an annotation to distinguish them
 		mediaType := mediatype.New(opts.ModelFormat, mediatype.CodeBaseType, opts.LayerFormat, opts.Compression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, prompt.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, target, prompt.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -241,7 +241,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 			return nil, nil, fmt.Errorf("invalid MCP bundle for mcpServer %s: %w", server.Name, err)
 		}
 		mediaType := mediatype.New(mediatype.KitFormat, mediatype.MCPBBaseType, mediatype.RawFormat, mediatype.NoneCompression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, server.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, target, server.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -267,12 +267,12 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	return layers, diffIDs, nil
 }
 
-func saveContentLayer(ctx context.Context, localRepo local.LocalRepo, path string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
+func saveContentLayer(ctx context.Context, target oras.Target, path string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
 	switch mediaType.Format() {
 	case mediatype.TarFormat:
-		return saveContentLayerAsTar(ctx, localRepo, path, mediaType, ignore)
+		return saveContentLayerAsTar(ctx, target, path, mediaType, ignore)
 	case mediatype.RawFormat:
-		return saveContentLayerAsRaw(ctx, localRepo, path, mediaType, ignore)
+		return saveContentLayerAsRaw(ctx, target, path, mediaType, ignore)
 	default:
 		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("unknown layer format")
 	}

--- a/pkg/lib/filesystem/local-storage_test.go
+++ b/pkg/lib/filesystem/local-storage_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package filesystem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kitops-ml/kitops/pkg/artifact"
+	"github.com/kitops-ml/kitops/pkg/lib/constants/mediatype"
+	"github.com/kitops-ml/kitops/pkg/lib/filesystem/ignore"
+
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+// TestSaveModelToNonLocalTarget verifies that SaveModel can write directly to an arbitrary
+// oras.Target (such as a remote registry) without requiring a local.LocalRepo, which is what
+// allows `kit pack --push` to stream a modelkit straight to a registry without persisting it
+// to local storage first.
+func TestSaveModelToNonLocalTarget(t *testing.T) {
+	tmpDir := t.TempDir()
+	codeDir := filepath.Join(tmpDir, "code")
+	require.NoError(t, os.Mkdir(codeDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(codeDir, "main.py"), []byte("print('hi')"), 0644))
+
+	curDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(curDir) }()
+	require.NoError(t, os.Chdir(tmpDir))
+
+	kitfile := &artifact.KitFile{
+		ManifestVersion: "1.0.0",
+		Code:            []artifact.Code{{Path: "code"}},
+	}
+	ignorePaths, err := ignore.NewFromContext(tmpDir, kitfile)
+	require.NoError(t, err)
+
+	target := memory.New()
+	ctx := context.Background()
+	manifestDesc, err := SaveModel(ctx, target, kitfile, ignorePaths, &SaveModelOptions{
+		ModelFormat: mediatype.KitFormat,
+		Compression: mediatype.NoneCompression,
+		LayerFormat: mediatype.TarFormat,
+	})
+	require.NoError(t, err)
+
+	exists, err := target.Exists(ctx, *manifestDesc)
+	require.NoError(t, err)
+	require.True(t, exists, "manifest should be pushed directly to the target")
+}

--- a/pkg/lib/filesystem/raw.go
+++ b/pkg/lib/filesystem/raw.go
@@ -28,14 +28,14 @@ import (
 	"github.com/kitops-ml/kitops/pkg/lib/constants/mediatype"
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem/cache"
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem/ignore"
-	"github.com/kitops-ml/kitops/pkg/lib/repo/local"
 	"github.com/kitops-ml/kitops/pkg/output"
 	"github.com/klauspost/compress/zstd"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
 )
 
-func saveContentLayerAsRaw(ctx context.Context, localRepo local.LocalRepo, targetPath string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
+func saveContentLayerAsRaw(ctx context.Context, target oras.Target, targetPath string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
 	targetPath = filepath.Clean(targetPath)
 
 	fi, err := os.Lstat(targetPath)
@@ -133,7 +133,7 @@ func saveContentLayerAsRaw(ctx context.Context, localRepo local.LocalRepo, targe
 		DiffId: diffIdDigester.Digest().String(),
 	}
 
-	if err := saveFileToRepo(ctx, tempFileName, desc, localRepo); err != nil {
+	if err := saveFileToRepo(ctx, tempFileName, desc, target); err != nil {
 		return ocispec.DescriptorEmptyJSON, nil, err
 	}
 

--- a/pkg/lib/filesystem/tar.go
+++ b/pkg/lib/filesystem/tar.go
@@ -32,15 +32,15 @@ import (
 	"github.com/kitops-ml/kitops/pkg/lib/constants/mediatype"
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem/cache"
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem/ignore"
-	"github.com/kitops-ml/kitops/pkg/lib/repo/local"
 	"github.com/kitops-ml/kitops/pkg/output"
 	"github.com/klauspost/compress/zstd"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
 )
 
-func saveContentLayerAsTar(ctx context.Context, localRepo local.LocalRepo, path string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
+func saveContentLayerAsTar(ctx context.Context, target oras.Target, path string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
 	// We want to store a gzipped tar file in store, but to do so we need a descriptor, so we have to compress
 	// to a temporary file. Ideally, we can also add this to the internal store by moving the file to avoid
 	// copying if possible.
@@ -55,7 +55,7 @@ func saveContentLayerAsTar(ctx context.Context, localRepo local.LocalRepo, path 
 		}
 	}()
 
-	if err := saveFileToRepo(ctx, tempPath, desc, localRepo); err != nil {
+	if err := saveFileToRepo(ctx, tempPath, desc, target); err != nil {
 		return ocispec.DescriptorEmptyJSON, nil, err
 	}
 

--- a/pkg/lib/filesystem/util.go
+++ b/pkg/lib/filesystem/util.go
@@ -33,51 +33,63 @@ import (
 	"github.com/kitops-ml/kitops/pkg/output"
 	modelspecv1 "github.com/modelpack/model-spec/specs-go/v1"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
 )
 
-func saveFileToRepo(ctx context.Context, filePath string, desc ocispec.Descriptor, repo local.LocalRepo) error {
+// saveFileToRepo saves the content at filePath to target under desc. If target is a local.LocalRepo,
+// the file is moved directly into local storage to avoid copying a potentially very large file;
+// otherwise (e.g. a remote registry target), the file is streamed to the target via Push.
+func saveFileToRepo(ctx context.Context, filePath string, desc ocispec.Descriptor, target oras.Target) error {
 	mt, err := mediatype.ParseMediaType(desc.MediaType)
 	if err != nil {
 		return err
 	}
 
-	if exists, err := repo.Exists(ctx, desc); err != nil {
+	if exists, err := target.Exists(ctx, desc); err != nil {
 		return err
 	} else if exists {
 		output.Infof("Already saved %s layer: %s", mt.UserString(), desc.Digest)
 		return nil
 	}
 
-	// Workaround to avoid copying a potentially very large file: move it to the expected path
-	// and verify that it exists afterwards.
-	if err := repo.EnsureDirs(desc); err != nil {
-		return err
-	}
-	blobPath := repo.BlobPath(desc)
-	if err := os.Rename(filePath, blobPath); err != nil {
-		// This may fail on some systems (e.g. linux where / and /home are different partitions)
-		// Fallback to regular push which is basically a copy
-		output.Debugf("Failed to move temp file into storage (will copy instead): %s", err)
-		file, err := os.Open(filePath)
-		if err != nil {
-			return fmt.Errorf("failed to open temporary file: %w", err)
+	if localRepo, ok := target.(local.LocalRepo); ok {
+		// Workaround to avoid copying a potentially very large file: move it to the expected path
+		// and verify that it exists afterwards.
+		if err := localRepo.EnsureDirs(desc); err != nil {
+			return err
 		}
-		defer file.Close()
-		if err := repo.Push(ctx, desc, file); err != nil {
-			return fmt.Errorf("failed to add layer to storage: %w", err)
+		blobPath := localRepo.BlobPath(desc)
+		if err := os.Rename(filePath, blobPath); err != nil {
+			// This may fail on some systems (e.g. linux where / and /home are different partitions)
+			// Fallback to regular push which is basically a copy
+			output.Debugf("Failed to move temp file into storage (will copy instead): %s", err)
+			if err := pushFileToTarget(ctx, filePath, desc, target); err != nil {
+				return fmt.Errorf("failed to add layer to storage: %w", err)
+			}
 		}
+	} else if err := pushFileToTarget(ctx, filePath, desc, target); err != nil {
+		return fmt.Errorf("failed to push layer: %w", err)
 	}
 
 	// Verify blob is in store now
-	exists, err := repo.Exists(ctx, desc)
+	exists, err := target.Exists(ctx, desc)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("failed to move layer to storage: file is not stored")
+		return fmt.Errorf("failed to save layer to target: blob is not stored")
 	}
 	output.Infof("Saved %s layer: %s", mt.UserString(), desc.Digest)
 	return nil
+}
+
+func pushFileToTarget(ctx context.Context, filePath string, desc ocispec.Descriptor, target oras.Target) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open temporary file: %w", err)
+	}
+	defer file.Close()
+	return target.Push(ctx, desc, file)
 }
 
 func fillDescAnnotations(desc *ocispec.Descriptor, targetPath string, fi fs.FileInfo) error {


### PR DESCRIPTION
### Description
Adds a `--push` flag to `kit pack` that streams the packed modelkit directly to
the remote registry specified by `--tag`, skipping local storage entirely.

Currently `kit pack` always writes layers/config/manifest to the local on-disk
cache before an optional separate `kit push`, meaning a model is stored twice
(source directory + local cache) before ever reaching the registry — costly in
CI environments where disk is limited. With `--push`, `SaveModel` and its layer
helpers write to a generic `oras.Target` instead of a concrete local repo, so
the same pack pipeline can target either local storage (default, unchanged
behavior) or a remote registry (`remote.NewRepository`) directly. Digests are
still computed via a temporary file (required to know the digest before
pushing), but nothing is persisted to the permanent local ModelKit cache when
`--push` is used.

Follows the approach agreed with @amisevsk in the issue thread (flag named
`--push` per that discussion).

### Linked issues
Closes #1026

### AI-Assisted Code
- [x] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created