### PR TITLE
fix: return error on extra tag removal failure

### DIFF
--- a/pkg/cmd/remove/remove.go
+++ b/pkg/cmd/remove/remove.go
@@ -107,11 +107,12 @@ func removeModel(ctx context.Context, opts *removeOptions) error {
 	}
 	desc, err := removeModelRef(ctx, localRepo, opts.modelRef, opts.forceDelete)
 	if err != nil {
-		return fmt.Errorf("failed to remove: %s", err)
+		return fmt.Errorf("failed to remove: %w", err)
 	}
 	displayRef := artifact.FormatRepositoryForDisplay(opts.modelRef.String())
 	output.Infof("Removed %s (digest %s)", displayRef, desc.Digest)
 
+	var failedCount int
 	for _, tag := range opts.extraTags {
 		ref := *opts.modelRef
 		ref.Reference = tag
@@ -119,9 +120,13 @@ func removeModel(ctx context.Context, opts *removeOptions) error {
 		desc, err := removeModelRef(ctx, localRepo, &ref, opts.forceDelete)
 		if err != nil {
 			output.Errorf("Failed to remove tag %s: %s", tag, err)
+			failedCount++
 		} else {
 			output.Infof("Removed %s (digest %s)", displayRef, desc.Digest)
 		}
+	}
+	if failedCount > 0 {
+		return fmt.Errorf("failed to remove %d extra tag(s)", failedCount)
 	}
 	return nil
 }


### PR DESCRIPTION
### Description
removeModel() in pkg/cmd/remove/remove.go logs errors when extra
comma-separated tags fail to remove but always returns nil. This
causes `kit remove repo:tag1,tag2,bogus` to exit with code 0 even
when some tags fail, since the caller only checks for a non-nil error.

Changes:
- Track failure count in the extra tags loop
- Return a non-nil error if any extra tag removal failed
- Fix a pre-existing %s→%w format verb in the same function

The exit code now correctly reflects partial failures.

### Linked issues
Closes #1246

### AI-Assisted Code
- [x] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created